### PR TITLE
Changes to implement User-informed dataflow

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -2938,13 +2938,16 @@ __attribute__ ((format (printf, 1, 2)))
 		std::vector<BNValueRange> ranges;
 		std::set<int64_t> valueSet;
 		std::vector<LookupTableEntry> table;
+		size_t count;
 
 		static PossibleValueSet FromAPIObject(BNPossibleValueSet& value);
+		BNPossibleValueSet ToAPIObject();
 	};
 
 	class FlowGraph;
 	class MediumLevelILFunction;
 	class HighLevelILFunction;
+	struct SSAVariable;
 
 	class Function: public CoreRefCountObject<BNFunction, BNNewFunctionReference, BNFreeFunction>
 	{
@@ -3159,6 +3162,10 @@ __attribute__ ((format (printf, 1, 2)))
 		void SetAnalysisSkipOverride(BNFunctionAnalysisSkipOverride skip);
 
 		Ref<FlowGraph> GetUnresolvedStackAdjustmentGraph();
+
+		void SetVariableValue(const Variable& var, uint64_t defAddr, PossibleValueSet& value);
+		void ClearInformedVariableValue(const Variable& var, uint64_t defAddr);
+		void ClearInformedVariableValues();
 
 		void RequestDebugReport(const std::string& name);
 
@@ -3702,7 +3709,6 @@ __attribute__ ((format (printf, 1, 2)))
 	};
 
 	struct MediumLevelILInstruction;
-	struct SSAVariable;
 
 	class MediumLevelILFunction: public CoreRefCountObject<BNMediumLevelILFunction,
 		BNNewMediumLevelILFunctionReference, BNFreeMediumLevelILFunction>

--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -2909,6 +2909,24 @@ __attribute__ ((format (printf, 1, 2)))
 		Ref<Architecture> arch;
 		uint64_t address;
 
+		ArchAndAddr& operator=(const ArchAndAddr& a)
+		{
+		    arch = a.arch;
+		    address = a.address;
+		    return *this;
+		}
+		bool operator==(const ArchAndAddr& a) const
+		{
+		    return (arch == a.arch) && (address == a.address);
+		}
+		bool operator<(const ArchAndAddr& a) const
+		{
+		    if (arch < a.arch)
+			return true;
+		    if (arch > a.arch)
+			return false;
+		    return address < a.address;
+		}
 		ArchAndAddr(): arch(nullptr), address(0) {}
 		ArchAndAddr(Architecture* a, uint64_t addr): arch(a), address(addr) {}
 	};
@@ -3163,9 +3181,10 @@ __attribute__ ((format (printf, 1, 2)))
 
 		Ref<FlowGraph> GetUnresolvedStackAdjustmentGraph();
 
-		void SetVariableValue(const Variable& var, uint64_t defAddr, PossibleValueSet& value);
-		void ClearInformedVariableValue(const Variable& var, uint64_t defAddr);
-		void ClearInformedVariableValues();
+		void SetUserVariableValue(const Variable& var, uint64_t defAddr, PossibleValueSet& value);
+		void ClearUserVariableValue(const Variable& var, uint64_t defAddr);
+		std::map<Variable, std::map<ArchAndAddr, PossibleValueSet>> GetAllUserVariableValues();
+		void ClearAllUserVariableValues();
 
 		void RequestDebugReport(const std::string& name);
 

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -881,6 +881,7 @@ extern "C"
 		size_t count;
 	};
 
+
 	struct BNRegisterOrConstant
 	{
 		bool constant;
@@ -1864,6 +1865,13 @@ extern "C"
 	{
 		BNArchitecture* arch;
 		uint64_t address;
+	};
+
+	struct BNUserVariableValue
+	{
+		BNVariable var;
+		BNArchitectureAndAddress defSite;
+		BNPossibleValueSet value;
 	};
 
 	enum BNAnalysisState
@@ -3370,9 +3378,10 @@ __attribute__ ((format (printf, 1, 2)))
 
 	BINARYNINJACOREAPI BNFlowGraph* BNGetUnresolvedStackAdjustmentGraph(BNFunction* func);
 
-	BINARYNINJACOREAPI void BNSetVariableValue(BNFunction* func, const BNVariable* var, const BNArchitectureAndAddress* defSite, const BNPossibleValueSet* value);
-	BINARYNINJACOREAPI void BNClearInformedVariableValue(BNFunction* func, const BNVariable* var, const BNArchitectureAndAddress* defSite);
-	BINARYNINJACOREAPI void BNClearInformedVariableValues(BNFunction* func);
+	BINARYNINJACOREAPI void BNSetUserVariableValue(BNFunction* func, const BNVariable* var, const BNArchitectureAndAddress* defSite, const BNPossibleValueSet* value);
+	BINARYNINJACOREAPI void BNClearUserVariableValue(BNFunction* func, const BNVariable* var, const BNArchitectureAndAddress* defSite);
+	BINARYNINJACOREAPI BNUserVariableValue* BNGetAllUserVariableValues(BNFunction *func, size_t* count);
+	BINARYNINJACOREAPI void BNFreeUserVariableValues(BNUserVariableValue* result);
 
 	BINARYNINJACOREAPI void BNRequestFunctionDebugReport(BNFunction* func, const char* name);
 

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -257,6 +257,8 @@ extern "C"
 		StructureHexDumpTextToken = 27,
 		GotoLabelToken = 28,
 		CommentToken = 29,
+		PossibleValueToken = 30,
+		PossibleValueTypeToken = 31,
 		// The following are output by the analysis system automatically, these should
 		// not be used directly by the architecture plugins
 		CodeSymbolToken = 64,
@@ -3367,6 +3369,10 @@ __attribute__ ((format (printf, 1, 2)))
 	BINARYNINJACOREAPI void BNFreeAnalysisPerformanceInfo(BNPerformanceInfo* info, size_t count);
 
 	BINARYNINJACOREAPI BNFlowGraph* BNGetUnresolvedStackAdjustmentGraph(BNFunction* func);
+
+	BINARYNINJACOREAPI void BNSetVariableValue(BNFunction* func, const BNVariable* var, const BNArchitectureAndAddress* defSite, const BNPossibleValueSet* value);
+	BINARYNINJACOREAPI void BNClearInformedVariableValue(BNFunction* func, const BNVariable* var, const BNArchitectureAndAddress* defSite);
+	BINARYNINJACOREAPI void BNClearInformedVariableValues(BNFunction* func);
 
 	BINARYNINJACOREAPI void BNRequestFunctionDebugReport(BNFunction* func, const char* name);
 


### PR DESCRIPTION
This pull request adds the option for the user to inform variable values to BinaryNinja.

Example:
```python
>>> # MLIL variable for which the value is to be set
>>> v = current_mlil[17].operands[0]
>>> # Set Variable value to Constant, Signed/Unsigned Range Value, InSetOfValues, etc.
>>> # This will also trigger a reanalysis of the function and have the dataflow figure out 
>>> # values down the function from the definition site including folding branches whose values 
>>> # can now be determined statically
>>> current_function.set_user_var_value(v, 0x11d6, PossibleValueSet.constant(0))
>>> # Clear informed variable value
>>> current_function.clear_user_var_value(v, 0x11d6)
>>> # Get all user-informed variable values
>>> current_function.get_all_user_var_values()
>>> {<var uint64_t rax_5>: {archandaddr <x86_64 @ 0x11d6>: <const 0x0>}}
>>> # Clear all informed variable values
>>> current_function.clear_all_var_values()
```