### PR TITLE
Implement .tokens property in HLIL.

### DIFF
--- a/python/highlevelil.py
+++ b/python/highlevelil.py
@@ -44,6 +44,7 @@ from .commonil import (
     Loop, ControlFlow, Memory, Constant, Arithmetic, DoublePrecision, Terminal, FloatingPoint, Intrinsic, Return
 )
 
+TokenList = List['function.InstructionTextToken']
 LinesType = Generator['function.DisassemblyTextLine', None, None]
 ExpressionIndex = NewType('ExpressionIndex', int)
 InstructionIndex = NewType('InstructionIndex', int)
@@ -364,6 +365,11 @@ class HighLevelILInstruction(BaseILInstruction):
 
 	def __hash__(self):
 		return hash((self.function, self.expr_index))
+
+	@property
+	def tokens(self) -> TokenList:
+		"""HLIL tokens taken from the HLIL text lines(read-only)"""
+		return [token for line in self.lines for token in line.tokens]
 
 	@property
 	def lines(self) -> LinesType:


### PR DESCRIPTION
## Problem: 

The HighLevelILInstruction class does not have the `.tokens` property. This is inconsistent with functionality in LLIL and MLIL Instructions. HLILInstruction does have `.lines`, which is probably sufficient in most cases and is necessary as each HighLevelILInstruction can have multiple lines of tokens associated with it. 

However, this inconsistency requires that script managers handle LLIL/MLIL differently than HLIL Instructions. This PR addresses the inconsistency. 

## Proposed Solution

Offer the `.tokens` property which simply flattens the generator returned from `.lines` and returns a list of InstructionTextTokens.

## Depiction

Basically turns an instruction with multiple lines in `.lines`:
```
  63 @ 00404988  while (rdx#6 = ϕ(rdx#1, rdx#7)
  63 @ 00404988  rsi#3 = ϕ(rsi#2, rsi#4)
  63 @ 00404988  r8_2#3 = ϕ(r8_2#2, r8_2#4)
  63 @ 00404988  r9_1#3 = ϕ(r9_1#2, r9_1#4)
  63 @ 00404988  r10_1#2 = ϕ(r10_1#0, r10_1#3)
  63 @ 00404988  mem#8 = ϕ(mem#7, mem#9)
  63 @ 00404988  , true)
```
 into one line:

![oneline](https://user-images.githubusercontent.com/7316170/171864151-1e0e49c2-3e65-4a04-b786-aa36d5f26c59.png)