### PR TITLE
Fixed imports in undoaction.py

### DIFF
--- a/python/undoaction.py
+++ b/python/undoaction.py
@@ -25,6 +25,7 @@ import ctypes
 # Binary Ninja components
 from binaryninja import _binaryninjacore as core
 from binaryninja.enums import ActionType
+import binaryninja
 
 
 class UndoAction(object):


### PR DESCRIPTION
`undoaction.py` was missing an import and so it was broken as soon as you tried to use it. This is just a quick fix for that.