### PR TITLE
Fixed AnalysisCompletionEvent callback

### DIFF
--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -105,7 +105,7 @@ class StringReference(object):
 class AnalysisCompletionEvent(object):
 	def __init__(self, view, callback):
 		self.view = view
-		self.callback = callback
+		self.callback = callback.__get__(self)
 		self._cb = ctypes.CFUNCTYPE(None, ctypes.c_void_p)(self._notify)
 		self.handle = core.BNAddAnalysisCompletionEvent(self.view.handle, None, self._cb)
 


### PR DESCRIPTION
The `AnalysisCompletionEvent` class takes a callback as a parameter in its `__init__` method, but this callback is not added to the object as a bound method automatically in python 2 as it is in python 3. This means that the callback has no parameters passed to it, which prevents it from doing anything meaningful. This PR fixes this by binding the `callback` parameter to an initialized `AnalysisCompletionEvent`.