### PR TITLE
Type check SSA variables in __eq__

### DIFF
--- a/python/mediumlevelil.py
+++ b/python/mediumlevelil.py
@@ -43,7 +43,7 @@ class SSAVariable(object):
 		return "<ssa %s version %d>" % (repr(self.var), self.version)
 
 	def __eq__(self, other):
-		return (
+		return isinstance(other, SSAVariable) and (
 			(self.var, self.version) ==
 			(other.var, other.version)
 		)


### PR DESCRIPTION
Instantly bail if we try to compare a SSAVariable to something that isn't an SSA Variable. Prevents the following issue:
```
>>> bv.get_functions_at(here)[0].medium_level_il.ssa_form[96].src[0].src
<ssa <var uint64_t rax_2> version 13>
>>> type(bv.get_functions_at(here)[0].medium_level_il.ssa_form[96].src[0].src)
<class 'binaryninja.mediumlevelil.SSAVariable'>
>>> bv.get_functions_at(here)[0].medium_level_il.ssa_form[96].src[0].src == 'rax_2'
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/Applications/Binary Ninja.app/Contents/MacOS/plugins/../../Resources/python/binaryninja/mediumlevelil.py", line 48, in __eq__
    (other.var, other.version)
AttributeError: 'str' object has no attribute 'var'
```