### PR TITLE
Fix metadata

### DIFF
--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -3823,7 +3823,9 @@ class BinaryView(object):
 			>>> bv.query_metadata("string")
 			'my_data'
 		"""
-		core.BNBinaryViewStoreMetadata(self.handle, key, metadata.Metadata(md).handle)
+		if not isinstance(md, metadata.Metadata):
+			md = metadata.Metadata(md)
+		core.BNBinaryViewStoreMetadata(self.handle, key, md.handle)
 
 	def remove_metadata(self, key):
 		"""

--- a/python/metadata.py
+++ b/python/metadata.py
@@ -190,7 +190,7 @@ class Metadata(object):
 		raise ValueError("Metadata object not a string or raw type")
 
 	def __bytes__(self):
-		return bytes(bytearray(ord(i) for i in self.__str__()))
+		return bytes(bytearray(ord(i) for i in self.__str__())
 
 	def __int__(self):
 		if self.is_signed_integer:

--- a/python/metadata.py
+++ b/python/metadata.py
@@ -190,7 +190,7 @@ class Metadata(object):
 		raise ValueError("Metadata object not a string or raw type")
 
 	def __bytes__(self):
-		return bytes(bytearray(ord(i) for i in self.__str__())
+		return bytes(bytearray(ord(i) for i in self.__str__()))
 
 	def __int__(self):
 		if self.is_signed_integer:

--- a/python/metadata.py
+++ b/python/metadata.py
@@ -44,6 +44,8 @@ class Metadata(object):
 			self.handle = core.BNCreateMetadataBooleanData(value)
 		elif isinstance(value, (str, bytes)):
 			if raw:
+				if isinstance(value, str):
+					value = bytes(bytearray(ord(i) for i in value))
 				buffer = (ctypes.c_ubyte * len(value)).from_buffer_copy(value)
 				self.handle = core.BNCreateMetadataRawData(buffer, len(value))
 			else:

--- a/python/metadata.py
+++ b/python/metadata.py
@@ -42,9 +42,9 @@ class Metadata(object):
 				self.handle = core.BNCreateMetadataUnsignedIntegerData(value)
 		elif isinstance(value, bool):
 			self.handle = core.BNCreateMetadataBooleanData(value)
-		elif isinstance(value, str):
+		elif isinstance(value, (str, bytes)):
 			if raw:
-				buffer = (ctypes.c_ubyte * len(value)).from_buffer_copy(value.encode('charmap'))
+				buffer = (ctypes.c_ubyte * len(value)).from_buffer_copy(value)
 				self.handle = core.BNCreateMetadataRawData(buffer, len(value))
 			else:
 				self.handle = core.BNCreateMetadataStringData(value)
@@ -68,7 +68,7 @@ class Metadata(object):
 		if self.is_integer:
 			return int(self)
 		elif self.is_string or self.is_raw:
-			return str(self)
+			return bytes(self)
 		elif self.is_float:
 			return float(self)
 		elif self.is_boolean:
@@ -188,6 +188,9 @@ class Metadata(object):
 			return ''.join(chr(a) for a in out_list)
 
 		raise ValueError("Metadata object not a string or raw type")
+
+	def __bytes__(self):
+		return bytes(bytearray(ord(i) for i in self.__str__()))
 
 	def __int__(self):
 		if self.is_signed_integer:


### PR DESCRIPTION
Metadata doesn't work so well when you're pickling things that can potentially have a null-byte in the resulting pickled data. This PR does two things:

1. It allows raw Metadata objects to be passed into `BinaryView.store_metadata`, when previously they could not be.
2. It allows python3 to pass either a `str` or `bytes` object to `Metadata` as a value when the optional parameter `raw` is `True`.