### PR TITLE
Fix docstring confusing some syntax highlighters

### DIFF
--- a/python/function.py
+++ b/python/function.py
@@ -1436,7 +1436,7 @@ class Function(object):
 
 	@property
 	def highest_address(self):
-		"The highest virtual address contained in a function."""
+		"""The highest virtual address contained in a function."""
 		return max(self, key=lambda block:block.end).end - 1
 
 	@property


### PR DESCRIPTION
This is technically correct (and for illustration):

```py
>>> "asdf"""
'asdf'
>>> "asdf""qwer"
'asdfqwer'
>>> def foo():
...   "asdf"""
...   return 4
...
>>> foo()
4
>>> foo.__doc__
'asdf'
```

But as it currently exists, it messes up some (admittedly, incorrect) lexers/syntax highlighters (e.g. emacs's python-mode).