### PR TITLE
Fix issues in linux-setup.sh

### DIFF
--- a/scripts/linux-setup.sh
+++ b/scripts/linux-setup.sh
@@ -14,7 +14,7 @@ setvars()
 	APP="binaryninja"
 	FILECOMMENT="Binary Ninja Analysis Database"
 	APPCOMMENT="Binary Ninja: A Reverse Engineering Platform"
-	BNPATH="$(dirname $(readlink -f "$0"))/../"
+	BNPATH="$(dirname $(readlink -f "$0"))/.."
 	EXEC="${BNPATH}/binaryninja"
 	PNG="${BNPATH}/docs/images/logo.png"
 	EXT="bndb"

--- a/scripts/linux-setup.sh
+++ b/scripts/linux-setup.sh
@@ -81,14 +81,9 @@ Type=Application
 Categories=Utility;
 Comment=${APPCOMMENT}
 EOF
-	if [ "${ROOT}" == "root" ]
-	then
-		echo "${DESKTOP}" | $SUDO tee ${DESKTOPFILE} >/dev/null
-		$SUDO chmod +x ${DESKTOPFILE}
-		$SUDO update-desktop-database ${SHARE}/applications
-	else
-		echo "${DESKTOP}" > ${HOME}/Desktop/${APP}.desktop
-	fi
+	echo "${DESKTOP}" | $SUDO tee ${DESKTOPFILE} >/dev/null
+	$SUDO chmod +x ${DESKTOPFILE}
+	$SUDO update-desktop-database ${SHARE}/applications
 }
 
 createmime()
@@ -108,16 +103,12 @@ createmime()
 		<glob pattern=\"*.${EXT}\"/>
 		<sub-class-of type=\"application/x-sqlite3\" />
 	</mime-type>
-</mime-info>"| $SUDO tee ${MIMEFILE} >/dev/null
+</mime-info>"| $SUDO tee ${MIMEFILEbinary} >/dev/null
 
 	#echo Copying icon
 	#$SUDO cp $PNG $IMAGEFILE
-	if [ "${ROOT}" == "root" ]
-	then
-		$SUDO cp ${PNG} ${IMAGEFILE}
-		$SUDO update-mime-database ${SHARE}/mime
-	fi
-
+	$SUDO cp ${PNG} ${IMAGEFILE}
+	$SUDO update-mime-database ${SHARE}/mime
 }
 
 addtodesktop()
@@ -127,11 +118,8 @@ addtodesktop()
 
 uninstall()
 {
-	rm -i -r $DESKTOPFILE $MIMEFILE $IMAGEFILE
-	if [ "$ROOT" == "root" ]
-	then
-		$SUDO update-mime-database ${SHARE}/mime
-	fi
+	rm -i -r $DESKTOPFILE $MIMEFILE $IMAGEFILE ${HOME}/Desktop/${APP}.desktop
+	$SUDO update-mime-database ${SHARE}/mime
 	exit 0
 }
 

--- a/scripts/linux-setup.sh
+++ b/scripts/linux-setup.sh
@@ -14,7 +14,7 @@ setvars()
 	APP="binaryninja"
 	FILECOMMENT="Binary Ninja Analysis Database"
 	APPCOMMENT="Binary Ninja: A Reverse Engineering Platform"
-	BNPATH=$(dirname $(readlink -f "$0"))
+	BNPATH="$(dirname $(readlink -f "$0"))/../"
 	EXEC="${BNPATH}/binaryninja"
 	PNG="${BNPATH}/docs/images/logo.png"
 	EXT="bndb"

--- a/scripts/linux-setup.sh
+++ b/scripts/linux-setup.sh
@@ -83,11 +83,11 @@ Comment=${APPCOMMENT}
 EOF
 	if [ "${ROOT}" == "root" ]
 	then
-		echo ${DESKTOP} | $SUDO tee ${DESKTOPFILE} >/dev/null
+		echo "${DESKTOP}" | $SUDO tee ${DESKTOPFILE} >/dev/null
 		$SUDO chmod +x ${DESKTOPFILE}
 		$SUDO update-desktop-database ${SHARE}/applications
 	else
-		echo ${DESKTOP} > ${HOME}/Desktop/${APP}.desktop
+		echo "${DESKTOP}" > ${HOME}/Desktop/${APP}.desktop
 	fi
 }
 

--- a/scripts/linux-setup.sh
+++ b/scripts/linux-setup.sh
@@ -61,7 +61,12 @@ lastrun()
 pythonpath()
 {
 	echo Configuring python path
-	${SUDO}python ${BNPATH}/scripts/install_api.py $ROOT
+	if [[ $(python -V) == "Python 3."* ]]
+	then
+	    ${SUDO}python2 ${BNPATH}/scripts/install_api.py $ROOT
+	else
+	    ${SUDO}python ${BNPATH}/scripts/install_api.py $ROOT
+	fi
 }
 
 createdesktopfile()

--- a/scripts/linux-setup.sh
+++ b/scripts/linux-setup.sh
@@ -103,7 +103,7 @@ createmime()
 		<glob pattern=\"*.${EXT}\"/>
 		<sub-class-of type=\"application/x-sqlite3\" />
 	</mime-type>
-</mime-info>"| $SUDO tee ${MIMEFILEbinary} >/dev/null
+</mime-info>"| $SUDO tee ${MIMEFILE} >/dev/null
 
 	#echo Copying icon
 	#$SUDO cp $PNG $IMAGEFILE


### PR DESCRIPTION
Fixes #865 

Tested in Ubuntu 16.04, Fedora 26, Kali, and Arch Linux. The python API installation still fails on Arch and Fedora but I'm not sure why--I'm planning to address that in another PR.