### PR TITLE
Fixed MediumLevelILInstructionBase::GetNonSSAForm

### DIFF
--- a/mediumlevelilinstruction.cpp
+++ b/mediumlevelilinstruction.cpp
@@ -1166,7 +1166,7 @@ MediumLevelILInstruction MediumLevelILInstructionBase::GetSSAForm() const
 		return *this;
 	size_t expr = GetSSAExprIndex();
 	size_t instr = GetSSAInstructionIndex();
-	return MediumLevelILInstruction(ssa, ssa->GetRawExpr(GetSSAExprIndex()), expr, instr);
+	return MediumLevelILInstruction(ssa, ssa->GetRawExpr(expr), expr, instr);
 }
 
 
@@ -1177,7 +1177,7 @@ MediumLevelILInstruction MediumLevelILInstructionBase::GetNonSSAForm() const
 		return *this;
 	size_t expr = GetNonSSAExprIndex();
 	size_t instr = GetNonSSAInstructionIndex();
-	return MediumLevelILInstruction(nonSsa, nonSsa->GetRawExpr(GetSSAExprIndex()), expr, instr);
+	return MediumLevelILInstruction(nonSsa, nonSsa->GetRawExpr(expr), expr, instr);
 }
 
 


### PR DESCRIPTION
Fixed compilation error from #1171

Currently MediumLevelILInstructionBase::GetNonSSAForm passes the SSA expr-index to the non-SSA function when calling GetRawExpr, causing incorrect results. (Fixes #1091)