### PR TITLE
Added a missing API method

### DIFF
--- a/binaryview.cpp
+++ b/binaryview.cpp
@@ -1708,6 +1708,11 @@ uint64_t BinaryView::GetPreviousDataBeforeAddress(uint64_t addr)
 	return BNGetPreviousDataBeforeAddress(m_object, addr);
 }
 
+uint64_t BinaryView::GetPreviousDataVariableBeforeAddress(uint64_t addr)
+{
+	return BNGetPreviousDataVariableBeforeAddress(m_object, addr);
+}
+
 
 LinearDisassemblyPosition BinaryView::GetLinearDisassemblyPositionForAddress(uint64_t addr,
 	DisassemblySettings* settings)


### PR DESCRIPTION
The implementation for `BinaryView::GetPreviousDataVariableBeforeAddress` was missing from the C++ API, which causes a compiler error if a plugin references it. This PR adds the missing API method.