### PR TITLE
Fix str/bytes conversions for DataBuffers

### DIFF
--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -2652,13 +2652,9 @@ class BinaryView(object):
 			>>> bv.read(0,4)
 			'AAAA'
 		"""
-		if not isinstance(data, bytes):
-			if isinstance(data, str):
-				buf = databuffer.DataBuffer(data.encode())
-			else:
-				raise TypeError("Must be bytes or str")
-		else:
-			buf = databuffer.DataBuffer(data)
+		if isinstance(data, int) or isinstance(data, numbers.Integral):
+			raise TypeError("Data must be bytes-like or DataBuffer, not numeric")
+		buf = databuffer.DataBuffer(data)
 		return core.BNWriteViewBuffer(self.handle, addr, buf.handle)
 
 	def insert(self, addr, data):
@@ -2676,8 +2672,8 @@ class BinaryView(object):
 			>>> bv.read(0,8)
 			'BBBBAAAA'
 		"""
-		if not isinstance(data, bytes):
-			raise TypeError("Must be bytes")
+		if isinstance(data, int) or isinstance(data, numbers.Integral):
+			raise TypeError("Data must be bytes-like or DataBuffer, not numeric")
 		buf = databuffer.DataBuffer(data)
 		return core.BNInsertViewBuffer(self.handle, addr, buf.handle)
 
@@ -4994,7 +4990,9 @@ class BinaryView(object):
 			FindCaseInsensitive  Case-insensitive search
 			==================== ============================
 		"""
-		buf = databuffer.DataBuffer(str(data))
+		if isinstance(data, int) or isinstance(data, numbers.Integral):
+			raise TypeError("Data must be bytes-like or DataBuffer, not numeric")
+		buf = databuffer.DataBuffer(data)
 		result = ctypes.c_ulonglong()
 		if not core.BNFindNextData(self.handle, start, buf.handle, result, flags):
 			return None

--- a/python/databuffer.py
+++ b/python/databuffer.py
@@ -36,10 +36,12 @@ class DataBuffer(object):
 			self.handle = core.BNCreateDataBuffer(None, contents)
 		elif isinstance(contents, DataBuffer):
 			self.handle = core.BNDuplicateDataBuffer(contents.handle)
-		else:
+		elif isinstance(contents, str) or isinstance(contents, bytes):
 			if bytes != str and isinstance(contents, str):
 				contents = contents.encode('charmap')
 			self.handle = core.BNCreateDataBuffer(contents, len(contents))
+		else:
+			raise TypeError("DataBuffer contents must be bytes or str")
 
 	def __del__(self):
 		core.BNFreeDataBuffer(self.handle)


### PR DESCRIPTION
This makes it safe to pass a `bytes` into several functions like `bv.find_next_data`.