### PR TITLE
Add View Type to BNIsBackedByDatabase

### DIFF
--- a/rust/src/filemetadata.rs
+++ b/rust/src/filemetadata.rs
@@ -109,8 +109,15 @@ impl FileMetadata {
         }
     }
 
-    pub fn is_database_backed(&self) -> bool {
-        unsafe { BNIsBackedByDatabase(self.handle) }
+    pub fn is_database_backed<S: BnStrCompatible>(&self, view_type: S) -> bool {
+        let view_type = view_type.as_bytes_with_nul();
+
+        unsafe { 
+            BNIsBackedByDatabase(
+                self.handle, 
+                view_type.as_ref().as_ptr() as *const _
+            ) 
+        }
     }
 
     pub fn begin_undo_actions(&self) {


### PR DESCRIPTION
The call to `BNIsBackedByDatabase` is missing the `binaryViewType` parameter.

This MR fixes that and enables the *dwarfdump* example to build.