### PR TITLE
Fix PluginManager Doc Example

### DIFF
--- a/python/pluginmanager.py
+++ b/python/pluginmanager.py
@@ -382,7 +382,6 @@ class RepositoryManager(object):
 			>>> mgr = RepositoryManager()
 			>>> mgr.add_repository(url="https://github.com/vector35/community-plugins.git",
 			                       repopath="myrepo",
-			                       repomanifest="plugins",
 			                       localreference="master", remotereference="origin")
 			True
 			>>>


### PR DESCRIPTION
Noticed that the doc string example for add_repository had a named argument that doesn't seem to exist any more.