### PR TITLE
Revert the tag api change introduced in 430bf12

### DIFF
--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -3833,7 +3833,7 @@ class BinaryView(object):
 			tags = self.get_data_tags_at(addr)
 			for tag in tags:
 				if tag.type == type and tag.data == data:
-					return tag
+					return
 
 		tag = self.create_tag(type, data, False)
 		core.BNAddAutoDataTag(self.handle, addr, tag.handle)


### PR DESCRIPTION
Pull the tag change from 430bf12 into #2013 so it can be discussed there.

Currently the `dev` API is half-wrong or half-fixed (depending on your perspective)
