### PR TITLE
Add type check to `Variable.__eq__`

### DIFF
--- a/python/function.py
+++ b/python/function.py
@@ -293,6 +293,8 @@ class Variable(object):
 		return self.name
 
 	def __eq__(self, other):
+		if not isinstance(other, Variable):
+			return False
 		return (self.identifier, self.function) == (other.identifier, other.function)
 
 	def __hash__(self):

--- a/python/mediumlevelil.py
+++ b/python/mediumlevelil.py
@@ -76,6 +76,8 @@ class MediumLevelILOperationAndSize(object):
 			return other == self.operation
 		if isinstance(other, MediumLevelILOperationAndSize):
 			return other.size == self.size and other.operation == self.operation
+		else:
+			return False
 
 
 class MediumLevelILInstruction(object):

--- a/python/mediumlevelil.py
+++ b/python/mediumlevelil.py
@@ -71,6 +71,12 @@ class MediumLevelILOperationAndSize(object):
 			return "<%s>" % self.operation.name
 		return "<%s %d>" % (self.operation.name, self.size)
 
+	def __eq__(self, other):
+		if isinstance(other, MediumLevelILOperation):
+			return other == self.operation
+		if isinstance(other, MediumLevelILOperationAndSize):
+			return other.size == self.size and other.operation == self.operation
+
 
 class MediumLevelILInstruction(object):
 	"""


### PR DESCRIPTION
`Variable.__eq__` fails to check if the other value is actually a Variable object before comparing member properties. This fixes the exception that gets raised when comparing a Variable against something else.