### PR TITLE
Implement .is_thunk property for HLILFunction.

### DIFF
--- a/python/highlevelil.py
+++ b/python/highlevelil.py
@@ -2525,6 +2525,18 @@ class HighLevelILFunction:
 		core.BNFreeILInstructionList(uses)
 		return result
 
+	@property
+	def is_thunk(self) -> bool:
+		"""Return True if the function is a thunk, else False. (read-only)"""
+		instructions = self.instructions
+		try:
+			for _ in range(0, 2):
+				instruction = next(instructions)
+				if isinstance(instruction, Tailcall):
+					return True
+		except StopIteration:
+			pass
+		return False
 
 class HighLevelILBasicBlock(basicblock.BasicBlock):
 	"""


### PR DESCRIPTION
## Problem

There is not currently a way for a developer to query whether or not a HighLevelILFunction is a thunk from within the object itself. This is especially useful when writing snippets that operate on all functions within a BinaryView, but where thunks are not needed.

## Solution

Implement the `is_thunk` property that looks at the first two instructions of a HighLevelILFunction. If one of those instructions is a Tailcall, we can confidently say the function is a thunk. I have not observed a case where this does not hold for HighLevelILFunctions but additional testing may be necessary.