### PR TITLE
Avoid using `isinstance` on objects returned by `NewType`

### DIFF
--- a/python/architecture.py
+++ b/python/architecture.py
@@ -1440,7 +1440,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 				log_error(traceback.format_exc())
 		elif isinstance(reg, lowlevelil.ILRegister):
 			return reg.index
-		elif isinstance(reg, RegisterIndex):
+		elif isinstance(reg, int):
 			return reg
 		raise Exception("Attempting to get register index of non-existant register")
 
@@ -1451,7 +1451,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 				return reg_stack_info.index
 		elif isinstance(reg_stack, lowlevelil.ILRegisterStack):
 			return reg_stack.index
-		elif isinstance(reg_stack, RegisterStackIndex):
+		elif isinstance(reg_stack, int):
 			return reg_stack
 		raise Exception("reg_stack is not convertable to index")
 
@@ -1460,16 +1460,16 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			return self._flags[flag]
 		elif isinstance(flag, lowlevelil.ILFlag):
 			return flag.index
-		elif isinstance(flag, FlagIndex):
+		elif isinstance(flag, int):
 			return flag
 		raise Exception("flag is not convertable to index")
 
 	def get_semantic_flag_class_index(self, sem_class:SemanticClassType) -> SemanticClassIndex:
-		if isinstance(sem_class, SemanticClassName):
+		if isinstance(sem_class, str):
 			return self._semantic_flag_classes[sem_class]
 		elif isinstance(sem_class, lowlevelil.ILSemanticFlagClass):
 			return sem_class.index
-		elif isinstance(sem_class, SemanticClassIndex):
+		elif isinstance(sem_class, int):
 			return sem_class
 		raise Exception("sem_class is not convertable to index")
 
@@ -1528,11 +1528,11 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 		:return: the corresponding intrinsic string
 		:rtype: IntrinsicIndex
 		"""
-		if isinstance(intrinsic, IntrinsicName):
+		if isinstance(intrinsic, str):
 			return self._intrinsics[intrinsic]
 		elif isinstance(intrinsic, lowlevelil.ILIntrinsic):
 			return intrinsic.index
-		elif isinstance(intrinsic, IntrinsicIndex):
+		elif isinstance(intrinsic, int):
 			return intrinsic
 		raise Exception("intrinsic is not convertable to index")
 
@@ -1629,7 +1629,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 		operand_list = (core.BNRegisterOrConstant * len(operands))()
 		for i in range(len(operands)):
 			operand = operands[i]
-			if isinstance(operand, RegisterName):
+			if isinstance(operand, str):
 				operand_list[i].constant = False
 				operand_list[i].reg = self.regs[operand].index
 			elif isinstance(operand, lowlevelil.ILRegister):
@@ -2327,7 +2327,7 @@ class CoreArchitecture(Architecture):
 		operand_list = (core.BNRegisterOrConstant * len(operands))()
 		for i in range(len(operands)):
 			operand = operands[i]
-			if isinstance(operand, RegisterName):
+			if isinstance(operand, str):
 				operand_list[i].constant = False
 				operand_list[i].reg = self.regs[operand].index
 			elif isinstance(operand, lowlevelil.ILRegister):

--- a/python/architecture.py
+++ b/python/architecture.py
@@ -1441,7 +1441,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 		elif isinstance(reg, lowlevelil.ILRegister):
 			return reg.index
 		elif isinstance(reg, int):
-			return reg
+			return RegisterIndex(reg)
 		raise Exception("Attempting to get register index of non-existant register")
 
 	def get_reg_stack_index(self, reg_stack:RegisterStackType) -> RegisterStackIndex:
@@ -1452,7 +1452,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 		elif isinstance(reg_stack, lowlevelil.ILRegisterStack):
 			return reg_stack.index
 		elif isinstance(reg_stack, int):
-			return reg_stack
+			return RegisterStackIndex(reg_stack)
 		raise Exception("reg_stack is not convertable to index")
 
 	def get_flag_index(self, flag:FlagType) -> FlagIndex:
@@ -1461,16 +1461,16 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 		elif isinstance(flag, lowlevelil.ILFlag):
 			return flag.index
 		elif isinstance(flag, int):
-			return flag
+			return FlagIndex(flag)
 		raise Exception("flag is not convertable to index")
 
 	def get_semantic_flag_class_index(self, sem_class:SemanticClassType) -> SemanticClassIndex:
 		if isinstance(sem_class, str):
-			return self._semantic_flag_classes[sem_class]
+			return self._semantic_flag_classes[SemanticClassName(sem_class)]
 		elif isinstance(sem_class, lowlevelil.ILSemanticFlagClass):
 			return sem_class.index
 		elif isinstance(sem_class, int):
-			return sem_class
+			return SemanticClassIndex(sem_class)
 		raise Exception("sem_class is not convertable to index")
 
 	def get_semantic_flag_class_name(self, class_index:SemanticClassIndex) -> SemanticClassName:
@@ -1529,11 +1529,11 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 		:rtype: IntrinsicIndex
 		"""
 		if isinstance(intrinsic, str):
-			return self._intrinsics[intrinsic]
+			return self._intrinsics[IntrinsicName(intrinsic)]
 		elif isinstance(intrinsic, lowlevelil.ILIntrinsic):
 			return intrinsic.index
 		elif isinstance(intrinsic, int):
-			return intrinsic
+			return IntrinsicIndex(intrinsic)
 		raise Exception("intrinsic is not convertable to index")
 
 	def get_flag_write_type_name(self, write_type:FlagWriteTypeIndex) -> FlagWriteTypeName:
@@ -1631,7 +1631,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			operand = operands[i]
 			if isinstance(operand, str):
 				operand_list[i].constant = False
-				operand_list[i].reg = self.regs[operand].index
+				operand_list[i].reg = self.regs[RegisterName(operand)].index
 			elif isinstance(operand, lowlevelil.ILRegister):
 				operand_list[i].constant = False
 				operand_list[i].reg = operand.index
@@ -2329,7 +2329,7 @@ class CoreArchitecture(Architecture):
 			operand = operands[i]
 			if isinstance(operand, str):
 				operand_list[i].constant = False
-				operand_list[i].reg = self.regs[operand].index
+				operand_list[i].reg = self.regs[RegisterName(operand)].index
 			elif isinstance(operand, lowlevelil.ILRegister):
 				operand_list[i].constant = False
 				operand_list[i].reg = operand.index

--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -98,7 +98,7 @@ class ILRegister:
 
 	def __eq__(self, other):
 		if isinstance(other, str) and other in self.arch.regs:
-			index = self.arch.regs[other].index
+			index = self.arch.regs[architecture.RegisterName(other)].index
 			assert index is not None
 			other = ILRegister(self.arch, index)
 		elif not isinstance(other, self.__class__):
@@ -3046,7 +3046,7 @@ class LowLevelILFunction:
 		elif isinstance(operation, LowLevelILOperation):
 			operation = operation.value
 		if isinstance(flags, str):
-			_flags = self.arch.get_flag_write_type_by_name(flags)
+			_flags = self.arch.get_flag_write_type_by_name(architecture.FlagWriteTypeName(flags))
 		elif isinstance(flags, ILFlag):
 			_flags = flags.index
 		elif flags is None:
@@ -3068,12 +3068,12 @@ class LowLevelILFunction:
 		if isinstance(original, LowLevelILInstruction):
 			original = original.expr_index
 		elif isinstance(original, int):
-			original = original
+			original = ExpressionIndex(original)
 
 		if isinstance(new, LowLevelILInstruction):
 			new = new.expr_index
 		elif isinstance(new, int):
-			new = new
+			new = ExpressionIndex(new)
 
 		core.BNReplaceLowLevelILExpr(self.handle, original, new)
 
@@ -3869,7 +3869,7 @@ class LowLevelILFunction:
 		if sem_class is not None:
 			class_index = self.arch.get_semantic_flag_class_index(sem_class)
 			assert isinstance(class_index, int)
-		return self.expr(LowLevelILOperation.LLIL_FLAG_COND, cond, class_index)
+		return self.expr(LowLevelILOperation.LLIL_FLAG_COND, cond, architecture.SemanticClassIndex(class_index))
 
 	def flag_group(self, sem_group) -> ExpressionIndex:
 		"""
@@ -4431,7 +4431,7 @@ class LowLevelILFunction:
 		for i in range(len(operands)):
 			op = operands[i]
 			if isinstance(op, int):
-				operand_list[i] = op
+				operand_list[i] = ExpressionIndex(op)
 			else:
 				raise Exception("Invalid operand type")
 		return ExpressionIndex(core.BNLowLevelILAddOperandList(self.handle, operand_list, len(operands)))

--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -97,7 +97,7 @@ class ILRegister:
 		return self.index
 
 	def __eq__(self, other):
-		if isinstance(other, architecture.RegisterName) and other in self.arch.regs:
+		if isinstance(other, str) and other in self.arch.regs:
 			index = self.arch.regs[other].index
 			assert index is not None
 			other = ILRegister(self.arch, index)
@@ -3045,7 +3045,7 @@ class LowLevelILFunction:
 			operation = LowLevelILOperation[operation]
 		elif isinstance(operation, LowLevelILOperation):
 			operation = operation.value
-		if isinstance(flags, architecture.FlagWriteTypeName):
+		if isinstance(flags, str):
 			_flags = self.arch.get_flag_write_type_by_name(flags)
 		elif isinstance(flags, ILFlag):
 			_flags = flags.index
@@ -3067,12 +3067,12 @@ class LowLevelILFunction:
 		"""
 		if isinstance(original, LowLevelILInstruction):
 			original = original.expr_index
-		elif isinstance(original, ExpressionIndex):
+		elif isinstance(original, int):
 			original = original
 
 		if isinstance(new, LowLevelILInstruction):
 			new = new.expr_index
-		elif isinstance(new, ExpressionIndex):
+		elif isinstance(new, int):
 			new = new
 
 		core.BNReplaceLowLevelILExpr(self.handle, original, new)
@@ -3868,7 +3868,7 @@ class LowLevelILFunction:
 		class_index = architecture.SemanticClassIndex(0)
 		if sem_class is not None:
 			class_index = self.arch.get_semantic_flag_class_index(sem_class)
-			assert isinstance(class_index, architecture.SemanticClassIndex)
+			assert isinstance(class_index, int)
 		return self.expr(LowLevelILOperation.LLIL_FLAG_COND, cond, class_index)
 
 	def flag_group(self, sem_group) -> ExpressionIndex:
@@ -4430,9 +4430,7 @@ class LowLevelILFunction:
 		operand_list = (ctypes.c_ulonglong * len(operands))()
 		for i in range(len(operands)):
 			op = operands[i]
-			if isinstance(op, ExpressionIndex):
-				operand_list[i] = op
-			elif isinstance(op, int):
+			if isinstance(op, int):
 				operand_list[i] = op
 			else:
 				raise Exception("Invalid operand type")


### PR DESCRIPTION
I've been seeing some errors on these checks: `TypeError: isinstance() arg 2 must be a type or tuple of types`.

According to the docs [here](https://mypy.readthedocs.io/en/stable/more_types.html), this isn't supported:

> You cannot use isinstance() or issubclass() on the object returned by NewType(), because function objects don’t support these operations. You cannot create subclasses of these objects either.

I've edited these lines to use the underlying type. The other thing you could do is something like [this](https://github.com/python/mypy/issues/3325#issuecomment-299546004). Happy to do it like that if that's preferable.