### PR TITLE
Fix SSAVariable.__hash__

### DIFF
--- a/python/mediumlevelil.py
+++ b/python/mediumlevelil.py
@@ -43,7 +43,7 @@ class SSAVariable(object):
 		)
 
 	def __hash__(self):
-		return hash(self.var.identifier, self.version)
+		return hash((self.var.identifier, self.version))
 
 
 class MediumLevelILLabel(object):


### PR DESCRIPTION
I accidentally omitted the parenthesis to create a tuple for `SSAVariable.__hash__`, so it raises a `TypeError` if you try to add it to a set. This fixes that. Sorry for the mess up!