### PR TITLE
Fixed possible IndexError in Function.get_*_at methods

### DIFF
--- a/python/function.py
+++ b/python/function.py
@@ -648,7 +648,13 @@ class Function(object):
 		"""
 		if arch is None:
 			arch = self.arch
-		return self.low_level_il[core.BNGetLowLevelILForInstruction(self.handle, arch.handle, addr)]
+
+		idx = core.BNGetLowLevelILForInstruction(self.handle, arch.handle, addr)
+
+		if idx == len(self.low_level_il):
+			return None
+
+		return self.low_level_il[idx]
 
 	def get_low_level_il_exits_at(self, addr, arch=None):
 		if arch is None:
@@ -799,7 +805,13 @@ class Function(object):
 	def get_lifted_il_at(self, addr, arch=None):
 		if arch is None:
 			arch = self.arch
-		return self.lifted_il[core.BNGetLiftedILForInstruction(self.handle, arch.handle, addr)]
+
+		idx = core.BNGetLiftedILForInstruction(self.handle, arch.handle, addr)
+
+		if idx == len(self.lifted_il):
+			return None
+
+		return self.lifted_il[idx]
 
 	def get_lifted_il_flag_uses_for_definition(self, i, flag):
 		flag = self.arch.get_flag_index(flag)


### PR DESCRIPTION
`Function.get_low_level_il_at` and `Function.get_lifted_il_at` methods could raise an IndexError because proper checking was not performed on the index returned by the core method that retrieves the IL instruction index of the requested instruction. The methods now check this value to see if it is equal to the length of the IL function, and if so, returns `None` instead. The onus of checking for `None` will be on the user, but at least they shouldn't have to wrap this in a try/except block anymore.

Given that it was my PR that originally introduced this functionality, I take full responsibility for fixing it :)