### PR TITLE
Persistent setter for variable names.

### DIFF
--- a/python/function.py
+++ b/python/function.py
@@ -874,7 +874,14 @@ class Variable(object):
 
 	@name.setter
 	def name(self, value):
-		self._name = value
+		if self._function is None:
+			self._name = value
+		elif value is not None:
+			self._function.create_user_var(self, self._type, value)
+			self._name = value
+		else:
+			self._function.delete_user_var(self)
+			# TODO: Reset to default name!
 
 	@property
 	def type(self):

--- a/python/function.py
+++ b/python/function.py
@@ -876,12 +876,14 @@ class Variable(object):
 	def name(self, value):
 		if self._function is None:
 			self._name = value
-		elif value is not None:
+		elif value:
 			self._function.create_user_var(self, self._type, value)
 			self._name = value
 		else:
-			self._function.delete_user_var(self)
-			# TODO: Reset to default name!
+			self._function.create_user_var(self, self._type, "")
+			self._function.view.update_analysis_and_wait()
+			var = core.BNFromVariableIdentifier(self._identifier)
+			self._name = core.BNGetVariableName(self._function.handle, var)
 
 	@property
 	def type(self):

--- a/python/function.py
+++ b/python/function.py
@@ -881,7 +881,7 @@ class Variable(object):
 			self._name = value
 		else:
 			self._function.create_user_var(self, self._type, "")
-			self._function.view.update_analysis_and_wait()
+			self._function.reanalyze()
 			var = core.BNFromVariableIdentifier(self._identifier)
 			self._name = core.BNGetVariableName(self._function.handle, var)
 


### PR DESCRIPTION
This is a fix for https://github.com/Vector35/binaryninja-api/issues/1871.  Updates to variable names through the Python object's setter are now persisted into the binary as user vars, and setting the name to `None` or the empty string will restore the default name.