### PR TITLE
Added missing files to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,13 @@ add_library(binaryninjaapi STATIC
 	log.cpp
 	lowlevelil.cpp
 	mainthread.cpp
+    mediumlevelil.cpp
+    metadata.cpp
 	platform.cpp
 	plugin.cpp
+    pluginmanager.cpp
 	scriptingprovider.cpp
+    settings.cpp
 	tempfile.cpp
 	transform.cpp
 	type.cpp


### PR DESCRIPTION
Several files were missing from CMakeLists, which made it impossible to build the API via CMake