### PR TITLE
made header file valid C

### DIFF
--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 #ifdef __GNUC__
 #  ifdef BINARYNINJACORE_LIBRARY
@@ -105,88 +106,88 @@
 extern "C"
 {
 #endif
-	enum BNPluginLoadOrder
+	typedef enum BNPluginLoadOrder
 	{
 		EarlyPluginLoadOrder,
 		NormalPluginLoadOrder,
 		LatePluginLoadOrder
-	};
+	} BNPluginLoadOrder;
 
 	typedef bool (*BNCorePluginInitFunction)(void);
 	typedef void (*BNCorePluginDependencyFunction)(void);
 
-	struct BNDataBuffer;
-	struct BNBinaryView;
-	struct BNBinaryViewType;
-	struct BNBinaryReader;
-	struct BNBinaryWriter;
-	struct BNFileMetadata;
-	struct BNTransform;
-	struct BNArchitecture;
-	struct BNFunction;
-	struct BNBasicBlock;
-	struct BNDownloadProvider;
-	struct BNDownloadInstance;
-	struct BNFlowGraph;
-	struct BNFlowGraphNode;
-	struct BNFlowGraphLayoutRequest;
-	struct BNSymbol;
-	struct BNTemporaryFile;
-	struct BNLowLevelILFunction;
-	struct BNMediumLevelILFunction;
-	struct BNType;
-	struct BNStructure;
-	struct BNNamedTypeReference;
-	struct BNEnumeration;
-	struct BNCallingConvention;
-	struct BNPlatform;
-	struct BNAnalysisCompletionEvent;
-	struct BNDisassemblySettings;
-	struct BNScriptingProvider;
-	struct BNScriptingInstance;
-	struct BNMainThreadAction;
-	struct BNBackgroundTask;
-	struct BNRepository;
-	struct BNRepoPlugin;
-	struct BNRepositoryManager;
-	struct BNMetadata;
-	struct BNReportCollection;
-	struct BNRelocation;
-	struct BNSegment;
-	struct BNSection;
-	struct BNRelocationInfo;
-	struct BNRelocationHandler;
-	struct BNDataBuffer;
-	struct BNDataRenderer;
-	struct BNDataRendererContainer;
-	struct BNDisassemblyTextRenderer;
+  typedef struct BNDataBuffer BNDataBuffer;
+  typedef struct BNBinaryView BNBinaryView;
+  typedef struct BNBinaryViewType BNBinaryViewType;
+  typedef struct BNBinaryReader BNBinaryReader;
+  typedef struct BNBinaryWriter BNBinaryWriter;
+  typedef struct BNFileMetadata BNFileMetadata;
+  typedef struct BNTransform BNTransform;
+  typedef struct BNArchitecture BNArchitecture;
+  typedef struct BNFunction BNFunction;
+  typedef struct BNBasicBlock BNBasicBlock;
+  typedef struct BNDownloadProvider BNDownloadProvider;
+  typedef struct BNDownloadInstance BNDownloadInstance;
+  typedef struct BNFlowGraph BNFlowGraph;
+  typedef struct BNFlowGraphNode BNFlowGraphNode;
+  typedef struct BNFlowGraphLayoutRequest BNFlowGraphLayoutRequest;
+  typedef struct BNSymbol BNSymbol;
+  typedef struct BNTemporaryFile BNTemporaryFile;
+  typedef struct BNLowLevelILFunction BNLowLevelILFunction;
+  typedef struct BNMediumLevelILFunction BNMediumLevelILFunction;
+  typedef struct BNType BNType;
+  typedef struct BNStructure BNStructure;
+  typedef struct BNNamedTypeReference BNNamedTypeReference;
+  typedef struct BNEnumeration BNEnumeration;
+  typedef struct BNCallingConvention BNCallingConvention;
+  typedef struct BNPlatform BNPlatform;
+  typedef struct BNAnalysisCompletionEvent BNAnalysisCompletionEvent;
+  typedef struct BNDisassemblySettings BNDisassemblySettings;
+  typedef struct BNScriptingProvider BNScriptingProvider;
+  typedef struct BNScriptingInstance BNScriptingInstance;
+  typedef struct BNMainThreadAction BNMainThreadAction;
+  typedef struct BNBackgroundTask BNBackgroundTask;
+  typedef struct BNRepository BNRepository;
+  typedef struct BNRepoPlugin BNRepoPlugin;
+  typedef struct BNRepositoryManager BNRepositoryManager;
+  typedef struct BNMetadata BNMetadata;
+  typedef struct BNReportCollection BNReportCollection;
+  typedef struct BNRelocation BNRelocation;
+  typedef struct BNSegment BNSegment;
+  typedef struct BNSection BNSection;
+  typedef struct BNRelocationInfo BNRelocationInfo;
+  typedef struct BNRelocationHandler BNRelocationHandler;
+  typedef struct BNDataBuffer BNDataBuffer;
+  typedef struct BNDataRenderer BNDataRenderer;
+  typedef struct BNDataRendererContainer BNDataRendererContainer;
+  typedef struct BNDisassemblyTextRenderer BNDisassemblyTextRenderer;
 
 	typedef bool (*BNLoadPluginCallback)(const char* repoPath, const char* pluginPath, void* ctx);
 
 	//! Console log levels
-	enum BNLogLevel
+	typedef enum BNLogLevel
 	{
 		DebugLog = 0,   //! Debug logging level, most verbose logging level
 		InfoLog = 1,    //! Information logging level, default logging level
 		WarningLog = 2, //! Warning logging level, messages show with warning icon in the UI
 		ErrorLog = 3,   //! Error logging level, messages show with error icon in the UI
 		AlertLog = 4    //! Alert logging level, messages are displayed with popup message box in the UI
-	};
+	} BNLogLevel;
 
-	enum BNEndianness
+	typedef enum BNEndianness
 	{
 		LittleEndian = 0,
 		BigEndian = 1
-	};
+	} BNEndianness;
 
-	enum BNModificationStatus
+	typedef enum BNModificationStatus
 	{
 		Original = 0,
 		Changed = 1,
 		Inserted = 2
-	};
+	} BNModificationStatus;
 
-	enum BNTransformType
+	typedef enum BNTransformType
 	{
 		BinaryCodecTransform = 0, // Two-way transform of data, binary input/output
 		TextCodecTransform = 1, // Two-way transform of data, encoder output is text
@@ -197,9 +198,9 @@ extern "C"
 		EncryptTransform = 6, // Two-way encryption
 		InvertingTransform = 7, // Transform that can be undone by performing twice
 		HashTransform = 8 // Hash function
-	};
+	} BNTransformType;
 
-	enum BNBranchType
+	typedef enum BNBranchType
 	{
 		UnconditionalBranch = 0,
 		FalseBranch = 1,
@@ -210,9 +211,9 @@ extern "C"
 		IndirectBranch = 6,
 		ExceptionBranch = 7,
 		UnresolvedBranch = 127
-	};
+	} BNBranchType;
 
-	enum BNInstructionTextTokenType
+	typedef enum BNInstructionTextTokenType
 	{
 		TextToken = 0,
 		InstructionToken = 1,
@@ -247,17 +248,17 @@ extern "C"
 		AddressDisplayToken = 68,
 		IndirectImportToken = 69,
 		ExternalSymbolToken = 70
-	};
+	} BNInstructionTextTokenType;
 
-	enum BNInstructionTextTokenContext
+	typedef enum BNInstructionTextTokenContext
 	{
 		NoTokenContext = 0,
 		LocalVariableTokenContext = 1,
 		DataVariableTokenContext = 2,
 		FunctionReturnTokenContext = 3
-	};
+	} BNInstructionTextTokenContext;
 
-	enum BNLinearDisassemblyLineType
+	typedef enum BNLinearDisassemblyLineType
 	{
 		BlankLineType,
 		BasicLineType,
@@ -278,9 +279,9 @@ extern "C"
 		SectionEndLineType,
 		SectionSeparatorLineType,
 		NonContiguousSeparatorLineType
-	};
+	} BNLinearDisassemblyLineType;
 
-	enum BNSymbolType
+	typedef enum BNSymbolType
 	{
 		FunctionSymbol = 0,
 		ImportAddressSymbol = 1,
@@ -288,25 +289,25 @@ extern "C"
 		DataSymbol = 3,
 		ImportedDataSymbol = 4,
 		ExternalSymbol = 5
-	};
+	} BNSymbolType;
 
-	enum BNSymbolBinding
+	typedef enum BNSymbolBinding
 	{
 		NoBinding,
 		LocalBinding,
 		GlobalBinding,
 		WeakBinding
-	};
+	} BNSymbolBinding;
 
-	enum BNActionType
+	typedef enum BNActionType
 	{
 		TemporaryAction = 0,
 		DataModificationAction = 1,
 		AnalysisAction = 2,
 		DataModificationAndAnalysisAction = 3
-	};
+	} BNActionType;
 
-	enum BNLowLevelILOperation
+	typedef enum BNLowLevelILOperation
 	{
 		LLIL_NOP,
 		LLIL_SET_REG, // Not valid in SSA form (see LLIL_SET_REG_SSA)
@@ -447,9 +448,9 @@ extern "C"
 		LLIL_REG_STACK_PHI,
 		LLIL_FLAG_PHI,
 		LLIL_MEM_PHI
-	};
+	} BNLowLevelILOperation;
 
-	enum BNLowLevelILFlagCondition
+	typedef enum BNLowLevelILFlagCondition
 	{
 		LLFC_E,
 		LLFC_NE,
@@ -473,9 +474,9 @@ extern "C"
 		LLFC_FGT,
 		LLFC_FO,
 		LLFC_FUO
-	};
+	} BNLowLevelILFlagCondition;
 
-	enum BNFlagRole
+	typedef enum BNFlagRole
 	{
 		SpecialFlagRole = 0,
 		ZeroFlagRole = 1,
@@ -488,9 +489,9 @@ extern "C"
 		OddParityFlagRole = 8,
 		OrderedFlagRole = 9,
 		UnorderedFlagRole = 10
-	};
+	} BNFlagRole;
 
-	enum BNFunctionGraphType
+	typedef enum BNFunctionGraphType
 	{
 		NormalFunctionGraph = 0,
 		LowLevelILFunctionGraph = 1,
@@ -500,9 +501,9 @@ extern "C"
 		MediumLevelILSSAFormFunctionGraph = 5,
 		MappedMediumLevelILFunctionGraph = 6,
 		MappedMediumLevelILSSAFormFunctionGraph = 7
-	};
+	} BNFunctionGraphType;
 
-	enum BNDisassemblyOption
+	typedef enum BNDisassemblyOption
 	{
 		ShowAddress = 0,
 		ShowOpcode = 1,
@@ -518,9 +519,9 @@ extern "C"
 
 		// Debugging options
 		ShowFlagUsage = 128
-	};
+	} BNDisassemblyOption;
 
-	enum BNTypeClass
+	typedef enum BNTypeClass
 	{
 		VoidTypeClass = 0,
 		BoolTypeClass = 1,
@@ -535,9 +536,9 @@ extern "C"
 		ValueTypeClass = 10,
 		NamedTypeReferenceClass = 11,
 		WideCharTypeClass = 12
-	};
+	} BNTypeClass;
 
-	enum BNNamedTypeReferenceClass
+	typedef enum BNNamedTypeReferenceClass
 	{
 		UnknownNamedTypeClass = 0,
 		TypedefNamedTypeClass = 1,
@@ -545,49 +546,49 @@ extern "C"
 		StructNamedTypeClass = 3,
 		UnionNamedTypeClass = 4,
 		EnumNamedTypeClass = 5
-	};
+	} BNNamedTypeReferenceClass;
 
-	enum BNStructureType
+	typedef enum BNStructureType
 	{
 		ClassStructureType = 0,
 		StructStructureType = 1,
 		UnionStructureType = 2
-	};
+	} BNStructureType;
 
-	enum BNMemberScope {
+	typedef enum BNMemberScope {
 		NoScope,
 		StaticScope,
 		VirtualScope,
 		ThunkScope,
 		FriendScope
-	};
+	} BNMemberScope;
 
-	enum BNMemberAccess
+	typedef enum BNMemberAccess
 	{
 		NoAccess,
 		PrivateAccess,
 		ProtectedAccess,
 		PublicAccess
-	};
+	} BNMemberAccess;
 
-	enum BNReferenceType
+	typedef enum BNReferenceType
 	{
 		PointerReferenceType = 0,
 		ReferenceReferenceType = 1,
 		RValueReferenceType = 2,
 		NoReference = 3
-	};
+	} BNReferenceType;
 
-	enum BNPointerSuffix
+	typedef enum BNPointerSuffix
 	{
 		Ptr64Suffix,
 		UnalignedSuffix,
 		RestrictSuffix,
 		ReferenceSuffix,
 		LvalueSuffix
-	};
+	} BNPointerSuffix;
 
-	enum BNNameType
+	typedef enum BNNameType
 	{
 		NoNameType,
 		ConstructorNameType,
@@ -667,9 +668,9 @@ extern "C"
 		OperatorUnaryPlusNameType,
 		OperatorUnaryBitAndNameType,
 		OperatorUnaryStarNameType
-	};
+	} BNNameType;
 
-	enum BNCallingConventionName
+	typedef enum BNCallingConventionName
 	{
 		NoCallingConvention,
 		CdeclCallingConvention,
@@ -680,17 +681,17 @@ extern "C"
 		CLRCallCallingConvention,
 		EabiCallCallingConvention,
 		VectorCallCallingConvention
-	};
+	} BNCallingConventionName;
 
-	enum BNStringType
+	typedef enum BNStringType
 	{
 		AsciiString = 0,
 		Utf16String = 1,
 		Utf32String = 2,
 		Utf8String = 3
-	};
+	} BNStringType;
 
-	enum BNIntegerDisplayType
+	typedef enum BNIntegerDisplayType
 	{
 		DefaultIntegerDisplayType,
 		BinaryDisplayType,
@@ -702,9 +703,9 @@ extern "C"
 		UnsignedHexadecimalDisplayType,
 		CharacterConstantDisplayType,
 		PointerDisplayType
-	};
+	} BNIntegerDisplayType;
 
-	enum BNFlowGraphOption
+	typedef enum BNFlowGraphOption
 	{
 		FlowGraphUsesBlockHighlights,
 		FlowGraphUsesInstructionHighlights,
@@ -712,9 +713,9 @@ extern "C"
 		FlowGraphAllowsPatching,
 		FlowGraphAllowsInlineInstructionEditing,
 		FlowGraphShowsSecondaryRegisterHighlighting
-	};
+	} BNFlowGraphOption;
 
-	struct BNLowLevelILInstruction
+	typedef struct BNLowLevelILInstruction
 	{
 		BNLowLevelILOperation operation;
 		size_t size;
@@ -722,38 +723,38 @@ extern "C"
 		uint32_t sourceOperand;
 		uint64_t operands[4];
 		uint64_t address;
-	};
+	} BNLowLevelILInstruction;
 
-	struct BNLowLevelILLabel
+	typedef struct BNLowLevelILLabel
 	{
 		bool resolved;
 		size_t ref;
 		size_t operand;
-	};
+	} BNLowLevelILLabel;
 
-	enum BNImplicitRegisterExtend
+	typedef enum BNImplicitRegisterExtend
 	{
 		NoExtend,
 		ZeroExtendToFullWidth,
 		SignExtendToFullWidth
-	};
+	} BNImplicitRegisterExtend;
 
-	struct BNRegisterInfo
+	typedef struct BNRegisterInfo
 	{
 		uint32_t fullWidthRegister;
 		size_t offset;
 		size_t size;
 		BNImplicitRegisterExtend extend;
-	};
+	} BNRegisterInfo;
 
-	struct BNRegisterStackInfo
+	typedef struct BNRegisterStackInfo
 	{
 		uint32_t firstStorageReg, firstTopRelativeReg;
 		uint32_t storageCount, topRelativeCount;
 		uint32_t stackTopReg;
-	};
+	} BNRegisterStackInfo;
 
-	enum BNRegisterValueType
+	typedef enum BNRegisterValueType
 	{
 		UndeterminedValue,
 		EntryValue,
@@ -770,55 +771,55 @@ extern "C"
 		LookupTableValue,
 		InSetOfValues,
 		NotInSetOfValues
-	};
+	} BNRegisterValueType;
 
-	enum BNPluginOrigin
+	typedef enum BNPluginOrigin
 	{
 		OfficialPluginOrigin,
 		CommunityPluginOrigin,
 		OtherPluginOrigin
-	};
+	} BNPluginOrigin;
 
-	enum BNPluginUpdateStatus
+	typedef enum BNPluginUpdateStatus
 	{
 		UpToDatePluginStatus,
 		UpdatesAvailablePluginStatus
-	};
+	} BNPluginUpdateStatus;
 
-	enum BNPluginType
+	typedef enum BNPluginType
 	{
 		CorePluginType,
 		UiPluginType,
 		ArchitecturePluginType,
 		BinaryViewPluginType
-	};
+	} BNPluginType;
 
-	struct BNLookupTableEntry
+	typedef struct BNLookupTableEntry
 	{
 		int64_t* fromValues;
 		size_t fromCount;
 		int64_t toValue;
-	};
+	} BNLookupTableEntry;
 
-	struct BNRegisterValue
+	typedef struct BNRegisterValue
 	{
 		BNRegisterValueType state;
 		int64_t value;
 		int64_t offset;
-	};
+	} BNRegisterValue;
 
-	struct BNRegisterValueWithConfidence
+	typedef struct BNRegisterValueWithConfidence
 	{
 		BNRegisterValue value;
 		uint8_t confidence;
-	};
+	} BNRegisterValueWithConfidence;
 
-	struct BNValueRange
+	typedef struct BNValueRange
 	{
 		uint64_t start, end, step;
-	};
+	} BNValueRange;
 
-	struct BNPossibleValueSet
+	typedef struct BNPossibleValueSet
 	{
 		BNRegisterValueType state;
 		int64_t value;
@@ -827,24 +828,24 @@ extern "C"
 		int64_t* valueSet;
 		BNLookupTableEntry* table;
 		size_t count;
-	};
+	} BNPossibleValueSet;
 
-	struct BNRegisterOrConstant
+	typedef struct BNRegisterOrConstant
 	{
 		bool constant;
 		uint32_t reg;
 		uint64_t value;
-	};
+	} BNRegisterOrConstant;
 
-	struct BNDataVariable
+	typedef struct BNDataVariable
 	{
 		uint64_t address;
 		BNType* type;
 		bool autoDiscovered;
 		uint8_t typeConfidence;
-	};
+	} BNDataVariable;
 
-	enum BNMediumLevelILOperation
+	typedef enum BNMediumLevelILOperation
 	{
 		MLIL_NOP,
 		MLIL_SET_VAR, // Not valid in SSA form (see MLIL_SET_VAR_SSA)
@@ -981,77 +982,77 @@ extern "C"
 		MLIL_FREE_VAR_SLOT_SSA,
 		MLIL_VAR_PHI,
 		MLIL_MEM_PHI
-	};
+	} BNMediumLevelILOperation;
 
-	struct BNMediumLevelILInstruction
+	typedef struct BNMediumLevelILInstruction
 	{
 		BNMediumLevelILOperation operation;
 		uint32_t sourceOperand;
 		size_t size;
 		uint64_t operands[5];
 		uint64_t address;
-	};
+	} BNMediumLevelILInstruction;
 
-	struct BNMediumLevelILLabel
+	typedef struct BNMediumLevelILLabel
 	{
 		bool resolved;
 		size_t ref;
 		size_t operand;
-	};
+	} BNMediumLevelILLabel;
 
-	enum BNVariableSourceType
+	typedef enum BNVariableSourceType
 	{
 		StackVariableSourceType,
 		RegisterVariableSourceType,
 		FlagVariableSourceType
-	};
+	} BNVariableSourceType;
 
-	struct BNVariable
+	typedef struct BNVariable
 	{
 		BNVariableSourceType type;
 		uint32_t index;
 		int64_t storage;
-	};
+	} BNVariable;
 
 	// Callbacks
-	struct BNLogListener
+	typedef struct BNLogListener
 	{
 		void* context;
 		void (*log)(void* ctxt, BNLogLevel level, const char* msg);
 		void (*close)(void* ctxt);
 		BNLogLevel (*getLogLevel)(void* ctxt);
-	};
+	} BNLogListener;
 
-	struct BNNavigationHandler
+	typedef struct BNNavigationHandler
 	{
 		void* context;
 		char* (*getCurrentView)(void* ctxt);
 		uint64_t (*getCurrentOffset)(void* ctxt);
 		bool (*navigate)(void* ctxt, const char* view, uint64_t offset);
-	};
+	} BNNavigationHandler;
 
-	struct BNNameList
+	typedef struct BNNameList
 	{
 		char** name;
 		char* join;
 		size_t nameCount;
-	};
+	} BNNameList;
 
-	struct BNNameSpace
+	typedef struct BNNameSpace
 	{
 		char** name;
 		char* join;
 		size_t nameCount;
-	};
+	} BNNameSpace;
 
-	struct BNQualifiedName
+	typedef struct BNQualifiedName
 	{
 		char** name;
 		char* join;
 		size_t nameCount;
-	};
+	} BNQualifiedName;
 
-	struct BNBinaryDataNotification
+	typedef struct BNBinaryDataNotification
 	{
 		void* context;
 		void (*dataWritten)(void* ctxt, BNBinaryView* view, uint64_t offset, size_t len);
@@ -1068,17 +1069,17 @@ extern "C"
 		void (*stringRemoved)(void* ctxt, BNBinaryView* view, BNStringType type, uint64_t offset, size_t len);
 		void (*typeDefined)(void* ctxt, BNBinaryView* view, BNQualifiedName* name, BNType* type);
 		void (*typeUndefined)(void* ctxt, BNBinaryView* view, BNQualifiedName* name, BNType* type);
-	};
+	} BNBinaryDataNotification;
 
-	struct BNFileAccessor
+	typedef struct BNFileAccessor
 	{
 		void* context;
 		uint64_t (*getLength)(void* ctxt);
 		size_t (*read)(void* ctxt, void* dest, uint64_t offset, size_t len);
 		size_t (*write)(void* ctxt, uint64_t offset, const void* src, size_t len);
-	};
+	} BNFileAccessor;
 
-	struct BNCustomBinaryView
+	typedef struct BNCustomBinaryView
 	{
 		void* context;
 		bool (*init)(void* ctxt);
@@ -1102,38 +1103,38 @@ extern "C"
 		bool (*isRelocatable)(void* ctxt);
 		size_t (*getAddressSize)(void* ctxt);
 		bool (*save)(void* ctxt, BNFileAccessor* accessor);
-	};
+	} BNCustomBinaryView;
 
-	struct BNCustomBinaryViewType
+	typedef struct BNCustomBinaryViewType
 	{
 		void* context;
 		BNBinaryView* (*create)(void* ctxt, BNBinaryView* data);
 		bool (*isValidForData)(void* ctxt, BNBinaryView* data);
-	};
+	} BNCustomBinaryViewType;
 
-	struct BNTransformParameterInfo
+	typedef struct BNTransformParameterInfo
 	{
 		char* name;
 		char* longName;
 		size_t fixedLength; // Variable length if zero
-	};
+	} BNTransformParameterInfo;
 
-	struct BNTransformParameter
+	typedef struct BNTransformParameter
 	{
 		const char* name;
 		BNDataBuffer* value;
-	};
+	} BNTransformParameter;
 
-	struct BNCustomTransform
+	typedef struct BNCustomTransform
 	{
 		void* context;
 		BNTransformParameterInfo* (*getParameters)(void* ctxt, size_t* count);
 		void (*freeParameters)(BNTransformParameterInfo* params, size_t count);
 		bool (*decode)(void* ctxt, BNDataBuffer* input, BNDataBuffer* output, BNTransformParameter* params, size_t paramCount);
 		bool (*encode)(void* ctxt, BNDataBuffer* input, BNDataBuffer* output, BNTransformParameter* params, size_t paramCount);
-	};
+	} BNCustomTransform;
 
-	struct BNInstructionInfo
+	typedef struct BNInstructionInfo
 	{
 		size_t length;
 		size_t branchCount;
@@ -1142,9 +1143,9 @@ extern "C"
 		BNBranchType branchType[BN_MAX_INSTRUCTION_BRANCHES];
 		uint64_t branchTarget[BN_MAX_INSTRUCTION_BRANCHES];
 		BNArchitecture* branchArch[BN_MAX_INSTRUCTION_BRANCHES]; // If null, same architecture as instruction
-	};
+	} BNInstructionInfo;
 
-	enum BNRelocationType
+	typedef enum BNRelocationType
 	{
 		ELFGlobalRelocationType,
 		ELFCopyRelocationType,
@@ -1152,9 +1153,9 @@ extern "C"
 		StandardRelocationType,
 		IgnoredRelocation,
 		UnhandledRelocation
-	};
+	} BNRelocationType;
 	#define MAX_RELOCATION_SIZE 8
-	struct BNRelocationInfo
+	typedef struct BNRelocationInfo
 	{
 		BNRelocationType type; // BinaryNinja Relocation Type
 		bool pcRelative;       // PC Relative or Absolute (subtract address from relocation)
@@ -1175,9 +1176,9 @@ extern "C"
 		uint8_t relocationDataCache[MAX_RELOCATION_SIZE];
 		struct BNRelocationInfo* prev; // Link to relocation another related relocation
 		struct BNRelocationInfo* next; // Link to relocation another related relocation
-	};
+	} BNRelocationInfo;
 
-	struct BNInstructionTextToken
+	typedef struct BNInstructionTextToken
 	{
 		BNInstructionTextTokenType type;
 		char* text;
@@ -1188,34 +1189,34 @@ extern "C"
 		uint64_t address;
 		char** typeNames;
 		size_t namesCount;
-	};
+	} BNInstructionTextToken;
 
-	struct BNInstructionTextLine
+	typedef struct BNInstructionTextLine
 	{
 		BNInstructionTextToken* tokens;
 		size_t count;
-	};
+	} BNInstructionTextLine;
 
-	struct BNFlagConditionForSemanticClass
+	typedef struct BNFlagConditionForSemanticClass
 	{
 		uint32_t semanticClass;
 		BNLowLevelILFlagCondition condition;
-	};
+	} BNFlagConditionForSemanticClass;
 
-	struct BNNameAndType
+	typedef struct BNNameAndType
 	{
 		char* name;
 		BNType* type;
 		uint8_t typeConfidence;
-	};
+	} BNNameAndType;
 
-	struct BNTypeWithConfidence
+	typedef struct BNTypeWithConfidence
 	{
 		BNType* type;
 		uint8_t confidence;
-	};
+	} BNTypeWithConfidence;
 
-	struct BNCustomArchitecture
+	typedef struct BNCustomArchitecture
 	{
 		void* context;
 		void (*init)(void* context, BNArchitecture* obj);
@@ -1284,39 +1285,39 @@ extern "C"
 		bool (*alwaysBranch)(void* ctxt, uint8_t* data, uint64_t addr, size_t len);
 		bool (*invertBranch)(void* ctxt, uint8_t* data, uint64_t addr, size_t len);
 		bool (*skipAndReturnValue)(void* ctxt, uint8_t* data, uint64_t addr, size_t len, uint64_t value);
-	};
+	} BNCustomArchitecture;
 
-	struct BNBasicBlockEdge
+	typedef struct BNBasicBlockEdge
 	{
 		BNBranchType type;
 		BNBasicBlock* target;
 		bool backEdge;
 		bool fallThrough;
-	};
+	} BNBasicBlockEdge;
 
-	struct BNPoint
+	typedef struct BNPoint
 	{
 		float x;
 		float y;
-	};
+	} BNPoint;
 
-	struct BNFlowGraphEdge
+	typedef struct BNFlowGraphEdge
 	{
 		BNBranchType type;
 		BNFlowGraphNode* target;
 		BNPoint* points;
 		size_t pointCount;
 		bool backEdge;
-	};
+	} BNFlowGraphEdge;
 
-	enum BNHighlightColorStyle
+	typedef enum BNHighlightColorStyle
 	{
 		StandardHighlightColor = 0,
 		MixedHighlightColor = 1,
 		CustomHighlightColor = 2
-	};
+	} BNHighlightColorStyle;
 
-	enum BNHighlightStandardColor
+	typedef enum BNHighlightStandardColor
 	{
 		NoHighlightColor = 0,
 		BlueHighlightColor = 1,
@@ -1328,49 +1329,49 @@ extern "C"
 		OrangeHighlightColor = 7,
 		WhiteHighlightColor = 8,
 		BlackHighlightColor = 9
-	};
+	} BNHighlightStandardColor;
 
-	struct BNHighlightColor
+	typedef struct BNHighlightColor
 	{
 		BNHighlightColorStyle style;
 		BNHighlightStandardColor color;
 		BNHighlightStandardColor mixColor;
 		uint8_t mix, r, g, b, alpha;
-	};
+	} BNHighlightColor;
 
-	struct BNDisassemblyTextLine
+	typedef struct BNDisassemblyTextLine
 	{
 		uint64_t addr;
 		size_t instrIndex;
 		BNInstructionTextToken* tokens;
 		size_t count;
 		BNHighlightColor highlight;
-	};
+	} BNDisassemblyTextLine;
 
-	struct BNLinearDisassemblyLine
+	typedef struct BNLinearDisassemblyLine
 	{
 		BNLinearDisassemblyLineType type;
 		BNFunction* function;
 		BNBasicBlock* block;
 		size_t lineOffset;
 		BNDisassemblyTextLine contents;
-	};
+	} BNLinearDisassemblyLine;
 
-	struct BNLinearDisassemblyPosition
+	typedef struct BNLinearDisassemblyPosition
 	{
 		BNFunction* function;
 		BNBasicBlock* block;
 		uint64_t address;
-	};
+	} BNLinearDisassemblyPosition;
 
-	struct BNReferenceSource
+	typedef struct BNReferenceSource
 	{
 		BNFunction* func;
 		BNArchitecture* arch;
 		uint64_t addr;
-	};
+	} BNReferenceSource;
 
-	struct BNUndoAction
+	typedef struct BNUndoAction
 	{
 		BNActionType type;
 		void* context;
@@ -1378,96 +1379,96 @@ extern "C"
 		void (*undo)(void* ctxt, BNBinaryView* data);
 		void (*redo)(void* ctxt, BNBinaryView* data);
 		char* (*serialize)(void* ctxt);
-	};
+	} BNUndoAction;
 
-	struct BNCallingConventionWithConfidence
+	typedef struct BNCallingConventionWithConfidence
 	{
 		BNCallingConvention* convention;
 		uint8_t confidence;
-	};
+	} BNCallingConventionWithConfidence;
 
-	struct BNBoolWithConfidence
+	typedef struct BNBoolWithConfidence
 	{
 		bool value;
 		uint8_t confidence;
-	};
+	} BNBoolWithConfidence;
 
-	struct BNSizeWithConfidence
+	typedef struct BNSizeWithConfidence
 	{
 		size_t value;
 		uint8_t confidence;
-	};
+	} BNSizeWithConfidence;
 
-	struct BNOffsetWithConfidence
+	typedef struct BNOffsetWithConfidence
 	{
 		int64_t value;
 		uint8_t confidence;
-	};
+	} BNOffsetWithConfidence;
 
-	struct BNMemberScopeWithConfidence
+	typedef struct BNMemberScopeWithConfidence
 	{
 		BNMemberScope value;
 		uint8_t confidence;
-	};
+	} BNMemberScopeWithConfidence;
 
-	struct BNMemberAccessWithConfidence
+	typedef struct BNMemberAccessWithConfidence
 	{
 		BNMemberAccess value;
 		uint8_t confidence;
-	};
+	} BNMemberAccessWithConfidence;
 
-	struct BNParameterVariablesWithConfidence
+	typedef struct BNParameterVariablesWithConfidence
 	{
 		BNVariable* vars;
 		size_t count;
 		uint8_t confidence;
-	};
+	} BNParameterVariablesWithConfidence;
 
-	struct BNRegisterSetWithConfidence
+	typedef struct BNRegisterSetWithConfidence
 	{
 		uint32_t* regs;
 		size_t count;
 		uint8_t confidence;
-	};
+	} BNRegisterSetWithConfidence;
 
-	struct BNFunctionParameter
+	typedef struct BNFunctionParameter
 	{
 		char* name;
 		BNType* type;
 		uint8_t typeConfidence;
 		bool defaultLocation;
 		BNVariable location;
-	};
+	} BNFunctionParameter;
 
-	struct BNQualifiedNameAndType
+	typedef struct BNQualifiedNameAndType
 	{
 		BNQualifiedName name;
 		BNType* type;
-	};
+	} BNQualifiedNameAndType;
 
-	struct BNStructureMember
+	typedef struct BNStructureMember
 	{
 		BNType* type;
 		char* name;
 		uint64_t offset;
 		uint8_t typeConfidence;
-	};
+	} BNStructureMember;
 
-	struct BNEnumerationMember
+	typedef struct BNEnumerationMember
 	{
 		char* name;
 		uint64_t value;
 		bool isDefault;
-	};
+	} BNEnumerationMember;
 
-	struct BNFunctionRecognizer
+	typedef struct BNFunctionRecognizer
 	{
 		void* context;
 		bool (*recognizeLowLevelIL)(void* ctxt, BNBinaryView* data, BNFunction* func, BNLowLevelILFunction* il);
 		bool (*recognizeMediumLevelIL)(void* ctxt, BNBinaryView* data, BNFunction* func, BNMediumLevelILFunction* il);
-	};
+	} BNFunctionRecognizer;
 
-	struct BNCustomRelocationHandler
+	typedef struct BNCustomRelocationHandler
 	{
 		void* context;
 		void (*freeObject)(void* ctxt);
@@ -1478,46 +1479,46 @@ extern "C"
 			size_t len);
 		size_t (*getOperandForExternalRelocation)(void* ctxt, const uint8_t* data, uint64_t addr, size_t length,
 			BNLowLevelILFunction* il, BNRelocation* relocation);
-	};
+	} BNCustomRelocationHandler;
 
-	struct BNTypeParserResult
+	typedef struct BNTypeParserResult
 	{
 		BNQualifiedNameAndType* types;
 		BNQualifiedNameAndType* variables;
 		BNQualifiedNameAndType* functions;
 		size_t typeCount, variableCount, functionCount;
-	};
+	} BNTypeParserResult;
 
-	enum BNUpdateResult
+	typedef enum BNUpdateResult
 	{
 		UpdateFailed = 0,
 		UpdateSuccess = 1,
 		AlreadyUpToDate = 2,
 		UpdateAvailable = 3
-	};
+	} BNUpdateResult;
 
-	struct BNUpdateChannel
+	typedef struct BNUpdateChannel
 	{
 		char* name;
 		char* description;
 		char* latestVersion;
-	};
+	} BNUpdateChannel;
 
-	struct BNUpdateVersion
+	typedef struct BNUpdateVersion
 	{
 		char* version;
 		char* notes;
 		uint64_t time;
-	};
+	} BNUpdateVersion;
 
-	struct BNStringReference
+	typedef struct BNStringReference
 	{
 		BNStringType type;
 		uint64_t start;
 		size_t length;
-	};
+	} BNStringReference;
 
-	enum BNPluginCommandType
+	typedef enum BNPluginCommandType
 	{
 		DefaultPluginCommand,
 		AddressPluginCommand,
@@ -1527,9 +1528,9 @@ extern "C"
 		LowLevelILInstructionPluginCommand,
 		MediumLevelILFunctionPluginCommand,
 		MediumLevelILInstructionPluginCommand
-	};
+	} BNPluginCommandType;
 
-	struct BNPluginCommand
+	typedef struct BNPluginCommand
 	{
 		char* name;
 		char* description;
@@ -1553,9 +1554,9 @@ extern "C"
 		bool (*lowLevelILInstructionIsValid)(void* ctxt, BNBinaryView* view, BNLowLevelILFunction* func, size_t instr);
 		bool (*mediumLevelILFunctionIsValid)(void* ctxt, BNBinaryView* view, BNMediumLevelILFunction* func);
 		bool (*mediumLevelILInstructionIsValid)(void* ctxt, BNBinaryView* view, BNMediumLevelILFunction* func, size_t instr);
-	};
+	} BNPluginCommand;
 
-	struct BNCustomCallingConvention
+	typedef struct BNCustomCallingConvention
 	{
 		void* context;
 
@@ -1584,18 +1585,18 @@ extern "C"
 			BNFunction* func, BNVariable* result);
 		void (*getParameterVariableForIncomingVariable)(void* ctxt, const BNVariable* var,
 			BNFunction* func, BNVariable* result);
-	};
+	} BNCustomCallingConvention;
 
-	struct BNVariableNameAndType
+	typedef struct BNVariableNameAndType
 	{
 		BNVariable var;
 		BNType* type;
 		char* name;
 		bool autoDefined;
 		uint8_t typeConfidence;
-	};
+	} BNVariableNameAndType;
 
-	struct BNStackVariableReference
+	typedef struct BNStackVariableReference
 	{
 		uint32_t sourceOperand;
 		uint8_t typeConfidence;
@@ -1604,61 +1605,61 @@ extern "C"
 		uint64_t varIdentifier;
 		int64_t referencedOffset;
 		size_t size;
-	};
+	} BNStackVariableReference;
 
-	struct BNIndirectBranchInfo
+	typedef struct BNIndirectBranchInfo
 	{
 		BNArchitecture* sourceArch;
 		uint64_t sourceAddr;
 		BNArchitecture* destArch;
 		uint64_t destAddr;
 		bool autoDefined;
-	};
+	} BNIndirectBranchInfo;
 
-	struct BNArchitectureAndAddress
+	typedef struct BNArchitectureAndAddress
 	{
 		BNArchitecture* arch;
 		uint64_t address;
-	};
+	} BNArchitectureAndAddress;
 
-	enum BNAnalysisState
+	typedef enum BNAnalysisState
 	{
 		IdleState,
 		DisassembleState,
 		AnalyzeState,
 		ExtendedAnalyzeState
-	};
+	} BNAnalysisState;
 
-	struct BNActiveAnalysisInfo
+	typedef struct BNActiveAnalysisInfo
 	{
 		BNFunction* func;
 		uint64_t analysisTime;
 		size_t updateCount;
 		size_t submitCount;
-	};
+	} BNActiveAnalysisInfo;
 
-	struct BNAnalysisInfo
+	typedef struct BNAnalysisInfo
 	{
 		BNAnalysisState state;
 		uint64_t analysisTime;
 		BNActiveAnalysisInfo* activeInfo;
 		size_t count;
-	};
+	} BNAnalysisInfo;
 
-	struct BNAnalysisProgress
+	typedef struct BNAnalysisProgress
 	{
 		BNAnalysisState state;
 		size_t count, total;
-	};
+	} BNAnalysisProgress;
 
-	enum BNAnalysisMode
+	typedef enum BNAnalysisMode
 	{
 		FullAnalysisMode,
 		BasicAnalysisMode,
 		ControlFlowAnalysisMode
-	};
+	} BNAnalysisMode;
 
-	struct BNAnalysisParameters
+	typedef struct BNAnalysisParameters
 	{
 		uint64_t maxAnalysisTime;
 		uint64_t maxFunctionSize;
@@ -1668,52 +1669,52 @@ extern "C"
 		bool suppressNewAutoFunctionAnalysis;
 		BNAnalysisMode mode;
 		bool alwaysAnalyzeIndirectBranches;
-	};
+	} BNAnalysisParameters;
 
-	struct BNDownloadInstanceOutputCallbacks
+	typedef struct BNDownloadInstanceOutputCallbacks
 	{
 		uint64_t (*writeCallback)(uint8_t* data, uint64_t len, void* ctxt);
 		void* writeContext;
 		bool (*progressCallback)(void* ctxt, uint64_t progress, uint64_t total);
 		void* progressContext;
-	};
+	} BNDownloadInstanceOutputCallbacks;
 
-	struct BNDownloadInstanceCallbacks
+	typedef struct BNDownloadInstanceCallbacks
 	{
 		void* context;
 		void (*destroyInstance)(void* ctxt);
 		int (*performRequest)(void* ctxt, const char* url);
-	};
+	} BNDownloadInstanceCallbacks;
 
-	struct BNDownloadProviderCallbacks
+	typedef struct BNDownloadProviderCallbacks
 	{
 		void* context;
 		BNDownloadInstance* (*createInstance)(void* ctxt);
-	};
+	} BNDownloadProviderCallbacks;
 
-	enum BNFindFlag
+	typedef enum BNFindFlag
 	{
 		FindCaseSensitive = 0,
 		FindCaseInsensitive = 1
-	};
+	} BNFindFlag;
 
-	enum BNScriptingProviderInputReadyState
+	typedef enum BNScriptingProviderInputReadyState
 	{
 		NotReadyForInput,
 		ReadyForScriptExecution,
 		ReadyForScriptProgramInput
-	};
+	} BNScriptingProviderInputReadyState;
 
-	enum BNScriptingProviderExecuteResult
+	typedef enum BNScriptingProviderExecuteResult
 	{
 		InvalidScriptInput,
 		IncompleteScriptInput,
 		SuccessfulScriptExecution,
 		ScriptExecutionCancelled
-	};
+	} BNScriptingProviderExecuteResult;
 
 
-	struct BNScriptingInstanceCallbacks
+	typedef struct BNScriptingInstanceCallbacks
 	{
 		void* context;
 		void (*destroyInstance)(void* ctxt);
@@ -1724,67 +1725,67 @@ extern "C"
 		void (*setCurrentBasicBlock)(void* ctxt, BNBasicBlock* block);
 		void (*setCurrentAddress)(void* ctxt, uint64_t addr);
 		void (*setCurrentSelection)(void* ctxt, uint64_t begin, uint64_t end);
-	};
+	} BNScriptingInstanceCallbacks;
 
-	struct BNScriptingProviderCallbacks
+	typedef struct BNScriptingProviderCallbacks
 	{
 		void* context;
 		BNScriptingInstance* (*createInstance)(void* ctxt);
 
-	};
+	} BNScriptingProviderCallbacks;
 
-	struct BNScriptingOutputListener
+	typedef struct BNScriptingOutputListener
 	{
 		void* context;
 		void (*output)(void* ctxt, const char* text);
 		void (*error)(void* ctxt, const char* text);
 		void (*inputReadyStateChanged)(void* ctxt, BNScriptingProviderInputReadyState state);
-	};
+	} BNScriptingOutputListener;
 
-	struct BNMainThreadCallbacks
+	typedef struct BNMainThreadCallbacks
 	{
 		void* context;
 		void (*addAction)(void* ctxt, BNMainThreadAction* action);
-	};
+	} BNMainThreadCallbacks;
 
-	struct BNConstantReference
+	typedef struct BNConstantReference
 	{
 		int64_t value;
 		size_t size;
 		bool pointer, intermediate;
-	};
+	} BNConstantReference;
 
-	struct BNMetadataValueStore
+	typedef struct BNMetadataValueStore
 	{
 		size_t size;
 		char** keys;
 		BNMetadata** values;
-	};
+	} BNMetadataValueStore;
 
-	enum BNMessageBoxIcon
+	typedef enum BNMessageBoxIcon
 	{
 		InformationIcon,
 		QuestionIcon,
 		WarningIcon,
 		ErrorIcon
-	};
+	} BNMessageBoxIcon;
 
-	enum BNMessageBoxButtonSet
+	typedef enum BNMessageBoxButtonSet
 	{
 		OKButtonSet,
 		YesNoButtonSet,
 		YesNoCancelButtonSet
-	};
+	} BNMessageBoxButtonSet;
 
-	enum BNMessageBoxButtonResult
+	typedef enum BNMessageBoxButtonResult
 	{
 		NoButton = 0,
 		YesButton = 1,
 		OKButton = 2,
 		CancelButton = 3
-	};
+	} BNMessageBoxButtonResult;
 
-	enum BNFormInputFieldType
+	typedef enum BNFormInputFieldType
 	{
 		LabelFormField,
 		SeparatorFormField,
@@ -1796,9 +1797,9 @@ extern "C"
 		OpenFileNameFormField,
 		SaveFileNameFormField,
 		DirectoryNameFormField
-	};
+	} BNFormInputFieldType;
 
-	struct BNFormInputField
+	typedef struct BNFormInputField
 	{
 		BNFormInputFieldType type;
 		const char* prompt;
@@ -1812,9 +1813,9 @@ extern "C"
 		uint64_t addressResult;
 		char* stringResult;
 		size_t indexResult;
-	};
+	} BNFormInputField;
 
-	struct BNInteractionHandlerCallbacks
+	typedef struct BNInteractionHandlerCallbacks
 	{
 		void* context;
 		void (*showPlainTextReport)(void* ctxt, BNBinaryView* view, const char* title, const char* contents);
@@ -1837,9 +1838,9 @@ extern "C"
 		bool (*getFormInput)(void* ctxt, BNFormInputField* fields, size_t count, const char* title);
 		BNMessageBoxButtonResult (*showMessageBox)(void* ctxt, const char* title, const char* text,
 			BNMessageBoxButtonSet buttons, BNMessageBoxIcon icon);
-	};
+	} BNInteractionHandlerCallbacks;
 
-	struct BNObjectDestructionCallbacks
+	typedef struct BNObjectDestructionCallbacks
 	{
 		void* context;
 		// The provided pointers have a reference count of zero. Do not add additional references, doing so
@@ -1848,9 +1849,9 @@ extern "C"
 		void (*destructBinaryView)(void* ctxt, BNBinaryView* view);
 		void (*destructFileMetadata)(void* ctxt, BNFileMetadata* file);
 		void (*destructFunction)(void* ctxt, BNFunction* func);
-	};
+	} BNObjectDestructionCallbacks;
 
-	struct BNCustomDataRenderer
+	typedef struct BNCustomDataRenderer
 	{
 		void* context;
 		void (*freeObject)(void* ctxt);
@@ -1859,9 +1860,9 @@ extern "C"
 		BNDisassemblyTextLine* (*getLinesForData)(void* ctxt, BNBinaryView* view, uint64_t addr, BNType* type,
 			const BNInstructionTextToken* prefix, size_t prefixCount, size_t width, size_t* count, BNType** typeCtx,
 			size_t ctxCount);
-	};
+	} BNCustomDataRenderer;
 
-	enum BNSegmentFlag
+	typedef enum BNSegmentFlag
 	{
 		SegmentExecutable = 1,
 		SegmentWritable = 2,
@@ -1870,56 +1871,56 @@ extern "C"
 		SegmentContainsCode = 0x10,
 		SegmentDenyWrite = 0x20,
 		SegmentDenyExecute = 0x40
-	};
+	} BNSegmentFlag;
 
-	enum BNSectionSemantics
+	typedef enum BNSectionSemantics
 	{
 		DefaultSectionSemantics,
 		ReadOnlyCodeSectionSemantics,
 		ReadOnlyDataSectionSemantics,
 		ReadWriteDataSectionSemantics,
 		ExternalSectionSemantics
-	};
+	} BNSectionSemantics;
 
-	struct BNAddressRange
+	typedef struct BNAddressRange
 	{
 		uint64_t start;
 		uint64_t end;
-	};
+	} BNAddressRange;
 
-	struct BNSystemCallInfo
+	typedef struct BNSystemCallInfo
 	{
 		uint32_t number;
 		BNQualifiedName name;
 		BNType* type;
-	};
+	} BNSystemCallInfo;
 
-	enum BNILBranchDependence
+	typedef enum BNILBranchDependence
 	{
 		NotBranchDependent,
 		TrueBranchDependent,
 		FalseBranchDependent
-	};
+	} BNILBranchDependence;
 
-	struct BNILBranchInstructionAndDependence
+	typedef struct BNILBranchInstructionAndDependence
 	{
 		size_t branch;
 		BNILBranchDependence dependence;
-	};
+	} BNILBranchInstructionAndDependence;
 
-	struct BNPerformanceInfo
+	typedef struct BNPerformanceInfo
 	{
 		char* name;
 		double seconds;
-	};
+	} BNPerformanceInfo;
 
-	struct BNMemoryUsageInfo
+	typedef struct BNMemoryUsageInfo
 	{
 		char* name;
 		uint64_t value;
-	};
+	} BNMemoryUsageInfo;
 
-	enum BNMetadataType
+	typedef enum BNMetadataType
 	{
 		InvalidDataType,
 		BooleanDataType,
@@ -1930,46 +1931,46 @@ extern "C"
 		RawDataType,
 		KeyValueDataType,
 		ArrayDataType
-	};
+	} BNMetadataType;
 
-	struct BNRegisterStackAdjustment
+	typedef struct BNRegisterStackAdjustment
 	{
 		uint32_t regStack;
 		int32_t adjustment;
 		uint8_t confidence;
-	};
+	} BNRegisterStackAdjustment;
 
-	enum BNFunctionAnalysisSkipOverride
+	typedef enum BNFunctionAnalysisSkipOverride
 	{
 		DefaultFunctionAnalysisSkip,
 		NeverSkipFunctionAnalysis,
 		AlwaysSkipFunctionAnalysis
-	};
+	} BNFunctionAnalysisSkipOverride;
 
-	enum BNReportType
+	typedef enum BNReportType
 	{
 		PlainTextReportType,
 		MarkdownReportType,
 		HTMLReportType,
 		FlowGraphReportType
-	};
+	} BNReportType;
 
-	struct BNCustomFlowGraph
+	typedef struct BNCustomFlowGraph
 	{
 		void* context;
 		void (*prepareForLayout)(void* ctxt);
 		void (*populateNodes)(void* ctxt);
 		void (*completeLayout)(void* ctxt);
 		BNFlowGraph* (*update)(void* ctxt);
-	};
+	} BNCustomFlowGraph;
 
-	struct BNRange
+	typedef struct BNRange
 	{
 		uint64_t start;
 		uint64_t end;
-	};
+	} BNRange;
 
-	enum BNAnalysisSkipReason
+	typedef enum BNAnalysisSkipReason
 	{
 		NoSkipReason,
 		AlwaysSkipReason,
@@ -1978,9 +1979,9 @@ extern "C"
 		ExceedFunctionUpdateCountSkipReason,
 		NewAutoFunctionAnalysisSuppressedReason,
 		BasicAnalysisSkipReason
-	};
+	} BNAnalysisSkipReason;
 
-	enum BNSettingsScope
+	typedef enum BNSettingsScope
 	{
 		SettingsInvalidScope = 0,
 		SettingsAutoScope = 1,
@@ -1988,7 +1989,7 @@ extern "C"
 		SettingsUserScope = 3,
 		SettingsWorkspaceScope = 4,
 		SettingsContextScope = 5
-	};
+	} BNSettingsScope;
 
 	BINARYNINJACOREAPI char* BNAllocString(const char* contents);
 	BINARYNINJACOREAPI void BNFreeString(char* str);


### PR DESCRIPTION
I changed all your struct and enum definitions in binaryninjacore.h to typedefs to make them valid C, which is essential for automatic binding generators (particularly, c2hs for haskell). 