### PR TITLE
Fix wrong CorePluginABIVersion, plugin_abi_version, and plugin_abi_minimum_version

### DIFF
--- a/rust/examples/flowgraph/src/lib.rs
+++ b/rust/examples/flowgraph/src/lib.rs
@@ -4,7 +4,6 @@ use binaryninja::{
     disassembly::{DisassemblyTextLine, InstructionTextToken, InstructionTextTokenType},
     flowgraph::{BranchType, EdgePenStyle, EdgeStyle, FlowGraph, FlowGraphNode, ThemeColor},
 };
-use binaryninja::plugin_abi_version;
 
 fn test_graph(view: &BinaryView) {
     let graph = FlowGraph::new();
@@ -48,9 +47,4 @@ pub extern "C" fn UIPluginInit() -> bool {
         test_graph,
     );
     true
-}
-
-#[no_mangle]
-pub extern "C" fn UIPluginABIVersion() -> u32 {
-    plugin_abi_version()
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -217,13 +217,23 @@ pub fn version() -> string::BnString {
     unsafe { string::BnString::from_raw(binaryninjacore_sys::BNGetVersionString()) }
 }
 
-// TODO : We need to get this from uitypes.h::BN_CURRENT_UI_ABI_VERSION
 pub fn plugin_abi_version() -> u32 {
+    binaryninjacore_sys::BN_CURRENT_CORE_ABI_VERSION
+}
+
+pub fn plugin_abi_minimum_version() -> u32 {
+    binaryninjacore_sys::BN_MINIMUM_CORE_ABI_VERSION
+}
+
+// TODO : We need to get this from uitypes.h::BN_CURRENT_UI_ABI_VERSION
+pub fn plugin_ui_abi_version() -> u32 {
+    //xxxx::BN_CURRENT_UI_ABI_VERSION
     2
 }
 
 // TODO : We need to get this from uitypes.h::BN_MINIMUM_UI_ABI_VERSION
-pub fn plugin_abi_minimum_version() -> u32 {
+pub fn plugin_ui_abi_minimum_version() -> u32 {
+    //xxxx::BN_MINIMUM_UI_ABI_VERSION
     2
 }
 
@@ -235,17 +245,22 @@ pub fn core_abi_minimum_version() -> u32 {
     unsafe { binaryninjacore_sys::BNGetMinimumCoreABIVersion() }
 }
 
+// TODO : We need to get this from uitypes.h::UIPluginABIVersion()
+pub fn ui_plugin_abi_version() -> u32 {
+    //unsafe { xxxx::UIPluginABIVersion() }
+    2
+}
+
 // Provide ABI version automatically so that the core can verify binary compatibility
 #[cfg(any(windows, not(feature = "headless")))]
 #[no_mangle]
 #[allow(non_snake_case)]
 pub extern "C" fn CorePluginABIVersion() -> u32 {
-    core_abi_version()
+    plugin_abi_version()
 }
 
-// TODO : We need to get this from uitypes.h
 #[cfg(any(windows, not(feature = "headless")))]
 #[no_mangle]
 pub extern "C" fn UIPluginABIVersion() -> u32 {
-    plugin_abi_version()
+    plugin_ui_abi_version()
 }

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -217,12 +217,14 @@ pub fn version() -> string::BnString {
     unsafe { string::BnString::from_raw(binaryninjacore_sys::BNGetVersionString()) }
 }
 
+// TODO : We need to get this from uitypes.h::BN_CURRENT_UI_ABI_VERSION
 pub fn plugin_abi_version() -> u32 {
-    binaryninjacore_sys::BN_CURRENT_CORE_ABI_VERSION
+    2
 }
 
+// TODO : We need to get this from uitypes.h::BN_MINIMUM_UI_ABI_VERSION
 pub fn plugin_abi_minimum_version() -> u32 {
-    binaryninjacore_sys::BN_MINIMUM_CORE_ABI_VERSION
+    2
 }
 
 pub fn core_abi_version() -> u32 {
@@ -238,7 +240,7 @@ pub fn core_abi_minimum_version() -> u32 {
 #[no_mangle]
 #[allow(non_snake_case)]
 pub extern "C" fn CorePluginABIVersion() -> u32 {
-    plugin_abi_version()
+    core_abi_version()
 }
 
 // TODO : We need to get this from uitypes.h


### PR DESCRIPTION
The current Rust lib incorrectly defines the functions needed to register ABI versions.

As I'm not familiar with rustgen I cannot provide the right fix to generate `uitypes.h` and retrieve the variables `BN_MINIMUM_UI_ABI_VERSION` and `BN_CURRENT_UI_ABI_VERSION`.

With this fix the included plugins build and run with the latest BinaryNinja dev release.