### PR TITLE
Fix freeing of user allocated BNInstructionTextToken's

### DIFF
--- a/architecture.cpp
+++ b/architecture.cpp
@@ -107,6 +107,21 @@ BNInstructionTextToken* InstructionTextToken::CreateInstructionTextTokenList(con
 	return result;
 }
 
+void InstructionTextToken::FreeInstructionTextTokenList(BNInstructionTextToken* tokens, size_t count)
+{
+	for (size_t i = 0; i < count; i++)
+	{
+		BNInstructionTextToken* token = &tokens[i];
+
+		BNFreeString(token->text);
+
+		for (size_t j = 0; j < token->namesCount; ++j)
+			BNFreeString(token->typeNames[j]);
+
+		delete[] token->typeNames;
+	}
+	delete[] tokens;
+}
 
 vector<InstructionTextToken> InstructionTextToken::ConvertInstructionTextTokenList(const BNInstructionTextToken* tokens, size_t count)
 {
@@ -227,9 +242,7 @@ bool Architecture::GetInstructionTextCallback(void* ctxt, const uint8_t* data, u
 
 void Architecture::FreeInstructionTextCallback(BNInstructionTextToken* tokens, size_t count)
 {
-	for (size_t i = 0; i < count; i++)
-		BNFreeString(tokens[i].text);
-	delete[] tokens;
+	InstructionTextToken::FreeInstructionTextTokenList(tokens, count);
 }
 
 

--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -1051,6 +1051,7 @@ namespace BinaryNinja
 
 		InstructionTextToken WithConfidence(uint8_t conf);
 		static BNInstructionTextToken* CreateInstructionTextTokenList(const std::vector<InstructionTextToken>& tokens);
+		static void FreeInstructionTextTokenList(BNInstructionTextToken* tokens, size_t count);
 		static std::vector<InstructionTextToken> ConvertAndFreeInstructionTextTokenList(BNInstructionTextToken* tokens, size_t count);
 		static std::vector<InstructionTextToken> ConvertInstructionTextTokenList(const BNInstructionTextToken* tokens, size_t count);
 	};

--- a/datarenderer.cpp
+++ b/datarenderer.cpp
@@ -111,11 +111,9 @@ vector<DisassemblyTextLine> DataRenderer::GetLinesForData(BinaryView* data, uint
 	BNDisassemblyTextLine* lines = BNGetLinesForData(m_object, data->GetObject(), addr, type->GetObject(), prefixes,
 		prefix.size(), width, &count, typeCtx, context.size());
 
-	delete[] typeCtx;
-	for (size_t i = 0; i < prefix.size(); i++)
-		BNFreeString(prefixes[i].text);
+	InstructionTextToken::FreeInstructionTextTokenList(prefixes, prefix.size());
 
-	delete[] prefixes;
+	delete[] typeCtx;
 
 	vector<DisassemblyTextLine> result;
 	result.reserve(count);


### PR DESCRIPTION
BNInstructionTextToken typeName's were previously not freed.