### PR TITLE
Support all colors of the rainbow in export_svg.py

### DIFF
--- a/python/examples/export_svg.py
+++ b/python/examples/export_svg.py
@@ -179,10 +179,13 @@ def render_svg(function, origname):
         rgb = colors['none']
         try:
             bb = block.basic_block
-            color_code = bb.highlight.color
-            color_str = bb.highlight._standard_color_to_str(color_code)
-            if color_str in colors:
-                rgb = colors[color_str]
+            if hasattr(bb.highlight, 'color'):
+                color_code = bb.highlight.color
+                color_str = bb.highlight._standard_color_to_str(color_code)
+                if color_str in colors:
+                    rgb = colors[color_str]
+            else:
+                rgb = [bb.highlight.red, bb.highlight.green, bb.highlight.blue]
         except:
             pass
         output += '			<rect class="basicblock" x="{x}" y="{y}" fill-opacity="0.4" height="{height}" width="{width}" fill="rgb({r},{g},{b})"/>\n'.format(


### PR DESCRIPTION
Some scripts/plugins like bncov use block.set_user_highlight() with colors constructed by RGB value instead of default colors.  This addition allows export_svg.py to show these colors.