### PR TITLE
Update lowlevelil.py

### DIFF
--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -61,9 +61,18 @@ class ILRegister(object):
 		return self._name
 
 	def __eq__(self, other):
-		if not isinstance(other, self.__class__):
+		if isinstance(other, str) and other in self._arch.regs:
+			other = binaryninja.lowlevelil.ILRegister(
+				self._arch, self._arch.regs[other].index
+			)
+		elif not isinstance(other, self.__class__):
 			return NotImplemented
-		return (self._arch, self._index, self._name) == (other._arch, other._index, other._name)
+		return (self._arch, self._index, self._name) == (
+			other._arch,
+			other._index,
+			other._name,
+		)
+
 
 	def __ne__(self, other):
 		if not isinstance(other, self.__class__):

--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -75,7 +75,7 @@ class ILRegister(object):
 
 
 	def __ne__(self, other):
-		if not isinstance(other, self.__class__):
+		if not isinstance(other, (self.__class__, str)):
 			return NotImplemented
 		return not (self == other)
 


### PR DESCRIPTION
Add string handling to ILRegister comparison.

This is especially nice with the CallingConvention API. It returns a string for things like "int_return_reg". This allows comparison without sprinkling of str().