### PR TITLE
[WIP] Rust: Better errors

### DIFF
--- a/rust/src/backgroundtask.rs
+++ b/rust/src/backgroundtask.rs
@@ -43,7 +43,7 @@ impl BackgroundTask {
             return Err(
                 bn_api_error!(
                     BNBeginBackgroundTask,
-                    &format!("initial_text={:?}, can_cancel={:?}", bytes_error_repr(text.as_ref()), can_cancel)
+                    &format!("initial_text={:?}, can_cancel={:?}", Utf8Display(&text), can_cancel)
                 )
             );
         }

--- a/rust/src/binaryview.rs
+++ b/rust/src/binaryview.rs
@@ -294,7 +294,7 @@ pub trait BinaryViewExt: BinaryViewBase {
             );
 
             if raw_sym.is_null() {
-                return Err(bn_api_error!(BNGetSymbolByRawName, &format!("raw_name={:?}", bytes_error_repr(raw_name.as_ref()))));
+                return Err(bn_api_error!(BNGetSymbolByRawName, &format!("raw_name={:?}", Utf8Display(&raw_name))));
             }
 
             Ok(Ref::new(Symbol::from_raw(raw_sym)))
@@ -495,7 +495,7 @@ pub trait BinaryViewExt: BinaryViewBase {
             if raw_section.is_null() {
                 return Err(bn_api_error!(
                     BNGetSectionByName,
-                    &format!("name={:?}", bytes_error_repr(raw_name.as_ref()))
+                    &format!("name={:?}", Utf8Display(&raw_name))
                 ));
             }
 
@@ -665,7 +665,7 @@ pub trait BinaryViewExt: BinaryViewBase {
         if settings_handle.is_null() {
             Err(bn_api_error!(
                 BNBinaryViewGetLoadSettings,
-                &format!("name={:?}", bytes_error_repr(view_type_name.as_ref()))
+                &format!("name={:?}", Utf8Display(&view_type_name))
             ))
         } else {
             Ok(unsafe { Settings::from_raw(settings_handle) })
@@ -867,8 +867,8 @@ impl BinaryView {
             return Err(bn_api_error!(
                 BNCreateBinaryDataViewFromFilename,
                 &format!("meta.filename={:?}, filename={:?}",
-                    bytes_error_repr(meta.filename().as_ref()),
-                    bytes_error_repr(file.as_ref())
+                    Utf8Display(&meta.filename()),
+                    Utf8Display(&file)
                 )
             ));
         }
@@ -883,7 +883,7 @@ impl BinaryView {
         if handle.is_null() {
             return Err(bn_api_error!(
                 BNCreateBinaryDataViewFromFile,
-                &format!("meta.filename={:?}", bytes_error_repr(meta.filename().as_ref()))
+                &format!("meta.filename={:?}", Utf8Display(&meta.filename()))
             ));
         }
 
@@ -898,7 +898,7 @@ impl BinaryView {
         if handle.is_null() {
             return Err(bn_api_error!(
                 BNCreateBinaryDataViewFromData,
-                &format!("meta.filename={:?}", bytes_error_repr(meta.filename().as_ref()))
+                &format!("meta.filename={:?}", Utf8Display(&meta.filename()))
             ));
         }
 

--- a/rust/src/binaryview.rs
+++ b/rust/src/binaryview.rs
@@ -138,7 +138,7 @@ pub trait BinaryViewExt: BinaryViewBase {
         let handle = unsafe { BNGetParentView(self.as_ref().handle) };
 
         if handle.is_null() {
-            return Err(BNError::api_error("BNGetParentView", None));
+            return Err(bn_api_error!(BNGetParentView));
         }
 
         unsafe { Ok(BinaryView::from_raw(handle)) }

--- a/rust/src/custombinaryview.rs
+++ b/rust/src/custombinaryview.rs
@@ -227,7 +227,7 @@ impl BinaryViewType {
             false => Ok(BinaryViewType(res)),
             true => Err(bn_api_error!(
                 BNGetBinaryViewTypeByName,
-                &format!("name={:?}", bytes_error_repr(bytes.as_ref()))
+                &format!("name={:?}", Utf8Display(&bytes))
             )),
         }
     }

--- a/rust/src/debuginfo.rs
+++ b/rust/src/debuginfo.rs
@@ -71,6 +71,7 @@ use crate::{
     binaryview::BinaryView,
     callingconvention::CallingConvention,
     platform::Platform,
+    errors::*,
     rc::*,
     string::{raw_to_string, BnStrCompatible, BnString},
     types::{DataVariableAndName, NameAndType, Type},
@@ -96,12 +97,15 @@ impl DebugInfoParser {
     }
 
     /// Returns debug info parser of the given name, if it exists
-    pub fn from_name<S: BnStrCompatible>(name: S) -> Result<Ref<Self>, ()> {
+    pub fn from_name<S: BnStrCompatible>(name: S) -> BNResult<Ref<Self>> {
         let name = name.as_bytes_with_nul();
         let parser = unsafe { BNGetDebugInfoParserByName(name.as_ref().as_ptr() as *mut _) };
 
         if parser.is_null() {
-            Err(())
+            Err(bn_api_error!(
+                BNGetDebugInfoParserByName,
+                &format!("name={:?}", Utf8Display(&name))
+            ))
         } else {
             unsafe { Ok(Self::from_raw(parser)) }
         }

--- a/rust/src/demangle.rs
+++ b/rust/src/demangle.rs
@@ -33,8 +33,10 @@ pub fn demangle_gnu3<S: BnStrCompatible>(
         let cstr = match CStr::from_bytes_with_nul(mangled_name_ptr) {
             Ok(cstr) => cstr,
             Err(e) => {
-                log::error!("demangle_gnu3: failed to parse mangled name");
-                return Err(e.into());
+                let msg = "demangle_gnu3: failed to parse mangled name";
+                log::error!("{}", msg);
+                let e: BNError = e.into();
+                return Err(e.contextualize(msg));
             }
         };
         return Ok((None, vec![cstr.to_string_lossy().into_owned()]));
@@ -94,8 +96,10 @@ pub fn demangle_ms<S: BnStrCompatible>(
         let cstr = match CStr::from_bytes_with_nul(mangled_name_ptr) {
             Ok(cstr) => cstr,
             Err(e) => {
-                log::error!("demangle_ms: failed to parse mangled name");
-                return Err(e.into());
+                let msg = "demangle_ms: failed to parse mangled name";
+                log::error!("{}", msg);
+                let e: BNError = e.into();
+                return Err(e.contextualize(msg));
             }
         };
         return Ok((None, vec![cstr.to_string_lossy().into_owned()]));

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -1,0 +1,69 @@
+use std::{fmt, backtrace::Backtrace, error::Error};
+
+#[allow(dead_code)] // it's used in `Debug` which is used in `Display` which is used to show the error
+#[derive(Debug)]
+pub struct BNError {
+    repr: BNErrorRepr,
+    backtrace: Option<Backtrace>,
+    cause: Option<Box<dyn Error>>,
+}
+
+#[derive(Debug, Eq, PartialEq, Hash)]
+pub enum BNErrorRepr {
+    Generic(String),
+    APIError { api_function: String, other_info: Option<String>},
+    IOError,
+}
+
+macro_rules! bn_api_error {
+    ($func:tt) => {
+        BNError::api_error(stringify!($func), None)
+    };
+    ($func:tt, $extra:expr) => {
+        BNError::api_error(stringify!($func), Some($extra))
+    };
+}
+pub(crate) use bn_api_error;
+
+pub type BNResult<R> = Result<R, BNError>;
+
+pub fn bytes_error_repr(r: &[u8]) -> String {
+    String::from_utf8_lossy(r).to_string()
+}
+
+impl fmt::Display for BNError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        <Self as fmt::Debug>::fmt(self, f)
+    }
+}
+
+impl BNError {
+    pub fn generic(msg: &str) -> BNError {
+        BNError {
+            repr: BNErrorRepr::Generic(String::from(msg)),
+            backtrace: Some(Backtrace::capture()),
+            cause: None
+        }
+    }
+    pub fn api_error(func: &str, other_info: Option<&str>) -> BNError {
+        BNError {
+            repr: BNErrorRepr::APIError{
+                api_function: String::from(func),
+                other_info: other_info.map(String::from),
+            },
+            backtrace: Some(Backtrace::capture()),
+            cause: None
+        }
+    }
+}
+impl Error for BNError {
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.backtrace.as_ref()
+    }
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match &self.cause {
+            Some(ex) => Some(ex.as_ref()),
+            None => None,
+        }
+    }
+}

--- a/rust/src/errors.rs
+++ b/rust/src/errors.rs
@@ -38,6 +38,7 @@ impl fmt::Display for BNError {
 }
 
 impl BNError {
+    #[inline(always)]
     pub fn generic(msg: &str) -> BNError {
         BNError {
             repr: BNErrorRepr::Generic(String::from(msg)),
@@ -45,6 +46,7 @@ impl BNError {
             cause: None
         }
     }
+    #[inline(always)]
     pub fn api_error(func: &str, other_info: Option<&str>) -> BNError {
         BNError {
             repr: BNErrorRepr::APIError{

--- a/rust/src/filemetadata.rs
+++ b/rust/src/filemetadata.rs
@@ -166,7 +166,7 @@ impl FileMetadata {
             } else {
                 Err(bn_api_error!(
                     BNNavigate,
-                    &format!("view={:?}, offset=0x{:x}", bytes_error_repr(view.as_ref()), offset)
+                    &format!("view={:?}, offset=0x{:x}", Utf8Display(&view), offset)
                 ))
             }
         }
@@ -181,7 +181,7 @@ impl FileMetadata {
             if res.is_null() {
                 Err(bn_api_error!(
                     BNGetFileViewOfType,
-                    &format!("view={:?}", bytes_error_repr(view.as_ref()))
+                    &format!("view={:?}", Utf8Display(&view))
                 ))
             } else {
                 Ok(BinaryView::from_raw(res))
@@ -224,7 +224,7 @@ impl FileMetadata {
             if bv.is_null() {
                 Err(bn_api_error!(
                     BNOpenDatabaseForConfiguration,
-                    &format!("filename={:?}", bytes_error_repr(filename.as_ref()))
+                    &format!("filename={:?}", Utf8Display(&filename))
                 ))
             } else {
                 Ok(BinaryView::from_raw(bv))
@@ -247,7 +247,7 @@ impl FileMetadata {
         if view.is_null() {
             Err(bn_api_error!(
                 BNOpenExistingDatabase,
-                &format!("filename={:?}", bytes_error_repr(filename.as_ref()))
+                &format!("filename={:?}", Utf8Display(&filename))
             ))
         } else {
             Ok(unsafe { BinaryView::from_raw(view) })

--- a/rust/src/function.rs
+++ b/rust/src/function.rs
@@ -25,6 +25,7 @@ use crate::types::Type;
 
 use crate::llil;
 
+use crate::errors::*;
 use crate::rc::*;
 use crate::string::*;
 
@@ -210,24 +211,30 @@ impl Function {
         }
     }
 
-    pub fn low_level_il(&self) -> Result<Ref<llil::RegularFunction<CoreArchitecture>>, ()> {
+    pub fn low_level_il(&self) -> BNResult<Ref<llil::RegularFunction<CoreArchitecture>>> {
         unsafe {
             let llil = BNGetFunctionLowLevelIL(self.handle);
 
             if llil.is_null() {
-                return Err(());
+                return Err(bn_api_error!(
+                    BNGetFunctionLowLevelIL,
+                    &format!("self={:?}", self)
+                ));
             }
 
             Ok(Ref::new(llil::RegularFunction::from_raw(self.arch(), llil)))
         }
     }
 
-    pub fn lifted_il(&self) -> Result<Ref<llil::LiftedFunction<CoreArchitecture>>, ()> {
+    pub fn lifted_il(&self) -> BNResult<Ref<llil::LiftedFunction<CoreArchitecture>>> {
         unsafe {
             let llil = BNGetFunctionLiftedIL(self.handle);
 
             if llil.is_null() {
-                return Err(());
+                return Err(bn_api_error!(
+                    BNGetFunctionLiftedIL,
+                    &format!("self={:?}", self)
+                ));
             }
 
             Ok(Ref::new(llil::LiftedFunction::from_raw(self.arch(), llil)))

--- a/rust/src/platform.rs
+++ b/rust/src/platform.rs
@@ -20,6 +20,7 @@ use crate::{
     architecture::{Architecture, CoreArchitecture},
     callingconvention::CallingConvention,
     rc::*,
+    errors::*,
     string::*,
     types::{QualifiedName, QualifiedNameAndType, Type},
 };
@@ -245,8 +246,8 @@ pub trait TypeParser {
         _filename: S,
         _include_directories: &[P],
         _auto_type_source: S,
-    ) -> Result<TypeParserResult, String> {
-        Err(String::new())
+    ) -> BNResult<TypeParserResult> {
+        Err(BNError::generic("unimplemented parse_types_from_sources"))
     }
 }
 
@@ -264,7 +265,7 @@ impl TypeParser for Platform {
         filename: S,
         include_directories: &[P],
         auto_type_source: S,
-    ) -> Result<TypeParserResult, String> {
+    ) -> BNResult<TypeParserResult> {
         let mut result = BNTypeParserResult {
             functionCount: 0,
             typeCount: 0,
@@ -304,7 +305,15 @@ impl TypeParser for Platform {
             let error_msg = BnString::from_raw(error_string);
 
             if !success {
-                return Err(error_msg.to_string());
+                return Err(bn_api_error!(
+                    BNParseTypesFromSource,
+                    &format!("self={:?}, src={:?}, filename={:?}, error_msg={:?}",
+                        self,
+                        Utf8Display(&src),
+                        Utf8Display(&filename),
+                        Utf8Display(&error_msg)
+                    )
+                ));
             }
 
             for i in slice::from_raw_parts(result.types, result.typeCount) {

--- a/rust/src/platform.rs
+++ b/rust/src/platform.rs
@@ -232,6 +232,12 @@ impl Platform {
     }
 }
 
+impl std::fmt::Debug for Platform {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Platform[name={:?}, arch={:?}]", self.name().as_str(), self.arch().name().as_str())
+    }
+}
+
 pub trait TypeParser {
     fn parse_types_from_source<S: BnStrCompatible, P: AsRef<Path>>(
         &self,

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -17,15 +17,14 @@
 // TODO : Test the get_enumeration and get_structure methods
 
 use binaryninjacore_sys::*;
-use std::{fmt, mem, ptr, result, slice};
+use std::{fmt, mem, ptr, slice};
 
 use crate::architecture::{Architecture, CoreArchitecture};
 use crate::callingconvention::CallingConvention;
 use crate::string::{raw_to_string, BnStr, BnStrCompatible, BnString};
 
 use crate::rc::*;
-
-pub type Result<R> = result::Result<R, ()>;
+use crate::errors::*;
 
 pub type ReferenceType = BNReferenceType;
 pub type TypeClass = BNTypeClass;
@@ -229,37 +228,37 @@ impl TypeBuilder {
         unsafe { BNIsTypeBuilderFloatingPoint(self.handle) }
     }
 
-    pub fn target(&self) -> Result<Conf<Ref<Type>>> {
+    pub fn target(&self) -> BNResult<Conf<Ref<Type>>> {
         let raw_target = unsafe { BNGetTypeBuilderChildType(self.handle) };
         if raw_target.type_.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetTypeBuilderChildType))
         } else {
             Ok(raw_target.into())
         }
     }
 
-    pub fn element_type(&self) -> Result<Conf<Ref<Type>>> {
+    pub fn element_type(&self) -> BNResult<Conf<Ref<Type>>> {
         let raw_target = unsafe { BNGetTypeBuilderChildType(self.handle) };
         if raw_target.type_.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetTypeBuilderChildType))
         } else {
             Ok(raw_target.into())
         }
     }
 
-    pub fn return_value(&self) -> Result<Conf<Ref<Type>>> {
+    pub fn return_value(&self) -> BNResult<Conf<Ref<Type>>> {
         let raw_target = unsafe { BNGetTypeBuilderChildType(self.handle) };
         if raw_target.type_.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetTypeBuilderChildType))
         } else {
             Ok(raw_target.into())
         }
     }
 
-    pub fn calling_convention(&self) -> Result<Conf<Ref<CallingConvention<CoreArchitecture>>>> {
+    pub fn calling_convention(&self) -> BNResult<Conf<Ref<CallingConvention<CoreArchitecture>>>> {
         let convention_confidence = unsafe { BNGetTypeBuilderCallingConvention(self.handle) };
         if convention_confidence.convention.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetTypeBuilderCallingConvention))
         } else {
             Ok(convention_confidence.into())
         }
@@ -271,28 +270,28 @@ impl TypeBuilder {
         unsafe { BNTypeBuilderHasVariableArguments(self.handle).into() }
     }
 
-    pub fn get_structure(&self) -> Result<Ref<Structure>> {
+    pub fn get_structure(&self) -> BNResult<Ref<Structure>> {
         let result = unsafe { BNGetTypeBuilderStructure(self.handle) };
         if result.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetTypeBuilderStructure))
         } else {
             Ok(unsafe { Structure::ref_from_raw(result) })
         }
     }
 
-    pub fn get_enumeration(&self) -> Result<Ref<Enumeration>> {
+    pub fn get_enumeration(&self) -> BNResult<Ref<Enumeration>> {
         let result = unsafe { BNGetTypeBuilderEnumeration(self.handle) };
         if result.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetTypeBuilderEnumeration))
         } else {
             Ok(Enumeration::ref_from_raw(result))
         }
     }
 
-    pub fn get_named_type_reference(&self) -> Result<NamedTypeReference> {
+    pub fn get_named_type_reference(&self) -> BNResult<NamedTypeReference> {
         let result = unsafe { BNGetTypeBuilderNamedTypeReference(self.handle) };
         if result.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetTypeBuilderNamedTypeReference))
         } else {
             Ok(unsafe { NamedTypeReference::from_raw(result) })
         }
@@ -572,37 +571,37 @@ impl Type {
         unsafe { BNIsTypeFloatingPoint(self.handle) }
     }
 
-    pub fn target(&self) -> Result<Conf<Ref<Type>>> {
+    pub fn target(&self) -> BNResult<Conf<Ref<Type>>> {
         let raw_target = unsafe { BNGetChildType(self.handle) };
         if raw_target.type_.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetChildType))
         } else {
             Ok(raw_target.into())
         }
     }
 
-    pub fn element_type(&self) -> Result<Conf<Ref<Type>>> {
+    pub fn element_type(&self) -> BNResult<Conf<Ref<Type>>> {
         let raw_target = unsafe { BNGetChildType(self.handle) };
         if raw_target.type_.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetChildType))
         } else {
             Ok(raw_target.into())
         }
     }
 
-    pub fn return_value(&self) -> Result<Conf<Ref<Type>>> {
+    pub fn return_value(&self) -> BNResult<Conf<Ref<Type>>> {
         let raw_target = unsafe { BNGetChildType(self.handle) };
         if raw_target.type_.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetChildType))
         } else {
             Ok(raw_target.into())
         }
     }
 
-    pub fn calling_convention(&self) -> Result<Conf<Ref<CallingConvention<CoreArchitecture>>>> {
+    pub fn calling_convention(&self) -> BNResult<Conf<Ref<CallingConvention<CoreArchitecture>>>> {
         let convention_confidence = unsafe { BNGetTypeCallingConvention(self.handle) };
         if convention_confidence.convention.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetTypeCallingConvention))
         } else {
             Ok(convention_confidence.into())
         }
@@ -619,28 +618,28 @@ impl Type {
         unsafe { BNFunctionTypeCanReturn(self.handle).into() }
     }
 
-    pub fn get_structure(&self) -> Result<Ref<Structure>> {
+    pub fn get_structure(&self) -> BNResult<Ref<Structure>> {
         let result = unsafe { BNGetTypeStructure(self.handle) };
         if result.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetTypeStructure))
         } else {
             Ok(unsafe { Structure::ref_from_raw(result) })
         }
     }
 
-    pub fn get_enumeration(&self) -> Result<Ref<Enumeration>> {
+    pub fn get_enumeration(&self) -> BNResult<Ref<Enumeration>> {
         let result = unsafe { BNGetTypeEnumeration(self.handle) };
         if result.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetTypeEnumeration))
         } else {
             Ok(Enumeration::ref_from_raw(result))
         }
     }
 
-    pub fn get_named_type_reference(&self) -> Result<NamedTypeReference> {
+    pub fn get_named_type_reference(&self) -> BNResult<NamedTypeReference> {
         let result = unsafe { BNGetTypeNamedTypeReference(self.handle) };
         if result.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetTypeNamedTypeReference))
         } else {
             Ok(unsafe { NamedTypeReference::from_raw(result) })
         }
@@ -658,10 +657,10 @@ impl Type {
         unsafe { BNGetTypeStackAdjustment(self.handle).into() }
     }
 
-    pub fn registered_name(&self) -> Result<NamedTypeReference> {
+    pub fn registered_name(&self) -> BNResult<NamedTypeReference> {
         let result = unsafe { BNGetRegisteredTypeName(self.handle) };
         if result.is_null() {
-            Err(())
+            Err(bn_api_error!(BNGetRegisteredTypeName))
         } else {
             Ok(unsafe { NamedTypeReference::from_raw(result) })
         }


### PR DESCRIPTION
I made an initial attempt at better error messages as discussed in the slack channel. I've implemented a custom BNError type we can use to designate various different forms of errors while keeping track of dependent Errors (causes) as well as the backtrace of each error. 

This does unfortunately currently rely on the unstable [backtrace](https://github.com/rust-lang/rust/issues/53487) feature: 
`#![feature(backtrace)]`

For now, I only modified the code in `binaryview.rs` to use them, I'm happy to modify the rest after some review if this is something that will be incorporated :).