### PR TITLE
Added move constructor/assignment operator to DataBuffer

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -672,10 +672,12 @@ namespace BinaryNinja
 		DataBuffer(size_t len);
 		DataBuffer(const void* data, size_t len);
 		DataBuffer(const DataBuffer& buf);
+		DataBuffer(DataBuffer&& buf);
 		DataBuffer(BNDataBuffer* buf);
 		~DataBuffer();
 
 		DataBuffer& operator=(const DataBuffer& buf);
+		DataBuffer& operator=(DataBuffer&& buf);
 
 		BNDataBuffer* GetBufferObject() const { return m_buffer; }
 

--- a/databuffer.cpp
+++ b/databuffer.cpp
@@ -47,6 +47,11 @@ DataBuffer::DataBuffer(const DataBuffer& buf)
 	m_buffer = BNDuplicateDataBuffer(buf.m_buffer);
 }
 
+DataBuffer::DataBuffer(DataBuffer&& buf)
+{
+	m_buffer = buf.m_buffer;
+	buf.m_buffer = BNCreateDataBuffer(nullptr, 0);
+}
 
 DataBuffer::DataBuffer(BNDataBuffer* buf)
 {
@@ -62,11 +67,27 @@ DataBuffer::~DataBuffer()
 
 DataBuffer& DataBuffer::operator=(const DataBuffer& buf)
 {
-	BNFreeDataBuffer(m_buffer);
-	m_buffer = BNDuplicateDataBuffer(buf.m_buffer);
+	if (this != &buf)
+	{
+		BNFreeDataBuffer(m_buffer);
+		m_buffer = BNDuplicateDataBuffer(buf.m_buffer);
+	}
+
 	return *this;
 }
 
+DataBuffer& DataBuffer::operator=(DataBuffer&& buf)
+{
+	if (this != &buf)
+	{
+		BNClearDataBuffer(m_buffer);
+		BNDataBuffer* temp = m_buffer;
+		m_buffer = buf.m_buffer;
+		buf.m_buffer = temp;
+	}
+
+	return *this;
+}
 
 void* DataBuffer::GetData()
 {


### PR DESCRIPTION
This should prevent a lot of unncessary copies when using DataBuffers (fixes part of #1093).