### PR TITLE
Fix use after free in settings api

### DIFF
--- a/settings.cpp
+++ b/settings.cpp
@@ -36,7 +36,7 @@ std::vector<int64_t> Setting::GetIntegerList(const std::string& pluginName,
 	delete[] buffer;
 
 	vector<int64_t> out(outBuffer, outBuffer + size);
-	BNFreeSettingIntegerList(buffer);
+	BNFreeSettingIntegerList(outBuffer);
 	return out;
 }
 


### PR DESCRIPTION
clang-tidy pointed out a use after free in the settings api.