### PR TITLE
added timeout parameter to BackgroundTaskThread.join()

### DIFF
--- a/python/plugin.py
+++ b/python/plugin.py
@@ -657,5 +657,5 @@ class BackgroundTaskThread(BackgroundTask):
 	def start(self):
 		self.thread.start()
 
-	def join(self):
-		self.thread.join()
+	def join(self, timeout=None):
+		self.thread.join(timeout)


### PR DESCRIPTION
Forward `BackgroundTaskThread.join(timeout=None)` to `threading.join(timeout=None)`.