### PR TITLE
Fix order of arguments to `RegisterInfo` constructor

### DIFF
--- a/python/architecture.py
+++ b/python/architecture.py
@@ -2011,7 +2011,7 @@ class CoreArchitecture(Architecture):
 			assert name is not None, ""
 			info = core.BNGetArchitectureRegisterInfo(self.handle, regs[i])
 			full_width_reg = RegisterName(core.BNGetArchitectureRegisterName(self.handle, info.fullWidthRegister))
-			self.regs[name] = RegisterInfo(full_width_reg, info.size, info.offset,
+			self.regs[name] = RegisterInfo(full_width_reg, info.offset, info.size,
 				ImplicitRegisterExtend(info.extend), regs[i])
 			self._all_regs[name] = regs[i]
 			self._regs_by_index[regs[i]] = name


### PR DESCRIPTION
In [this commit](https://github.com/Vector35/binaryninja-api/commit/920da93a153ff0e6cff405c76f6d5175a9cbcfa4), `RegisterInfo` got converted to a data class. This changed the order of arguments in `__init__` because the previous constructor had the fields in a different order to the way that they're listed in the class.