### PR TITLE
Correct type for `binaryninja.types.ParamsType`

### DIFF
--- a/python/types.py
+++ b/python/types.py
@@ -41,7 +41,7 @@ from . import typelibrary
 QualifiedNameType = Union[Iterable[Union[str, bytes]], str, 'QualifiedName']
 BoolWithConfidenceType = Union[bool, 'BoolWithConfidence']
 OffsetWithConfidenceType = Union[int, 'OffsetWithConfidence']
-ParamsType = Union[List['Type'], List['FunctionParameter'], List[Tuple['Type', str]]]
+ParamsType = Union[List['Type'], List['FunctionParameter'], List[Tuple[str, 'Type']]]
 MembersType = Union[List['StructureMember'], List['Type'], List[Tuple['Type', str]]]
 EnumMembersType = Union[List[Tuple[str, int]], List[str], List['EnumerationMember']]
 SomeType = Union['TypeBuilder', 'Type']


### PR DESCRIPTION
`FunctionBuilder._to_core_struct(params)` expects tuples of `(str, Type)`, and this is the only place this type is actually used:
https://github.com/Vector35/binaryninja-api/blob/4ee98c21c517e40a31d5eb51ef4cee9fe8b4bb7e/python/types.py#L968-L977