### PR TITLE
Add __hash__ to IL Function objects

### DIFF
--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -752,6 +752,9 @@ class LowLevelILFunction(object):
 				func_handle = self.source_function.handle
 			self.handle = core.BNCreateLowLevelILFunction(arch.handle, func_handle)
 
+	def __hash__(self):
+		return hash('LLIL') + hash(self.source_function)
+
 	def __del__(self):
 		if self.handle is not None:
 			core.BNFreeLowLevelILFunction(self.handle)

--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -753,7 +753,7 @@ class LowLevelILFunction(object):
 			self.handle = core.BNCreateLowLevelILFunction(arch.handle, func_handle)
 
 	def __hash__(self):
-		return hash('LLIL') + hash(self.source_function)
+		return hash(('LLIL', self.source_function))
 
 	def __del__(self):
 		if self.handle is not None:

--- a/python/mediumlevelil.py
+++ b/python/mediumlevelil.py
@@ -633,6 +633,9 @@ class MediumLevelILFunction(object):
 			func_handle = self.source_function.handle
 			self.handle = core.BNCreateMediumLevelILFunction(arch.handle, func_handle)
 
+	def __hash__(self):
+		return hash('MLIL') + hash(self.source_function)
+
 	def __del__(self):
 		if self.handle is not None:
 			core.BNFreeMediumLevelILFunction(self.handle)

--- a/python/mediumlevelil.py
+++ b/python/mediumlevelil.py
@@ -634,7 +634,7 @@ class MediumLevelILFunction(object):
 			self.handle = core.BNCreateMediumLevelILFunction(arch.handle, func_handle)
 
 	def __hash__(self):
-		return hash('MLIL') + hash(self.source_function)
+		return hash(('MLIL', self.source_function))
 
 	def __del__(self):
 		if self.handle is not None:


### PR DESCRIPTION
They didn't have a __hash__ method so I added one so I can use them in sets. It's really just the hash of the Function object plus a string to indicate it's MLIL or LLIL