### PR TITLE
import MainThreadAction from the correct location

### DIFF
--- a/python/mainthread.py
+++ b/python/mainthread.py
@@ -21,13 +21,14 @@
 # Binary Ninja components
 from binaryninja import _binaryninjacore as core
 from binaryninja import scriptingprovider
+from binaryninja import plugin
 
 
 def execute_on_main_thread(func):
 	action = scriptingprovider._ThreadActionContext(func)
 	obj = core.BNExecuteOnMainThread(0, action.callback)
 	if obj:
-		return scriptingprovider.MainThreadAction(obj)
+		return plugin.MainThreadAction(obj)
 	return None
 
 


### PR DESCRIPTION
Finally making a PR for this. 

The `execute_on_main_thread()` API throws python errors since `MainThreadAction` got refactored/moved from `scriptingprovider` to `plugin` at some point: 

```
>>> def foo(): print "bar"
>>> binaryninja.execute_on_main_thread(foo)
bar
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "C:\tools\disassemblers\BinaryNinja\plugins\..\python\binaryninja\mainthread.py", line 30, in execute_on_main_thread
    return scriptingprovider.MainThreadAction(obj)
AttributeError: 'module' object has no attribute 'MainThreadAction'
```

This PR simply imports `MainThreadAction` from the correct location, ensuring `execute_on_main_thread()` works as expected:

```
>>> def foo(): print "bar"
>>> binaryninja.execute_on_main_thread(foo)
<binaryninja.plugin.MainThreadAction object at 0x000000BE0EDE55F8>
bar
```
