### PR TITLE
Return a `SemanticClassIndex` of zero for a `None` argument

### DIFF
--- a/python/architecture.py
+++ b/python/architecture.py
@@ -1465,7 +1465,9 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			return flag
 		raise Exception("flag is not convertable to index")
 
-	def get_semantic_flag_class_index(self, sem_class:SemanticClassType) -> SemanticClassIndex:
+	def get_semantic_flag_class_index(self, sem_class:Optional[SemanticClassType]) -> SemanticClassIndex:
+		if sem_class is None:
+			return 0
 		if isinstance(sem_class, SemanticClassName):
 			return self._semantic_flag_classes[sem_class]
 		elif isinstance(sem_class, lowlevelil.ILSemanticFlagClass):
@@ -1660,9 +1662,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 		:param LowLevelILFunction il:
 		:rtype: ExpressionIndex
 		"""
-		_class_index = None
-		if sem_class is not None:
-			_class_index = self.get_semantic_flag_class_index(sem_class)
+		_class_index = self.get_semantic_flag_class_index(sem_class)
 		return lowlevelil.ExpressionIndex(core.BNGetDefaultArchitectureFlagConditionLowLevelIL(self.handle, cond,
 			_class_index, il.handle))
 
@@ -2599,16 +2599,12 @@ class CoreArchitecture(Architecture):
 		:rtype: FlagRole
 		"""
 		flag = self.get_flag_index(flag)
-		_sem_class = None
-		if sem_class is not None:
-			_sem_class = self.get_semantic_flag_class_index(sem_class)
+		_sem_class = self.get_semantic_flag_class_index(sem_class)
 		return FlagRole(core.BNGetArchitectureFlagRole(self.handle, flag, _sem_class))
 
 	def get_flags_required_for_flag_condition(self, cond:LowLevelILFlagCondition,
 		sem_class:Optional[SemanticClassType]=None) -> List[FlagName]:
-		_sem_class = None
-		if sem_class is not None:
-			_sem_class = self.get_semantic_flag_class_index(sem_class)
+		_sem_class = self.get_semantic_flag_class_index(sem_class)
 		count = ctypes.c_ulonglong()
 		flags = core.BNGetArchitectureFlagsRequiredForFlagCondition(self.handle, cond, _sem_class, count)
 		assert flags is not None, "core.BNGetArchitectureFlagsRequiredForFlagCondition returned None"


### PR DESCRIPTION
There are a few spots where we're leaving the index as `None` and then proceeding to pass it to a C function, resulting in a type error since you can't pass `None` to a function taking `ctype.u_int`. This error also seems to be causing Binja itself crash somehow.

Prior to [this change](https://github.com/Vector35/binaryninja-api/commit/61b4bb24e06aa955484293d35fa926c07887544b), the API was using 0 for when the the class type argument was `None` so I assume that's what we want.