### PR TITLE
Removed -v; now autodetects an active venv

### DIFF
--- a/scripts/install_api.py
+++ b/scripts/install_api.py
@@ -25,8 +25,9 @@ INTERACTIVE = True
 if '-s' in sys.argv[1:]:
 	INTERACTIVE = False
 
+# Autodetect venv
 INSTALL_VENV = False
-if '-v' in sys.argv[1:]:
+if sys.prefix == sys.base_prefix:
 	if os.environ.get('VIRTUAL_ENV'):
 		INSTALL_VENV = True
 	else:


### PR DESCRIPTION
Removed the virtualenv flag (-v) and added a prefix/base_prefix comparison to autodetect an active virtualenv. 