### PR TITLE
StructuredDataView has lingering members

### DIFF
--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -5092,12 +5092,12 @@ class StructuredDataView(object):
 	_structure_name = None
 	_address = 0
 	_bv = None
-	_members = OrderedDict()
 
 	def __init__(self, bv, structure_name, address):
 		self._bv = bv
 		self._structure_name = structure_name
 		self._address = address
+		self._members = OrderedDict()
 
 		self._lookup_structure()
 		self._define_members()


### PR DESCRIPTION
`_members` in `StructureDataView` is a class level variable that is instantiated with an OrderedDict. When one tries to use `StructuredDataView` with a different type `_members` is never re-instantiated and the dictionary ends up with stale values. Moving `_members` to the `__init__`.

```python
>>> var_type, _ = bv.parse_type_string("""struct {
...     uint32_t *blah;
...     uint32_t *blah1;
...     uint32_t *blah2;
...     uint32_t *blah3;
... } Apple""")
>>> bv.define_user_type('Apple', var_type)
>>> x = StructuredDataView(bv, 'Apple', here)
>>> print(x)
struct Apple 0x140018b90 {
	    +0 uint32_t* blah                           = 0000000000000001              
	    +8 uint32_t* blah1                          = 0001f48800000000              
	   +10 uint32_t* blah2                          = 00018b9000018ee0              
	   +18 uint32_t* blah3                          = 0000000000000000              
}
>>> StructuredDataView._members
OrderedDict([('blah', <uint32_t* blah, offset 0x0>), ('blah1', <uint32_t* blah1, offset 0x8>), ('blah2', <uint32_t* blah2, offset 0x10>), ('blah3', <uint32_t* blah3, offset 0x18>)])
```