### PR TITLE
Fix handling of `FlagIndex` in `LowLevelILFunction.expr`

### DIFF
--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -3049,6 +3049,8 @@ class LowLevelILFunction:
 			_flags = self.arch.get_flag_write_type_by_name(architecture.FlagWriteTypeName(flags))
 		elif isinstance(flags, ILFlag):
 			_flags = flags.index
+		elif isinstance(flags, architecture.FlagIndex):
+			_flags = flags
 		elif flags is None:
 			_flags = architecture.FlagIndex(0)
 		else:


### PR DESCRIPTION
Several functions, including `LowLevelILFunction.set_reg`, [default to `architecture.FlagIndex(0)` if no flags are explicitly provided](https://github.com/Vector35/binaryninja-api/blob/dev/python/lowlevelil.py#L3112-L3113). However, `LowLevelILFunction.expr` did not recognize `FlagIndex` as a valid type for flag arguments, and would thus [throw an assertion error](https://github.com/Vector35/binaryninja-api/blob/dev/python/lowlevelil.py#L3048-L3055)