### PR TITLE
Added flags parameter to sign_extend

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -8291,16 +8291,17 @@ class LowLevelILFunction(object):
 		"""
 		return self.expr(core.LLIL_NOT, value.index, size = size, flags = flags)
 
-	def sign_extend(self, size, value):
+	def sign_extend(self, size, value, flags = None):
 		"""
 		``sign_extend`` two's complement sign-extends the expression in ``value`` to ``size`` bytes
 
 		:param int size: the size of the result in bytes
 		:param LowLevelILExpr value: the expression to sign extend
+		:param str flags: optional, flags to set
 		:return: The expression ``sx.<size>(value)``
 		:rtype: LowLevelILExpr
 		"""
-		return self.expr(core.LLIL_SX, value.index, size = size)
+		return self.expr(core.LLIL_SX, value.index, size = size, flags = flags)
 
 	def zero_extend(self, size, value):
 		"""


### PR DESCRIPTION
`LowLevelILFunction.sign_extend()` does not currently have the optional `flags` parameter. While most architectures might not set any flags on a sign extension operation, the `sxt` instruction of the MSP430 architecture does; rather than having to manually implement setting all flags (which makes the IL a little ugly), I'm hoping that adding this parameter in would be a simple fix. Since it's still an optional parameter, it won't affect any other currently implemented architectures.

I don't get any log errors when I use this modified version of `__init__.py`, so it at least doesn't break anything; since I haven't quite figured out how to get flags working quite yet, I'm not sure that it actually sets any flags on the back end though.
