### PR TITLE
rust: bump bindgen version to ^0.59

### DIFF
--- a/rust/binaryninjacore-sys/Cargo.toml
+++ b/rust/binaryninjacore-sys/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Ryan Snyder <ryan@vector35.com>", "Kyle Martin <kyle@vector35.com>"]
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "0.58.1"
+bindgen = "^0.59"


### PR DESCRIPTION
Pinning it directly to 0.58.1 caused issues with dependencies that used
conflicting `proc-macro2` versions. Being more lax in the version allows
consumers of the rust API more chances to resolve dependencies.