### PR TITLE
Update export-svg.py path splitting

### DIFF
--- a/python/examples/export-svg.py
+++ b/python/examples/export-svg.py
@@ -14,7 +14,7 @@ def escape(string):
 	return ''.join(escape_table.get(i,i) for i in string) 				#still escape the basics
 
 def save_svg(bv,function):
-	filename = bv.file.filename.split(os.sep)[-1]
+	filename = os.path.split(bv.file.filename)[1]
 	address = hex(function.start).replace('L','')
 	outputfile = os.path.join(os.path.expanduser('~'), 'binaryninja-{filename}-{function}.html'.format(filename=filename,function=address))
 	content = render_svg(function)


### PR DESCRIPTION
Changed the path splitting part to the way python's documentation recommends it.

I got some errors trying to use that function on windows, because it didn't split correctly.
I stumbled upon this in the python documentation:
https://docs.python.org/2/library/os.html#os.sep
I changed the relevant line using their recommendation.