### PR TITLE
Fixed return type documentation for get_instruction_text()

### DIFF
--- a/python/architecture.py
+++ b/python/architecture.py
@@ -1455,15 +1455,15 @@ class Architecture(with_metaclass(_ArchitectureMetaClass, object)):
 
 	def get_instruction_text(self, data, addr):
 		"""
-		``get_instruction_text`` returns a list of InstructionTextToken objects for the instruction at the given virtual
-		address ``addr`` with data ``data``.
+		``get_instruction_text`` returns a tuple with the list of InstructionTextToken objects and the decoded \
+        instruction length for the instruction at the given virtual address ``addr`` with data ``data``.
 
 		.. note:: Architecture subclasses should implement this method.
 
 		:param str data: max_instruction_length bytes from the binary at virtual address ``addr``
 		:param int addr: virtual address of bytes in ``data``
-		:return: an InstructionTextToken list for the current instruction
-		:rtype: list(InstructionTextToken)
+		:return: a tuple of list(InstructionTextToken) and length of instruction decoded
+		:rtype: tuple(list(InstructionTextToken), int)
 		"""
 		return self.perform_get_instruction_text(data, addr)
 


### PR DESCRIPTION
```get_instruction_text()``` documentation does not match the most recent blog post, nor any of the example source code (like nes.py). Documentation states the return type is a ```list(InstructionTextToken``` but actually requires a ```tuple(list(InstructionTextToken), int)``` that includes the length of the decoded instruction.

Following the documentation and returning only a list resulted in the following error for me (using the z80 blog post, checkpoint 3 at https://binary.ninja/2020/01/08/guide-to-architecture-plugins-part1.html):

``` 
File binaryninja/architecture.py, line 545, in _get_instruction_text
    length[0] = info[1]
IndexError: list index out of range
```
