### PR TITLE
Add visibility to MediumLevelILInstructionAccessException

### DIFF
--- a/mediumlevelilinstruction.h
+++ b/mediumlevelilinstruction.h
@@ -179,7 +179,7 @@ namespace BinaryNinjaCore
 namespace BinaryNinja
 #endif
 {
-	class MediumLevelILInstructionAccessException: public std::exception
+	class __attribute__((visibility("default"))) MediumLevelILInstructionAccessException: public std::exception
 	{
 	public:
 		MediumLevelILInstructionAccessException(): std::exception() {}


### PR DESCRIPTION
This gets rid of the massive number of warnings that look like this when you compile anything that includes `mediumlevelilinstruction.h`:
```
ld: warning: direct access in function 'BinaryNinja::MediumLevelILInstruction::GetOutputSSAVariables() const' from file '/Users/user/Documents/Repos/binaryninja-api/bin/libbinaryninjaapi.a(mediumlevelilinstruction.cpp.o)' to global weak symbol 'typeinfo for BinaryNinja::MediumLevelILInstructionAccessException' from file 'analysis.cpp.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```