### PR TITLE
Update windows plugin path

### DIFF
--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -46,7 +46,7 @@ Plugins are meant to be loaded into a running Binary Ninja GUI and should either
 ### Windows
 
 ```
-%APPDATA%\Binary Ninja\plugins
+%APPDATA%\Roaming\Binary Ninja\plugins
 ```
 
 ### Linux


### PR DESCRIPTION
Unless my install is weird somehow, the Binary Ninja plugin folder on Windows lives under Roaming.