### PR TITLE
Set x64 max_instr_len to 15

### DIFF
--- a/python/architecture.py
+++ b/python/architecture.py
@@ -110,7 +110,7 @@ class Architecture(with_metaclass(_ArchitectureMetaClass, object)):
 	address_size = 8
 	default_int_size = 4
 	instr_alignment = 1
-	max_instr_length = 16
+	max_instr_length = 15
 	opcode_display_length = 8
 	regs = {}
 	stack_pointer = None


### PR DESCRIPTION
The maximum instruction length for x86-64 is defined to 15, not 16. 
While you can validly encode instructions longer than 15 bytes (infinitely actually), these are defined to be invalid by both Intel and AMD for all of their processors.