### PR TITLE
Added __hash__ to Function.

### DIFF
--- a/python/function.py
+++ b/python/function.py
@@ -254,6 +254,9 @@ class Function(object):
 			return True
 		return ctypes.addressof(self.handle.contents) != ctypes.addressof(value.handle.contents)
 
+	def __hash__(self):
+		return hash((self.start, self.arch.name, self.platform.name))
+
 	@classmethod
 	def _unregister(cls, func):
 		handle = ctypes.cast(func, ctypes.c_void_p)


### PR DESCRIPTION
As it stands, `Function` objects use the default `__hash__` method, which is just a wrapper for `hash(x)`, where `x` is the object. Since this uses the `id` or something similar, two `Function` objects that have the same backing function are seen as unique when added to a `set` or used as a `dict` key.

My suggested modification (which could also be applied to other objects as well) is to implement the `__hash__` method, hashing the `self.start`, `self.arch.name`, and `self.platform.name`, which should be sufficient to dedupe functions.

However, if you'd prefer, I think that `hash(id(self.handle.contents))` may also be sufficient.