### PR TITLE
type ref change notification

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -955,6 +955,7 @@ __attribute__ ((format (printf, 1, 2)))
 		static void StringRemovedCallback(void* ctxt, BNBinaryView* data, BNStringType type, uint64_t offset, size_t len);
 		static void TypeDefinedCallback(void* ctxt, BNBinaryView* data, BNQualifiedName* name, BNType* type);
 		static void TypeUndefinedCallback(void* ctxt, BNBinaryView* data, BNQualifiedName* name, BNType* type);
+		static void TypeReferenceChangedCallback(void* ctx, BNBinaryView* data, BNQualifiedName* name, BNType* type);
 
 	public:
 		BinaryDataNotification();
@@ -984,6 +985,8 @@ __attribute__ ((format (printf, 1, 2)))
 		virtual void OnStringRemoved(BinaryView* data, BNStringType type, uint64_t offset, size_t len) { (void)data; (void)type; (void)offset; (void)len; }
 		virtual void OnTypeDefined(BinaryView* data, const QualifiedName& name, Type* type) { (void)data; (void)name; (void)type; }
 		virtual void OnTypeUndefined(BinaryView* data, const QualifiedName& name, Type* type) { (void)data; (void)name; (void)type; }
+		virtual void OnTypeReferenceChanged(BinaryView* data, const QualifiedName&name, Type* type) { (void)data;
+			(void)name; (void)type; }
 	};
 
 	class FileAccessor

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -1313,6 +1313,7 @@ extern "C"
 		void (*stringRemoved)(void* ctxt, BNBinaryView* view, BNStringType type, uint64_t offset, size_t len);
 		void (*typeDefined)(void* ctxt, BNBinaryView* view, BNQualifiedName* name, BNType* type);
 		void (*typeUndefined)(void* ctxt, BNBinaryView* view, BNQualifiedName* name, BNType* type);
+		void (*typeReferenceChanged)(void* ctxt, BNBinaryView* view, BNQualifiedName* name, BNType* type);
 	};
 
 	struct BNFileAccessor

--- a/binaryview.cpp
+++ b/binaryview.cpp
@@ -216,6 +216,15 @@ void BinaryDataNotification::TypeUndefinedCallback(void* ctxt, BNBinaryView* dat
 }
 
 
+void BinaryDataNotification::TypeReferenceChangedCallback(void* ctxt, BNBinaryView* data, BNQualifiedName* name, BNType* type)
+{
+	BinaryDataNotification* notify = (BinaryDataNotification*)ctxt;
+	Ref<BinaryView> view = new BinaryView(BNNewViewReference(data));
+	Ref<Type> typeObj = new Type(BNNewTypeReference(type));
+	notify->OnTypeReferenceChanged(view, QualifiedName::FromAPIObject(name), typeObj);
+}
+
+
 BinaryDataNotification::BinaryDataNotification()
 {
 	m_callbacks.context = this;
@@ -241,6 +250,7 @@ BinaryDataNotification::BinaryDataNotification()
 	m_callbacks.stringRemoved = StringRemovedCallback;
 	m_callbacks.typeDefined = TypeDefinedCallback;
 	m_callbacks.typeUndefined = TypeUndefinedCallback;
+	m_callbacks.typeReferenceChanged = TypeReferenceChangedCallback;
 }
 
 

--- a/ui/typeview.h
+++ b/ui/typeview.h
@@ -192,6 +192,10 @@ public:
 		BinaryNinja::Type* type) override;
 	virtual void OnTypeReferenceChanged(BinaryNinja::BinaryView* view, const BinaryNinja::QualifiedName& name,
 		BinaryNinja::Type* type) override;
+	virtual void OnDataVariableAdded(BinaryNinja::BinaryView*, const BinaryNinja::DataVariable&);
+	virtual void OnDataVariableRemoved(BinaryNinja::BinaryView*, const BinaryNinja::DataVariable&);
+	virtual void OnDataVariableUpdated(BinaryNinja::BinaryView*, const BinaryNinja::DataVariable&);
+	virtual void OnDataMetadataUpdated(BinaryNinja::BinaryView*, const BinaryNinja::DataVariable&);
 
 	void MarkUpdatesRequired() { m_updatesRequired = true; }
 	virtual void updateFonts() override;

--- a/ui/typeview.h
+++ b/ui/typeview.h
@@ -190,6 +190,8 @@ public:
 		BinaryNinja::Type* type) override;
 	virtual void OnTypeUndefined(BinaryNinja::BinaryView* view, const BinaryNinja::QualifiedName& name,
 		BinaryNinja::Type* type) override;
+	virtual void OnTypeReferenceChanged(BinaryNinja::BinaryView* view, const BinaryNinja::QualifiedName& name,
+		BinaryNinja::Type* type) override;
 
 	void MarkUpdatesRequired() { m_updatesRequired = true; }
 	virtual void updateFonts() override;


### PR DESCRIPTION
This PR sends a notification after references to a type has changed, e.g., added or removed. TypeView consumes this notification and updates the display when notified