### PR TITLE
Have SymbolMapping get() method act like dictionary

### DIFF
--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -1492,11 +1492,11 @@ class SymbolMapping(collections.abc.Mapping):  # type: ignore
 		assert self._symbol_cache is not None
 		return self._symbol_cache.values()
 
-	def get(self, value):
+	def get(self, value, default = None):
 		try:
 			return self[value]
 		except KeyError:
-			return None
+			return default
 
 
 class TypeMapping(collections.abc.Mapping):  # type: ignore


### PR DESCRIPTION
arguably the default should be an empty list but this makes the function act more like a dictionary