### PR TITLE
Fix an incorrect field name in FlowGraphLayoutRequest._complete

### DIFF
--- a/python/flowgraph.py
+++ b/python/flowgraph.py
@@ -281,8 +281,8 @@ class FlowGraphLayoutRequest(object):
 
 	def _complete(self, ctxt):
 		try:
-			if self._on_complete is not None:
-				self._on_complete()
+			if self.on_complete is not None:
+				self.on_complete()
 		except:
 			log.log_error(traceback.format_exc())
 


### PR DESCRIPTION
`FlowGraphLayoutRequest.on_complete` was incorrectly referenced as `_on_complete` in `FlowGraphLayoutRequest._complete`. This simple PR fixes the issue.