### PR TITLE
Fixed install_api.py for virtualenv

### DIFF
--- a/scripts/install_api.py
+++ b/scripts/install_api.py
@@ -5,7 +5,14 @@
 
 import sys
 import os
-from site import getsitepackages, getusersitepackages, check_enableusersite
+from site import check_enableusersite
+
+# Handle both normal environments and virtualenvs
+from distutils.sysconfig import get_python_lib as getsitepackages
+try: 
+    from site import getusersitepackages
+except ImportError:
+    getusersitepackages = getsitepackages
 
 # Hacky command line parsing to accept a silent-install -s flag like linux-setup.sh:
 INTERACTIVE = True


### PR DESCRIPTION
`virtualenv` has its own `site.py` that does not contain `getsitepackages` or `getusersitepackages`. This commit replaces those imports with equivalent ones that do work in `virtualenv`.