### PR TITLE
Fix rust plugin linking on Windows

### DIFF
--- a/rust/binaryninjacore-sys/build.rs
+++ b/rust/binaryninjacore-sys/build.rs
@@ -3,11 +3,11 @@ extern crate bindgen;
 use std::env;
 use std::path::PathBuf;
 
-#[cfg(feature = "headless")]
+#[cfg(any(windows, feature = "headless"))]
 use std::fs::File;
-#[cfg(feature = "headless")]
+#[cfg(any(windows, feature = "headless"))]
 use std::io::prelude::*;
-#[cfg(feature = "headless")]
+#[cfg(any(windows, feature = "headless"))]
 use std::io::BufReader;
 
 #[cfg(all(target_os = "macos", feature = "headless"))]
@@ -16,10 +16,10 @@ static LASTRUN_PATH: (&str, &str) = ("HOME", "Library/Application Support/Binary
 #[cfg(all(target_os = "linux", feature = "headless"))]
 static LASTRUN_PATH: (&str, &str) = ("HOME", ".binaryninja/lastrun");
 
-#[cfg(all(windows, feature = "headless"))]
+#[cfg(windows)]
 static LASTRUN_PATH: (&str, &str) = ("APPDATA", "Binary Ninja\\lastrun");
 
-#[cfg(feature = "headless")]
+#[cfg(any(windows, feature = "headless"))]
 fn link_path() -> PathBuf {
     let home = PathBuf::from(env::var(LASTRUN_PATH.0).unwrap());
     let lastrun = PathBuf::from(&home).join(LASTRUN_PATH.1);
@@ -52,7 +52,7 @@ fn main() {
     // otherwise search the usual install paths
     let out_dir = env::var("OUT_DIR").unwrap();
 
-    #[cfg(feature = "headless")]
+    #[cfg(any(windows, feature = "headless"))]
     let link_path = env::var("BINARYNINJADIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| link_path());
@@ -140,7 +140,7 @@ fn main() {
         println!("cargo:rustc-link-search={}", out_dir);
     }
 
-    #[cfg(feature = "headless")]
+    #[cfg(any(windows, feature = "headless"))]
     {
         println!("cargo:rustc-link-lib=binaryninjacore");
         println!("cargo:rustc-link-search={}", link_path.to_str().unwrap());

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -233,7 +233,7 @@ pub fn core_abi_minimum_version() -> u32 {
 }
 
 // Provide ABI version automatically so that the core can verify binary compatibility
-#[cfg(not(feature = "headless"))]
+#[cfg(any(windows, not(feature = "headless")))]
 #[no_mangle]
 #[allow(non_snake_case)]
 pub extern "C" fn CorePluginABIVersion() -> u32 { plugin_abi_version() }


### PR DESCRIPTION
Windows requires the symbols from the core to crate the plugin dll. As
these were gated behind the headless feature, these didn't exist, and
thus linking failed. Enabling the headless feature was also
insufficient, as headless features disabled CorePluginABIVersion
function.

This patch turns all the headless cfgs into headless or windows cfgs.