### PR TITLE
Cleaned up the GitHub issue report templates.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,35 +1,32 @@
 ---
-name: Bug report
-about: Create a report to help us improve Binary Ninja
+name: Create a bug report
+about: Describe your issue and help us improve Binary Ninja
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-**Binary Ninja Version**
+**Version and Platform (required):**
+- Binary Ninja Version: 2.4.2487-dev (if version is stable, please also test the latest development build via the "Update Channel" option)
+- OS: [e.g. Ubuntu Linux]
+- OS Version: [e.g. 20.04]
 
+**Bug Description:**
+Please provide a clear and concise description of what happened.
 
-**Describe the bug**
-A clear and concise description of what the bug is.
-
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
+**Steps To Reproduce:**
+Please provide all steps required to reproduce the behavior:
+1. Go to...
+2. Click on...
+3. Scroll down to...
 4. See error
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+**Expected Behavior:**
+Please provide a clear and concise description of what you *expected* to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Screenshots:**
+If applicable, please add screenshots here to help explain your problem.
 
-**Version and Platform (required):**
- - Binary Ninja: Dev 2.4.2487 (if tested in stable, please also test the development channel via the "update channel" option)
- - OS: [e.g. Ubuntu Linux]
- - Version [e.g. 20.04]
-
-**Additional context**
-Add any other context about the problem here.
+**Additional Information:**
+Please add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@ blank_issues_enabled: false
 contact_links:
   - name: Binary Ninja Slack
     url: https://slack.binary.ninja/
-    about: For quick responses to short questions
+    about: Join for quick responses to short questions
   - name: Official Support
     url: https://binary.ninja/support/
-    about: Official Support Page
+    about: Check our official support page for more information

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,20 +1,20 @@
 ---
-name: Feature request
-about: Suggest an idea for this project
+name: Request a feature
+about: Let us know how we could improve Binary Ninja
 title: ''
 labels: enhancement
 assignees: ''
 
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**What is the feature you'd like to have?**
+Please provide a clear and concise description of what you want.
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Is your feature request related to a problem?**
+If applicable, please provide a clear and concise description of what the problem is.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Are any alternative solutions acceptable?**
+Please provide a clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+**Additional Information:**
+Please add any other context or screenshots that would help us understand your feature request here.


### PR DESCRIPTION
The GitHub issue report templates bugged me. I've tried to:

* Place the most important information toward the top
* Have consistent vocabulary
* Have consistent capitalization
* Match the default security vulnerability reporting option in tone/style