### PR TITLE
Fix prefix comparison logic for virtual environment detection

### DIFF
--- a/scripts/install_api.py
+++ b/scripts/install_api.py
@@ -27,7 +27,7 @@ if '-s' in sys.argv[1:]:
 
 # Autodetect venv
 INSTALL_VENV = False
-if sys.prefix == sys.base_prefix:
+if sys.prefix != sys.base_prefix:
 	if os.environ.get('VIRTUAL_ENV'):
 		INSTALL_VENV = True
 


### PR DESCRIPTION
According to this[^1], if we are in virtual environment, `sys.base_prefix` and `sys.prefix` should be different.

Test:
```
> python3 -c 'import sys; print(sys.prefix); print(sys.base_prefix)'
/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9
/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9

> source venv/bin/activate  

(venv) > python3 -c 'import sys; print(sys.prefix); print(sys.base_prefix)'
/Users/d0now/Library/Application Support/Binary Ninja/snippets/venv
/usr/local/opt/python@3.9/Frameworks/Python.framework/Versions/3.9

(venv) > python3 /Applications/Binary\ Ninja.app/Contents/Resources/scripts/install_api.py
Found install folder of /Applications/Binary Ninja.app/Contents/Resources/python
Found Binary Ninja core version: 3.1.3558-dev
Binary Ninja API installed using /Users/d0now/Library/Application Support/Binary Ninja/snippets/venv/lib/python3.9/site-packages/binaryninja.pth
```

[^1]: https://stackoverflow[.]com/questions/1871549/determine-if-python-is-running-inside-virtualenv