### PR TITLE
Add printf annotation for BNLog*

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -585,6 +585,9 @@ namespace BinaryNinja
 		\param fmt C-style format string.
 		\param ... Variable arguments corresponding to the format string.
 	 */
+#ifdef __GNUC__
+    __attribute__ ((format (printf, 2, 3)))
+#endif
 	void Log(BNLogLevel level, const char* fmt, ...);
 
 	/*! LogDebug only writes text to the error console if the console is set to log level: DebugLog
@@ -593,6 +596,9 @@ namespace BinaryNinja
 		\param fmt C-style format string.
 		\param ... Variable arguments corresponding to the format string.
 	 */
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
 	void LogDebug(const char* fmt, ...);
 
 	/*! LogInfo always writes text to the error console, and corresponds to the log level: InfoLog.
@@ -601,6 +607,9 @@ namespace BinaryNinja
 		\param fmt C-style format string.
 		\param ... Variable arguments corresponding to the format string.
 	 */
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
 	void LogInfo(const char* fmt, ...);
 
 	/*! LogWarn writes text to the error console including a warning icon,
@@ -609,6 +618,9 @@ namespace BinaryNinja
 		\param fmt C-style format string.
 		\param ... Variable arguments corresponding to the format string.
 	 */
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
 	void LogWarn(const char* fmt, ...);
 
 	/*! LogError writes text to the error console and pops up the error console. Additionall,
@@ -617,6 +629,9 @@ namespace BinaryNinja
 		\param fmt C-style format string.
 		\param ... Variable arguments corresponding to the format string.
 	 */
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
 	void LogError(const char* fmt, ...);
 
 	/*! LogAlert pops up a message box displaying the alert message and logs to the error console.
@@ -625,6 +640,9 @@ namespace BinaryNinja
 		\param fmt C-style format string.
 		\param ... Variable arguments corresponding to the format string.
 	 */
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
 	void LogAlert(const char* fmt, ...);
 
 	void LogToStdout(BNLogLevel minimumLevel);

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -2103,11 +2103,34 @@ extern "C"
 	BINARYNINJACOREAPI void BNAddOptionalPluginDependency(const char* name);
 
 	// Logging
+#ifdef __GNUC__
+__attribute__ ((format (printf, 2, 3)))
+#endif
 	BINARYNINJACOREAPI void BNLog(BNLogLevel level, const char* fmt, ...);
+
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
 	BINARYNINJACOREAPI void BNLogDebug(const char* fmt, ...);
+
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
 	BINARYNINJACOREAPI void BNLogInfo(const char* fmt, ...);
+
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
 	BINARYNINJACOREAPI void BNLogWarn(const char* fmt, ...);
+
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
 	BINARYNINJACOREAPI void BNLogError(const char* fmt, ...);
+
+#ifdef __GNUC__
+__attribute__ ((format (printf, 1, 2)))
+#endif
 	BINARYNINJACOREAPI void BNLogAlert(const char* fmt, ...);
 
 	BINARYNINJACOREAPI void BNRegisterLogListener(BNLogListener* listener);


### PR DESCRIPTION
Adds nice inference for IDEs, and emits compiler warnings when incorrect format strings are being used.