### PR TITLE
Updated BasicBlock.__eq__ to compare arch, start, and end.

### DIFF
--- a/python/basicblock.py
+++ b/python/basicblock.py
@@ -57,12 +57,21 @@ class BasicBlock(object):
 	def __eq__(self, value):
 		if not isinstance(value, BasicBlock):
 			return False
-		return ctypes.addressof(self.handle.contents) == ctypes.addressof(value.handle.contents)
+		return (
+			(self.arch, self.start, self.end) ==
+			(value.arch, value.start, value.end)
+		)
 
 	def __ne__(self, value):
 		if not isinstance(value, BasicBlock):
 			return True
-		return ctypes.addressof(self.handle.contents) != ctypes.addressof(value.handle.contents)
+		return (
+			(self.arch, self.start, self.end) !=
+			(value.arch, value.start, value.end)
+		)
+	
+	def __hash__(self):
+		return hash((self.arch, self.start, self.end))
 
 	def _create_instance(self, view, handle):
 		"""Internal method used to instantiante child instances"""


### PR DESCRIPTION
Also added a compatible `BasicBlock.__hash__`. The previous implementation of `__eq__` is based on `ctypes.addressof` which means that equality may fail to be reflexive.