### PR TITLE
Added __hash__ and __eq__ to Variable and SSAVariable

### DIFF
--- a/python/function.py
+++ b/python/function.py
@@ -203,6 +203,12 @@ class Variable(object):
 	def __str__(self):
 		return self.name
 
+	def __eq__(self, other):
+		return self.identifier == other.identifier
+
+	def __hash__(self):
+		return hash(self.identifier)
+
 
 class ConstantReference(object):
 	def __init__(self, val, size, ptr, intermediate):

--- a/python/mediumlevelil.py
+++ b/python/mediumlevelil.py
@@ -36,6 +36,15 @@ class SSAVariable(object):
 	def __repr__(self):
 		return "<ssa %s version %d>" % (repr(self.var), self.version)
 
+	def __eq__(self, other):
+		return (
+			(self.var.identifier, self.version) == 
+			(other.var.identifier, other.version)
+		)
+
+	def __hash__(self):
+		return hash(self.var.identifier, self.version)
+
 
 class MediumLevelILLabel(object):
 	def __init__(self, handle = None):


### PR DESCRIPTION
`Variable` and `SSAVariable` can't be uniquely added to a `set` or used as key values in a `dict`. Adding `__eq__` and `__hash__` fixes this.