### PR TITLE
rust: use useful derive macros on enums

### DIFF
--- a/rust/src/architecture.rs
+++ b/rust/src/architecture.rs
@@ -36,6 +36,7 @@ use crate::llil::{FlagWriteOp, LiftedExpr, Lifter};
 use crate::rc::*;
 use crate::string::*;
 
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum BranchInfo {
     Unconditional(u64),
     False(u64),
@@ -160,6 +161,7 @@ impl InstructionInfo {
     }
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum InstructionTextTokenContents {
     Text,
     Instruction,

--- a/rust/src/llil/mod.rs
+++ b/rust/src/llil/mod.rs
@@ -87,6 +87,7 @@ impl<R: ArchReg> SSARegister<R> {
     }
 }
 
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum VisitorAction {
     Descend,
     Sibling,

--- a/rust/src/section.rs
+++ b/rust/src/section.rs
@@ -21,6 +21,7 @@ use crate::binaryview::BinaryView;
 use crate::rc::*;
 use crate::string::*;
 
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum Semantics {
     DefaultSection,
     ReadOnlyCode,


### PR DESCRIPTION
This adds common derives to enums that are currently missing them.