### PR TITLE
Fix bninspect on documented properties

### DIFF
--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -6150,7 +6150,7 @@ class BinaryView:
 		``get_linear_disassembly`` gets an iterator for all lines in the linear disassembly of the view for the given
 		disassembly settings.
 
-		.. note:: linear_disassembly doesn't just return disassembly it will return a single line from the linear view,\
+		.. note:: linear_disassembly doesn't just return disassembly; it will return a single line from the linear view,\
 		 and thus will contain both data views, and disassembly.
 
 		:param DisassemblySettings settings: instance specifying the desired output formatting. Defaults to None which will use default settings.

--- a/python/scriptingprovider.py
+++ b/python/scriptingprovider.py
@@ -577,8 +577,7 @@ def bninspect(code_, globals_, locals_):
 		value = eval(code_, globals_, locals_)
 
 		try:
-			if not hasattr(value, "__qualname__"):
-				# It was called on something that isn't a method type
+			if not (inspect.ismethod(value) or inspect.isclass(value)):
 				if isinstance(code_, bytes):
 					code_ = code_.decode("utf-8")
 				class_type_str = code_.split(".")[:-1]


### PR DESCRIPTION
This fixes #3246 . 

How: 
* check whether the value we're trying to get docstrings from is a problematic type (non-class (not non-class-instance, but non-class-object) or non-method)
* Call `type(blah)` on everything before the property, then re-append the `.property` and re-eval. 
* This will work even on method types, but we try to be safe and fall back to the original behavior where we know it worked.

![image](https://user-images.githubusercontent.com/55725881/179372342-7103c994-da0b-4944-ac0b-8d9ac849636b.png)

Here:
`bv.length` is an undocumented `@property` and returns a primitive. It will print `int.__doc__` as it did before
`bv.functions` is a documented `@property` that returns a Class. It will print the docstring for the property function
`bv.types` is an undocumented `@property` that returns a documented Class. It will print the class docs
`bv.mlil_functions` is a documented function that already worked; It falls back to the original behavior as intended.
`current_function.start` is a documented `@property` that returns a primitive. It will print the property function docs.