### PR TITLE
Encode strings to bytes passed to databuffer

### DIFF
--- a/python/databuffer.py
+++ b/python/databuffer.py
@@ -37,6 +37,8 @@ class DataBuffer(object):
 		elif isinstance(contents, DataBuffer):
 			self.handle = core.BNDuplicateDataBuffer(contents.handle)
 		else:
+			if bytes != str and isinstance(contents, str):
+				contents = contents.encode('charmap')
 			self.handle = core.BNCreateDataBuffer(contents, len(contents))
 
 	def __del__(self):


### PR DESCRIPTION
`BinaryView.find_next_data` wraps the call to DataBuffer with `str`. For python3 this gets passed to `DataBuffer` as a unicode string and not a byte string. `DataBuffer` does not convert str to bytes and creates a bad DataBuffer. 

```python
>>> a = DataBuffer('abcd')
>>> str(a)
'abcd'
```
This PR encodes a python3 str to bytes using `charmap`. It verifies that `bytes != str` to only encode a python3 str and not a python2 str.