### PR TITLE
fix a type error when trying to create a function type with a parameter that has a location

### DIFF
--- a/python/types.py
+++ b/python/types.py
@@ -668,7 +668,7 @@ class Type(object):
 					param_buf[i].defaultLocation = True
 				else:
 					param_buf[i].defaultLocation = False
-					param_buf[i].location.type = params[i].location.type
+					param_buf[i].location.type = params[i].location.source_type
 					param_buf[i].location.index = params[i].location.index
 					param_buf[i].location.storage = params[i].location.storage
 			else:


### PR DESCRIPTION
to recreate:

```
for f in bv.functions:
	if '@' in ''.join(t.text for t in f.type_tokens):
		print(f)
		types.Type.function(f.return_type, f.function_type.parameters)
		break
```
output:
```
<func: aarch64@0xfffffff006123bb8>
Traceback (most recent call last):
  File "<console>", line 4, in <module>
  File "/Applications/Binary Ninja.app/Contents/MacOS/plugins/../../Resources/python/binaryninja/types.py", line 626, in function
    param_buf[i].location.type = params[i].location.type
TypeError: an integer is required (got type Type)
```
