### PR TITLE
Allow specifying flag writes for float comparisons

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -4130,14 +4130,14 @@ __attribute__ ((format (printf, 1, 2)))
 		ExprId Floor(size_t size, ExprId a, uint32_t flags = 0, const ILSourceLocation& loc = ILSourceLocation());
 		ExprId Ceil(size_t size, ExprId a, uint32_t flags = 0, const ILSourceLocation& loc = ILSourceLocation());
 		ExprId FloatTrunc(size_t size, ExprId a, uint32_t flags = 0, const ILSourceLocation& loc = ILSourceLocation());
-		ExprId FloatCompareEqual(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc = ILSourceLocation());
-		ExprId FloatCompareNotEqual(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc = ILSourceLocation());
-		ExprId FloatCompareLessThan(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc = ILSourceLocation());
-		ExprId FloatCompareLessEqual(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc = ILSourceLocation());
-		ExprId FloatCompareGreaterEqual(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc = ILSourceLocation());
-		ExprId FloatCompareGreaterThan(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc = ILSourceLocation());
-		ExprId FloatCompareOrdered(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc = ILSourceLocation());
-		ExprId FloatCompareUnordered(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc = ILSourceLocation());
+		ExprId FloatCompareEqual(size_t size, ExprId a, ExprId b, uint32_t flags = 0, const ILSourceLocation& loc = ILSourceLocation());
+		ExprId FloatCompareNotEqual(size_t size, ExprId a, ExprId b, uint32_t flags = 0, const ILSourceLocation& loc = ILSourceLocation());
+		ExprId FloatCompareLessThan(size_t size, ExprId a, ExprId b, uint32_t flags = 0, const ILSourceLocation& loc = ILSourceLocation());
+		ExprId FloatCompareLessEqual(size_t size, ExprId a, ExprId b, uint32_t flags = 0, const ILSourceLocation& loc = ILSourceLocation());
+		ExprId FloatCompareGreaterEqual(size_t size, ExprId a, ExprId b, uint32_t flags = 0, const ILSourceLocation& loc = ILSourceLocation());
+		ExprId FloatCompareGreaterThan(size_t size, ExprId a, ExprId b, uint32_t flags = 0, const ILSourceLocation& loc = ILSourceLocation());
+		ExprId FloatCompareOrdered(size_t size, ExprId a, ExprId b, uint32_t flags = 0, const ILSourceLocation& loc = ILSourceLocation());
+		ExprId FloatCompareUnordered(size_t size, ExprId a, ExprId b, uint32_t flags = 0, const ILSourceLocation& loc = ILSourceLocation());
 
 		ExprId Goto(BNLowLevelILLabel& label, const ILSourceLocation& loc = ILSourceLocation());
 		ExprId If(ExprId operand, BNLowLevelILLabel& t, BNLowLevelILLabel& f,

--- a/lowlevelilinstruction.cpp
+++ b/lowlevelilinstruction.cpp
@@ -3583,49 +3583,49 @@ ExprId LowLevelILFunction::FloatTrunc(size_t size, ExprId a, uint32_t flags, con
 }
 
 
-ExprId LowLevelILFunction::FloatCompareEqual(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc)
+ExprId LowLevelILFunction::FloatCompareEqual(size_t size, ExprId a, ExprId b, uint32_t flags, const ILSourceLocation& loc)
 {
-	return AddExprWithLocation(LLIL_FCMP_E, loc, size, 0, a, b);
+	return AddExprWithLocation(LLIL_FCMP_E, loc, size, flags, a, b);
 }
 
 
-ExprId LowLevelILFunction::FloatCompareNotEqual(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc)
+ExprId LowLevelILFunction::FloatCompareNotEqual(size_t size, ExprId a, ExprId b, uint32_t flags, const ILSourceLocation& loc)
 {
-	return AddExprWithLocation(LLIL_FCMP_NE, loc, size, 0, a, b);
+	return AddExprWithLocation(LLIL_FCMP_NE, loc, size, flags, a, b);
 }
 
 
-ExprId LowLevelILFunction::FloatCompareLessThan(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc)
+ExprId LowLevelILFunction::FloatCompareLessThan(size_t size, ExprId a, ExprId b, uint32_t flags, const ILSourceLocation& loc)
 {
-	return AddExprWithLocation(LLIL_FCMP_LT, loc, size, 0, a, b);
+	return AddExprWithLocation(LLIL_FCMP_LT, loc, size, flags, a, b);
 }
 
 
-ExprId LowLevelILFunction::FloatCompareLessEqual(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc)
+ExprId LowLevelILFunction::FloatCompareLessEqual(size_t size, ExprId a, ExprId b, uint32_t flags, const ILSourceLocation& loc)
 {
-	return AddExprWithLocation(LLIL_FCMP_LE, loc, size, 0, a, b);
+	return AddExprWithLocation(LLIL_FCMP_LE, loc, size, flags, a, b);
 }
 
 
-ExprId LowLevelILFunction::FloatCompareGreaterEqual(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc)
+ExprId LowLevelILFunction::FloatCompareGreaterEqual(size_t size, ExprId a, ExprId b, uint32_t flags, const ILSourceLocation& loc)
 {
-	return AddExprWithLocation(LLIL_FCMP_GE, loc, size, 0, a, b);
+	return AddExprWithLocation(LLIL_FCMP_GE, loc, size, flags, a, b);
 }
 
 
-ExprId LowLevelILFunction::FloatCompareGreaterThan(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc)
+ExprId LowLevelILFunction::FloatCompareGreaterThan(size_t size, ExprId a, ExprId b, uint32_t flags, const ILSourceLocation& loc)
 {
-	return AddExprWithLocation(LLIL_FCMP_GT, loc, size, 0, a, b);
+	return AddExprWithLocation(LLIL_FCMP_GT, loc, size, flags, a, b);
 }
 
 
-ExprId LowLevelILFunction::FloatCompareOrdered(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc)
+ExprId LowLevelILFunction::FloatCompareOrdered(size_t size, ExprId a, ExprId b, uint32_t flags, const ILSourceLocation& loc)
 {
-	return AddExprWithLocation(LLIL_FCMP_O, loc, size, 0, a, b);
+	return AddExprWithLocation(LLIL_FCMP_O, loc, size, flags, a, b);
 }
 
 
-ExprId LowLevelILFunction::FloatCompareUnordered(size_t size, ExprId a, ExprId b, const ILSourceLocation& loc)
+ExprId LowLevelILFunction::FloatCompareUnordered(size_t size, ExprId a, ExprId b, uint32_t flags, const ILSourceLocation& loc)
 {
-	return AddExprWithLocation(LLIL_FCMP_UO, loc, size, 0, a, b);
+	return AddExprWithLocation(LLIL_FCMP_UO, loc, size, flags, a, b);
 }


### PR DESCRIPTION
Hey!

I've been doing some work on the x86 Architecture module, notably on the flag lifting. I need to be able to specify some flag writes for FP comparison instructions in order to modify [this PR](https://github.com/Vector35/arch-x86/pull/26) as [suggested](https://github.com/Vector35/arch-x86/pull/26#issuecomment-1042043593) by @rssor.

Instead of directly lifting the flags for `UCOMISD` and al. [as done originally in the PR](https://github.com/Vector35/arch-x86/pull/26/commits/601706549ea142dcad596b208821cd34e83adc0d), @rssor suggested to use the `GetFlagWriteLowLevelIL` and use `IL_FLAGWRITE_ALL` in an instruction without side effect. A good candidate would be to try with `LLIL_FCMP_UO`.

And in order to do so, I need to be able to specify the flags writes for these IL instructions :)