### PR TITLE
Enable use within a venv

### DIFF
--- a/scripts/install_api.py
+++ b/scripts/install_api.py
@@ -81,6 +81,8 @@ if ( len(sys.argv) > 1 and sys.argv[1].lower() == "root" ):
         print("Root install specified but cannot write to {}".format(install_path))
         sys.exit(1)
 elif os.environ.get('VIRTUAL_ENV'):
+    print("Virtual environment detected - installing API in virtual environment.\n\
+           Deactivate environment and re-run this script to perform normal installation.")
     install_path = getsitepackages()[0]
 else:
     if check_enableusersite():

--- a/scripts/install_api.py
+++ b/scripts/install_api.py
@@ -80,6 +80,8 @@ if ( len(sys.argv) > 1 and sys.argv[1].lower() == "root" ):
     if not os.access(install_path, os.W_OK):
         print("Root install specified but cannot write to {}".format(install_path))
         sys.exit(1)
+elif os.environ.get('VIRTUAL_ENV'):
+    install_path = getsitepackages()[0]
 else:
     if check_enableusersite():
         install_path = getusersitepackages()


### PR DESCRIPTION
Checks for existence of **VIRTUAL_ENV** environment variable, and if it exists, install API at first path from _getsitepackages()_, which should always be the venv's site-packages folder. NOTE: Assumes user will _always_ want to do this if script is run from a virtual environment. Tested on macOS 10.15.3 with Homebrew Python3, Windows 10 with python.org 64-bit Python 3.8, and Ubuntu 18.04 with _python3-venv_ package installed.