### PR TITLE
Fix get_symantic_flag_group_name typo

### DIFF
--- a/python/interaction.py
+++ b/python/interaction.py
@@ -121,7 +121,7 @@ class IntegerField(object):
 class AddressField(object):
 	"""
 	``AddressField`` prompts the user for an address. By passing the optional view and current_address parameters
-	offsets can be used instead of just an address. Th reslut is stored as in int in self.result.
+	offsets can be used instead of just an address. The result is stored as in int in self.result.
 
 	Note: This API currenlty functions differently on the command line, as the view and current_address are
 	      disregarded. Additionally where as in the ui the result defaults to hexidecimal on the command line 0x must be 

--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -119,7 +119,7 @@ class ILSemanticFlagGroup(object):
 	def __init__(self, arch, sem_group):
 		self.arch = arch
 		self.index = sem_group
-		self.name = self.arch.get_semantic_flag_group_name(self.index)
+		self.name = self.arch.get_semantic_flag_group_index(self.index)
 
 	def __str__(self):
 		return self.name

--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -723,7 +723,7 @@ class LowLevelILFunction(object):
 
 	def load(self, size, addr):
 		"""
-		``laod`` Reads ``size`` bytes from the expression ``addr``
+		``load`` Reads ``size`` bytes from the expression ``addr``
 
 		:param int size: number of bytes to read
 		:param LowLevelILExpr addr: the expression to read memory from


### PR DESCRIPTION
Exception `'Architecture' object has no attribute 'get_semantic_flag_group_name'` occurred when calling `get_lifted_il_at`. Fixed by correcting the API call since an index is being used here

Will get the Contribution License Agreement started tomorrow :)