### PR TITLE
rust: workflow bindings and example

### DIFF
--- a/rust/examples/workflow/Cargo.toml
+++ b/rust/examples/workflow/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "workflow"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+binaryninja = { path = "../.." }
+log = "0.4"

--- a/rust/examples/workflow/src/lib.rs
+++ b/rust/examples/workflow/src/lib.rs
@@ -1,0 +1,21 @@
+use log::*;
+
+use binaryninja::activity::register_activity;
+use binaryninja::analysiscontext::AnalysisContext;
+use binaryninja::workflow::{register_workflow, Workflow};
+
+#[no_mangle]
+pub extern "C" fn CorePluginInit() -> bool {
+    binaryninja::logger::init(LevelFilter::Warn).unwrap();
+
+    let ww = Workflow::instance().duplicate("TestWorkflow");
+
+    let aa = register_activity("extension.test", move |_: &AnalysisContext| error!("hello from test workflow"));
+
+    ww.register_activity(aa);
+    ww.insert("core.function.translateTailCalls", &["extension.test"]);
+
+    register_workflow(ww);
+
+    true
+}

--- a/rust/src/activity.rs
+++ b/rust/src/activity.rs
@@ -1,0 +1,86 @@
+use std::borrow::Cow;
+use std::ffi::{c_void, CString, CStr};
+
+use binaryninjacore_sys::*;
+
+use crate::analysiscontext::AnalysisContext;
+use crate::rc::*;
+
+pub trait ActivityFn: 'static + Sync {
+    fn run(&self, ac: &AnalysisContext);
+}
+
+impl<T> ActivityFn for T
+where
+    T: 'static + Sync + Fn(&AnalysisContext),
+{
+    fn run(&self, ac: &AnalysisContext) {
+        self(ac)
+    }
+}
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub struct Activity(pub(crate) *mut BNActivity);
+
+impl ToOwned for Activity {
+    type Owned = Ref<Self>;
+
+    fn to_owned(&self) -> Self::Owned {
+        unsafe { RefCountable::inc_ref(self) }
+    }
+}
+
+unsafe impl RefCountable for Activity {
+    unsafe fn inc_ref(handle: &Self) -> Ref<Self> {
+        Ref::new(Self(BNNewActivityReference(handle.0)))
+    }
+
+    unsafe fn dec_ref(handle: &Self) {
+        BNFreeActivity(handle.0);
+    }
+}
+
+
+impl Activity {
+    pub(crate) unsafe fn from_raw(a: *mut BNActivity) -> Self {
+        Self(a)
+    }
+
+    pub fn name(&self) -> Cow<str> {
+        unsafe {
+            let name = BNActivityGetName(self.0);
+
+            // We need to guarantee ownership, as if we're still
+            // a Borrowed variant we're about to free the underlying
+            // memory.
+            let res = CStr::from_ptr(name);
+            let res = res.to_string_lossy().into_owned().into();
+
+            BNFreeString(name);
+
+            res
+        }
+    }
+}
+
+extern "C" fn activity_run<A: ActivityFn>(ctxt: *mut c_void, ac: *mut BNAnalysisContext) {
+    assert!(!ac.is_null());
+
+    ffi_wrap!("Activity::run", unsafe {
+        let activity = &*(ctxt as *const A);
+
+        let analysis_context = AnalysisContext::from_raw(ac);
+
+        activity.run(&analysis_context);
+    });
+}
+
+pub fn register_activity<A: ActivityFn>(name: &str, a: A) -> Ref<Activity> {
+    let cstr = CString::new(name).unwrap();
+
+    let b = Box::new(a);
+
+    let p = unsafe { BNCreateActivity(cstr.as_ptr(), Box::into_raw(b) as *mut c_void, Some(activity_run::<A>)) };
+
+    unsafe { Ref::new(Activity::from_raw(p)) }
+}

--- a/rust/src/analysiscontext.rs
+++ b/rust/src/analysiscontext.rs
@@ -1,0 +1,83 @@
+use std::ffi::CString;
+
+use binaryninjacore_sys::*;
+
+use crate::architecture::CoreArchitecture;
+use crate::basicblock::{BasicBlock, BlockContext};
+use crate::llil;
+use crate::function::Function;
+use crate::rc::*;
+
+pub struct AnalysisContext {
+    handle: *mut BNAnalysisContext,
+}
+
+impl AnalysisContext {
+    pub(crate) unsafe fn from_raw(handle: *mut BNAnalysisContext) -> Self {
+        debug_assert!(!handle.is_null());
+
+        Self { handle }
+    }
+
+    pub fn function(&self) -> Option<Ref<Function>> {
+        unsafe {
+            let p = BNAnalysisContextGetFunction(self.handle);
+
+            if p.is_null() {
+                return None;
+            }
+
+            Some(Function::from_raw(p))
+        }
+    }
+
+    pub fn low_level_il_function(&self) -> Option<Ref<llil::RegularFunction<CoreArchitecture>>> {
+        match self.function() {
+            Some(f) => match f.low_level_il() {
+                Ok(f) => Some(f),
+                Err(_) => None,
+            }
+            None => None,
+        }
+    }
+
+    pub fn set_low_level_il_function(&self, f: Ref<llil::RegularFunction<CoreArchitecture>>) {
+        unsafe { BNSetLowLevelILFunction(self.handle, f.handle) }
+    }
+
+    pub fn set_lifted_il_function(&self, f: Ref<llil::LiftedFunction<CoreArchitecture>>) {
+        unsafe { BNSetLiftedILFunction(self.handle, f.handle) }
+    }
+
+    pub fn mlil_function(&self) {
+        unimplemented!()
+    }
+
+    pub fn set_mlil_function(&self) {
+        unimplemented!()
+    }
+
+    pub fn hlil_function(&self) {
+        unimplemented!()
+    }
+
+    pub fn set_hlil_function(&self) {
+        unimplemented!()
+    }
+
+    pub fn set_basic_block_list<C: BlockContext>(&self, basic_block_list: &[BasicBlock<C>]) {
+        let mut blocks: Vec<*mut BNBasicBlock> = Vec::with_capacity(basic_block_list.len());
+
+        for block in basic_block_list {
+            blocks.push(block.handle);
+        }
+
+        unsafe { BNSetBasicBlockList(self.handle, blocks.as_ptr() as _, blocks.len()) }
+    }
+
+    pub fn inform(&self, request: &str) -> bool {
+        let req_with_nul = CString::new(request).unwrap();
+
+        unsafe { BNAnalysisContextInform(self.handle, req_with_nul.as_ptr()) }
+    }
+}

--- a/rust/src/ffi.rs
+++ b/rust/src/ffi.rs
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+macro_rules! cstr {
+    ($s:literal) => {
+        unsafe { CStr::from_bytes_with_nul_unchecked(concat!($s, "\0").as_bytes()) }
+    };
+}
+
 macro_rules! ffi_wrap {
     ($n:expr, $b:expr) => {{
         use std::panic;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -36,6 +36,7 @@ extern crate rayon;
 #[macro_use]
 mod ffi;
 
+pub mod activity;
 pub mod architecture;
 pub mod analysiscontext;
 pub mod backgroundtask;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -37,6 +37,7 @@ extern crate rayon;
 mod ffi;
 
 pub mod architecture;
+pub mod analysiscontext;
 pub mod backgroundtask;
 pub mod basicblock;
 pub mod binaryview;

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -63,6 +63,7 @@ pub mod settings;
 pub mod string;
 pub mod symbol;
 pub mod types;
+pub mod workflow;
 
 use std::collections::HashMap;
 use std::fs::File;

--- a/rust/src/workflow.rs
+++ b/rust/src/workflow.rs
@@ -1,0 +1,325 @@
+use std::borrow::Cow;
+use std::ffi::{CStr, CString};
+use std::slice;
+
+use binaryninjacore_sys::*;
+
+use crate::activity::Activity;
+use crate::flowgraph::FlowGraph;
+use crate::rc::*;
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+pub struct Workflow(pub(crate) *mut BNWorkflow);
+
+impl ToOwned for Workflow {
+    type Owned = Ref<Self>;
+
+    fn to_owned(&self) -> Self::Owned {
+        unsafe { RefCountable::inc_ref(self) }
+    }
+}
+
+unsafe impl RefCountable for Workflow {
+    unsafe fn inc_ref(handle: &Self) -> Ref<Self> {
+        Ref::new(Self(BNNewWorkflowReference(handle.0)))
+    }
+
+    unsafe fn dec_ref(handle: &Self) {
+        BNFreeWorkflow(handle.0);
+    }
+}
+
+impl Workflow {
+    pub(crate) unsafe fn from_raw(p: *mut BNWorkflow) -> Self {
+        Self(p)
+    }
+
+    pub fn new() -> Ref<Self> {
+        let name_with_nul = cstr!("");
+
+        unsafe {
+            let p = BNCreateWorkflow(name_with_nul.as_ptr());
+
+            Ref::new(Self(p))
+        }
+    }
+
+    pub fn with_name(name: &str) -> Ref<Self> {
+        let name_with_nul = CString::new(name).unwrap();
+
+        unsafe {
+            let p = BNCreateWorkflow(name_with_nul.as_ptr());
+
+            Ref::new(Self(p))
+        }
+    }
+
+    pub fn instance() -> Ref<Self> {
+        Self::instance_with_activity("")
+    }
+
+    pub fn instance_with_activity(activity: &str) -> Ref<Self> {
+        let activity_with_nul = CString::new(activity).unwrap();
+
+        unsafe { Ref::new(Self::from_raw(BNWorkflowInstance(activity_with_nul.as_ptr()))) }
+    }
+
+    // clone, but renamed to avoid confusion with rust's Clone trait
+    pub fn duplicate(&self, name: &str) -> Ref<Self> {
+        self.duplicate_with_activity(name, "")
+    }
+
+    pub fn duplicate_with_activity(&self, name: &str, activity: &str) -> Ref<Self> {
+        let name_with_nul = CString::new(name).unwrap();
+        let activity_with_nul = CString::new(activity).unwrap();
+
+        unsafe {
+            let ww = BNWorkflowClone(self.0, name_with_nul.as_ptr(), activity_with_nul.as_ptr());
+            Ref::new(Self::from_raw(ww))
+        }
+    }
+
+    pub fn register_activity(&self, activity: Ref<Activity>) -> bool {
+        self.register_activity_with_options(activity, &[], "")
+    }
+
+    pub fn register_activity_with_options(&self, activity: Ref<Activity>, subactivities: &[&str], desc: &str) -> bool {
+        let desc_with_nul = CString::new(desc).unwrap();
+
+        let mut buf: Vec<*mut i8> = subactivities.iter()
+            .map(|sa| unsafe {
+                let sa_with_nul = CString::new(*sa).unwrap();
+                BNAllocString(sa_with_nul.as_ptr())
+            })
+            .collect();
+
+        unsafe { 
+            let rr = BNWorkflowRegisterActivity(self.0, activity.0, buf.as_mut_ptr() as _, buf.len(), desc_with_nul.as_ptr());
+
+            for s in buf {
+                BNFreeString(s);
+            }
+
+            rr
+        }
+    }
+
+    pub fn contains(&self, activity: &str) -> bool {
+        let activity_with_nul = CString::new(activity).unwrap();
+
+        unsafe { BNWorkflowContains(self.0, activity_with_nul.as_ptr()) }
+    }
+
+    pub fn configuration(&self, activity: &str) -> Cow<str> {
+        let activity_with_nul = CString::new(activity).unwrap();
+
+        unsafe {
+            let cfg = BNWorkflowGetConfiguration(self.0, activity_with_nul.as_ptr());
+
+            // We need to guarantee ownership, as if we're still
+            // a Borrowed variant we're about to free the underlying
+            // memory.
+            let res = CStr::from_ptr(cfg);
+            let res = res.to_string_lossy().into_owned().into();
+
+            BNFreeString(cfg);
+
+            res
+        }
+    }
+
+    pub fn name(&self) -> Cow<str> {
+        unsafe {
+            let name = BNGetWorkflowName(self.0);
+
+            // We need to guarantee ownership, as if we're still
+            // a Borrowed variant we're about to free the underlying
+            // memory.
+            let res = CStr::from_ptr(name);
+            let res = res.to_string_lossy().into_owned().into();
+
+            BNFreeString(name);
+
+            res
+        }
+    }
+
+    pub fn registered(&self) -> bool {
+        unsafe { BNWorkflowIsRegistered(self.0) }
+    }
+
+    pub fn size(&self) -> usize {
+        unsafe { BNWorkflowSize(self.0) }
+    }
+
+    pub fn activity(&self, activity: &str) -> Ref<Activity> {
+        let activity_with_nul = CString::new(activity).unwrap();
+
+        unsafe {
+            let p = BNWorkflowGetActivity(self.0, activity_with_nul.as_ptr());
+            Ref::new(Activity::from_raw(p))   
+        }
+    }
+
+    pub fn activity_roots(&self) -> impl Iterator<Item=Cow<str>> {
+        self.activity_roots_with_activity("")
+    }
+
+    pub fn activity_roots_with_activity(&self, activity: &str) -> impl Iterator<Item=Cow<str>> {
+        let activity_with_nul = CString::new(activity).unwrap();
+
+        let mut count = 0;
+
+        unsafe {
+            let list = BNWorkflowGetActivityRoots(self.0, activity_with_nul.as_ptr(), &mut count);
+
+            let activities = slice::from_raw_parts_mut(list, count);
+
+            let rr: Vec<Cow<str>> = activities.into_iter()
+                .map(|aa| CStr::from_ptr(*aa as _).to_string_lossy().into_owned().into())
+                .collect();
+
+            BNFreeStringList(activities.as_mut_ptr() as _, activities.len());
+
+            rr.into_iter()
+        }
+    }
+
+    pub fn subactivities(&self) -> impl Iterator<Item=Cow<str>> {
+        self.subactivities_with_options("", true)
+    }
+
+    pub fn subactivities_with_options(&self, activity: &str, immediate: bool) -> impl Iterator<Item=Cow<str>> {
+        let activity_with_nul = CString::new(activity).unwrap();
+
+        let mut count = 0;
+
+        unsafe {
+            let list = BNWorkflowGetSubactivities(self.0, activity_with_nul.as_ptr(), immediate, &mut count);
+
+            let activities = slice::from_raw_parts_mut(list, count);
+
+            let rr: Vec<Cow<str>> = activities.into_iter()
+                .map(|aa| CStr::from_ptr(*aa as _).to_string_lossy().into_owned().into())
+                .collect();
+
+            BNFreeStringList(activities.as_mut_ptr() as _, activities.len());
+
+            rr.into_iter()
+        }
+    }
+
+    pub fn set_subactivities(&self, activity: &str) -> bool {
+        self.set_subactivities_with_activities(activity, &[])
+    }
+
+    pub fn set_subactivities_with_activities(&self, activity: &str, subactivities: &[&str]) -> bool {
+        let activity_with_nul = CString::new(activity).unwrap();
+
+        let mut buf: Vec<*mut i8> = subactivities.iter()
+            .map(|sa| unsafe {
+                let sa_with_nul = CString::new(*sa).unwrap();
+                BNAllocString(sa_with_nul.as_ptr())
+            })
+            .collect();
+
+        unsafe { 
+            let rr = BNWorkflowAssignSubactivities(self.0, activity_with_nul.as_ptr(), buf.as_mut_ptr() as _, buf.len());
+
+            for sa in buf {
+                BNFreeString(sa);
+            }
+
+            rr
+        }
+    }
+
+    pub fn clear(&self) -> bool {
+        unsafe { BNWorkflowClear(self.0) }
+    }
+
+    pub fn insert(&self, activity: &str, activities: &[&str]) -> bool {
+        let activity_with_nul = CString::new(activity).unwrap();
+
+        let mut buf: Vec<*mut i8> = activities.iter()
+            .map(|sa| unsafe {
+                let sa_with_nul = CString::new(*sa).unwrap();
+                BNAllocString(sa_with_nul.as_ptr())
+            })
+            .collect();
+
+        unsafe { 
+            let rr = BNWorkflowInsert(self.0, activity_with_nul.as_ptr(), buf.as_mut_ptr() as _, buf.len());
+
+            for sa in buf {
+                BNFreeString(sa);
+            }
+
+            rr
+        }
+    }
+
+    pub fn remove(&self, activity: &str) -> bool {
+        let activity_with_nul = CString::new(activity).unwrap();
+
+        unsafe { BNWorkflowRemove(self.0, activity_with_nul.as_ptr()) }
+    }
+
+    pub fn replace(&self, old: &str, new: &str) -> bool {
+        let old_with_nul = CString::new(old).unwrap();
+        let new_with_nul = CString::new(new).unwrap();
+
+        unsafe { BNWorkflowReplace(self.0, old_with_nul.as_ptr(), new_with_nul.as_ptr()) }
+    }
+
+    pub fn graph(&self) -> Option<Ref<FlowGraph>> {
+        self.graph_with_options("", false)
+    }
+
+    pub fn graph_with_options(&self, activity: &str, seq: bool) -> Option<Ref<FlowGraph>> {
+        let activity_with_nul = CString::new(activity).unwrap();
+
+        let p = unsafe { BNWorkflowGetGraph(self.0, activity_with_nul.as_ptr(), seq) };
+
+        if p.is_null() {
+            return None;
+        }
+
+        unsafe { Some(Ref::new(FlowGraph::from_raw(p))) }
+    }
+
+    pub fn show_report(&self, name: &str) {
+        let name_with_nul = CString::new(name).unwrap();
+
+        unsafe { BNWorkflowShowReport(self.0, name_with_nul.as_ptr()) }
+    }
+}
+
+pub fn register_workflow(ww: Ref<Workflow>) -> bool {
+    register_workflow_with_description(ww, "")
+}
+
+pub fn register_workflow_with_description(ww: Ref<Workflow>, descr: &str) -> bool {
+    let descr_with_nul = CString::new(descr).unwrap();
+
+    unsafe { BNRegisterWorkflow(ww.0, descr_with_nul.as_ptr()) }
+}
+
+// list
+pub fn iter_workflows() -> impl Iterator<Item=Ref<Workflow>> {
+    let mut count = 0;
+
+    unsafe {
+        let list = BNGetWorkflowList(&mut count);
+
+        let ptrs = slice::from_raw_parts(list, count); 
+        
+        let rr: Vec<Ref<Workflow>> = ptrs.into_iter()
+            .map(|ww| Ref::new(Workflow::from_raw(*ww)))
+            .collect();
+
+        BNFreeWorkflowList(list, count);
+
+        rr.into_iter()
+    }
+}


### PR DESCRIPTION
So as far as I can tell the bindings are correct for the workflow types, _however_ there are no bindings for emitting new IL inside the workflow passes. After looking at the existing bindings, there is enough nuance and complication that I don't think I'd be able to write the code that's needed here (or if so it would require extensive v35 help). As a result this code is practically useless. If/when the bindings for rust workflows are written by someone, they'll likely need code that looks very similar if not identical to this (or this would be a good starting spot for that work), but I don't know when that might be.

I'm happy any way this goes, feel free to merge or close.