### PR TITLE
data was of type bytes when trying to retrieve input, proper string cast

### DIFF
--- a/python/scriptingprovider.py
+++ b/python/scriptingprovider.py
@@ -606,7 +606,7 @@ from binaryninja import *
 			self.event.set()
 
 		def add_input(self, data):
-			self.input += data
+			self.input = self.input + data.decode("utf-8")
 			self.event.set()
 
 		def end(self):


### PR DESCRIPTION
might have been a python3 change, but need the conversion to string type for data, which was of bytes. this has to be done with decode to maintain the "\n"