### PR TITLE
Rust: Fix compilation error when compiling with the 'rayon' feature enabled

### DIFF
--- a/rust/src/rc.rs
+++ b/rust/src/rc.rs
@@ -363,7 +363,7 @@ use rayon::iter::plumbing::*;
 #[cfg(feature = "rayon")]
 impl<'a, P> Array<P>
 where
-    P: 'a + CoreArrayWrapper<'a>,
+    P: 'a + CoreArrayWrapper<'a> + CoreOwnedArrayProvider,
     P::Context: Sync,
     P::Wrapped: Send,
 {


### PR DESCRIPTION
Hi!

There seem to be an issue when compiling the Rust bindings from `dev` with the `rayon` feature enabled.  
Any attempt to compile a plugin will generate the following error:
```
error[E0277]: the trait bound `P: rc::CoreOwnedArrayProvider` is not satisfied
   --> C:\Users\user\.cargo\git\checkouts\binaryninja-api-3c86176688a74ccb\33d2cf8\rust\src\rc.rs:364:13
    |
364 | impl<'a, P> Array<P>
    |             ^^^^^^^^ the trait `rc::CoreOwnedArrayProvider` is not implemented for `P`
    |
note: required by a bound in `rc::Array`
   --> C:\Users\user\.cargo\git\checkouts\binaryninja-api-3c86176688a74ccb\33d2cf8\rust\src\rc.rs:168:21
    |
168 | pub struct Array<P: CoreOwnedArrayProvider> {
    |                     ^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `rc::Array`
help: consider further restricting this bound
    |
366 |     P: 'a + CoreArrayWrapper<'a> + rc::CoreOwnedArrayProvider,
    |                                  ++++++++++++++++++++++++++++
```

This PR fixes the issue by applying the suggestion given by the compiler.