### PR TITLE
Fix Rust API linker error on macos

### DIFF
--- a/rust/binaryninjacore-sys/build.rs
+++ b/rust/binaryninjacore-sys/build.rs
@@ -3,14 +3,14 @@ extern crate bindgen;
 use std::env;
 use std::path::PathBuf;
 
-#[cfg(any(windows, feature = "headless"))]
+#[cfg(any(not(target_os = "linux"), feature = "headless"))]
 use std::fs::File;
-#[cfg(any(windows, feature = "headless"))]
+#[cfg(any(not(target_os = "linux"), feature = "headless"))]
 use std::io::prelude::*;
-#[cfg(any(windows, feature = "headless"))]
+#[cfg(any(not(target_os = "linux"), feature = "headless"))]
 use std::io::BufReader;
 
-#[cfg(all(target_os = "macos", feature = "headless"))]
+#[cfg(target_os = "macos")]
 static LASTRUN_PATH: (&str, &str) = ("HOME", "Library/Application Support/Binary Ninja/lastrun");
 
 #[cfg(all(target_os = "linux", feature = "headless"))]
@@ -19,7 +19,7 @@ static LASTRUN_PATH: (&str, &str) = ("HOME", ".binaryninja/lastrun");
 #[cfg(windows)]
 static LASTRUN_PATH: (&str, &str) = ("APPDATA", "Binary Ninja\\lastrun");
 
-#[cfg(any(windows, feature = "headless"))]
+#[cfg(any(not(target_os = "linux"), feature = "headless"))]
 fn link_path() -> PathBuf {
     let home = PathBuf::from(env::var(LASTRUN_PATH.0).unwrap());
     let lastrun = PathBuf::from(&home).join(LASTRUN_PATH.1);
@@ -55,7 +55,7 @@ fn main() {
     let llvm_version = env::var("LLVM_VERSION");
     let llvm_install_dir = env::var("LLVM_INSTALL_DIR");
 
-    #[cfg(any(windows, feature = "headless"))]
+    #[cfg(any(not(target_os = "linux"), feature = "headless"))]
     let link_path = env::var("BINARYNINJADIR")
         .map(PathBuf::from)
         .unwrap_or_else(|_| link_path());
@@ -143,7 +143,7 @@ fn main() {
         println!("cargo:rustc-link-search={}", out_dir);
     }
 
-    #[cfg(any(windows, feature = "headless"))]
+    #[cfg(any(not(target_os = "linux"), feature = "headless"))]
     {
         println!("cargo:rustc-link-lib=binaryninjacore");
         println!("cargo:rustc-link-search={}", link_path.to_str().unwrap());


### PR DESCRIPTION
Using the Rust API bindings on MacOS without the `headless` feature presents a linker error:

<details>
  <summary>Compiler Error</summary>


```
  = note: Undefined symbols for architecture x86_64:
            "_BNFreeString", referenced from:
                _$LT$binaryninja..string..BnString$u20$as$u20$core..ops..drop..Drop$GT$::drop::h956d5737ff910656 in libbinaryninja-05333812c2624595.rlib(binaryninja-05333812c2624595.1guocegd4gq1ucmc.rcgu.o)
            "_BNFreeSettings", referenced from:
                _$LT$binaryninja..settings..Settings$u20$as$u20$binaryninja..rc..RefCountable$GT$::dec_ref::hbab1d4008efb5fbf in libbinaryninja-05333812c2624595.rlib(binaryninja-05333812c2624595.4rhej9hrx7sf3v1.rcgu.o)
            "_BNGetBinaryViewTypeName", referenced from:
                binaryninja::custombinaryview::BinaryViewTypeExt::name::h8489131d3c1daab5 in binja_py27.56sytksi6yvp551w.rcgu.o
            "_BNLog", referenced from:
                _$LT$binaryninja..logger..Logger$u20$as$u20$log..Log$GT$::log::h43a9f5260aef5bfa in libbinaryninja-05333812c2624595.rlib(binaryninja-05333812c2624595.2xmf187mitarh8tv.rcgu.o)
            "_BNGetViewLength", referenced from:
                _$LT$binaryninja..binaryview..BinaryView$u20$as$u20$binaryninja..binaryview..BinaryViewBase$GT$::len::hc3355578d309c5da in libbinaryninja-05333812c2624595.rlib(binaryninja-05333812c2624595.54frhn0126pibsgz.rcgu.o)
            "_BNReadViewData", referenced from:
                _$LT$binaryninja..binaryview..BinaryView$u20$as$u20$binaryninja..binaryview..BinaryViewBase$GT$::read::h83333d9a497a5e3d in libbinaryninja-05333812c2624595.rlib(binaryninja-05333812c2624595.54frhn0126pibsgz.rcgu.o)
            "_BNRegisterBinaryViewType", referenced from:
                binaryninja::custombinaryview::register_view_type::h36ec37084e75bf2f in binja_py27.mfltcfbiricszjh.rcgu.o
            "_BNGetBinaryViewDefaultLoadSettingsForData", referenced from:
                binaryninja::custombinaryview::BinaryViewTypeBase::load_settings_for_data::he71c90614150a5bc in binja_py27.56sytksi6yvp551w.rcgu.o
            "_BNLowLevelILAddExpr", referenced from:
                binaryninja::llil::lifting::_$LT$impl$u20$binaryninja..llil..function..Function$LT$A$C$binaryninja..llil..function..Mutable$C$binaryninja..llil..function..NonSSA$LT$binaryninja..llil..function..LiftedNonSSA$GT$$GT$$GT$::unimplemented::h395780dc3591cb01 in binja_py27.4jes7w59d57x83z8.rcgu.o
            "_BNFreeBinaryView", referenced from:
                _$LT$binaryninja..binaryview..BinaryView$u20$as$u20$binaryninja..rc..RefCountable$GT$::dec_ref::h4009d5e987b3e8c2 in libbinaryninja-05333812c2624595.rlib(binaryninja-05333812c2624595.54frhn0126pibsgz.rcgu.o)
            "_BNAllocString", referenced from:
                binaryninja::string::BnString::new::h01b4ccddf31aa458 in libbinaryninja-05333812c2624595.rlib(binaryninja-05333812c2624595.3k5j4bxoowop45h9.rcgu.o)
            "_BNLowLevelILAddInstruction", referenced from:
                binaryninja::llil::lifting::_$LT$impl$u20$binaryninja..llil..function..Function$LT$A$C$binaryninja..llil..function..Mutable$C$binaryninja..llil..function..NonSSA$LT$binaryninja..llil..function..LiftedNonSSA$GT$$GT$$GT$::instruction::h28f1878f320abea1 in binja_py27.4jes7w59d57x83z8.rcgu.o
            "_BNSetArchitectureDefaultCallingConvention", referenced from:
                binaryninja::architecture::ArchitectureExt::set_default_calling_convention::h455c235a405a4351 in binja_py27.56sytksi6yvp551w.rcgu.o
            "_BNGetDefaultArchitectureFlagWriteLowLevelIL", referenced from:
                binaryninja::architecture::register_architecture::cb_flag_write_llil::hcd749ca7f259800a in binja_py27.3175ivvqqxcgp66j.rcgu.o
            "_BNFreeCallingConvention", referenced from:
                _$LT$binaryninja..callingconvention..CallingConvention$LT$A$GT$$u20$as$u20$binaryninja..rc..RefCountable$GT$::dec_ref::hec12d61272c80ab9 in binja_py27.2p6arslybnmgp7aa.rcgu.o
            "_BNGetDefaultIncomingVariableForParameterVariable", referenced from:
                binaryninja::callingconvention::register_calling_convention::cb_incoming_var_for_param::_$u7b$$u7b$closure$u7d$$u7d$::h2145f54cbc93d19b in binja_py27.2p6arslybnmgp7aa.rcgu.o
            "_BNCreateCallingConvention", referenced from:
                binaryninja::callingconvention::register_calling_convention::h782378ddd1fe2ffe in binja_py27.2p6arslybnmgp7aa.rcgu.o
            "_BNGetDefaultParameterVariableForIncomingVariable", referenced from:
                binaryninja::callingconvention::register_calling_convention::cb_incoming_param_for_var::_$u7b$$u7b$closure$u7d$$u7d$::h63a6db1acccc25f8 in binja_py27.2p6arslybnmgp7aa.rcgu.o
            "_BNRegisterCallingConvention", referenced from:
                binaryninja::callingconvention::register_calling_convention::h782378ddd1fe2ffe in binja_py27.2p6arslybnmgp7aa.rcgu.o
            "_BNGetStartOffset", referenced from:
                _$LT$binaryninja..binaryview..BinaryView$u20$as$u20$binaryninja..binaryview..BinaryViewBase$GT$::start::h1e74ef211eb6ae1d in libbinaryninja-05333812c2624595.rlib(binaryninja-05333812c2624595.54frhn0126pibsgz.rcgu.o)
            "_BNCreateCustomBinaryView", referenced from:
                binaryninja::custombinaryview::CustomViewBuilder$LT$T$GT$::create::h8e80fb006dd2e804 in binja_py27.mfltcfbiricszjh.rcgu.o
            "_BNRegisterArchitecture", referenced from:
                binaryninja::architecture::register_architecture::h4356f4ed4332de87 in binja_py27.3175ivvqqxcgp66j.rcgu.o
            "_BNFreeFileMetadata", referenced from:
                _$LT$binaryninja..filemetadata..FileMetadata$u20$as$u20$binaryninja..rc..RefCountable$GT$::dec_ref::h49fa1e1829ad9311 in libbinaryninja-05333812c2624595.rlib(binaryninja-05333812c2624595.28clviu09caq44s8.rcgu.o)
            "_BNGetFileViewOfType", referenced from:
                binaryninja::filemetadata::FileMetadata::get_view_of_type::haebcfc679fda8f45 in binja_py27.19irqx07ddgf1zcg.rcgu.o
            "_BNGetFileForView", referenced from:
                binaryninja::binaryview::BinaryViewExt::metadata::h33dea1f33b1ecbc9 in binja_py27.145u23oxcy8zbukc.rcgu.o
          ld: symbol(s) not found for architecture x86_64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

</details>

Examining the linker command line I don't see libbinaryninjacore anywhere, or liblinkhack. I'm not sure if this is the intended behavior for Linux, but MacOS certainly needs this path to be set to successfully link.