### PR TITLE
Implement .is_thunk in LLILFunction.

### DIFF
--- a/python/function.py
+++ b/python/function.py
@@ -567,6 +567,14 @@ class Function:
 		return BasicBlockList(self)
 
 	@property
+	def is_thunk(self) -> bool:
+		"""Returns True if the function starts with a Tailcall (read-only)"""
+		if self.llil_if_available is not None:
+			return self.llil_if_available.is_thunk
+		else:
+			return False
+
+	@property
 	def comments(self) -> Dict[int, str]:
 		"""Dict of comments (read-only)"""
 		count = ctypes.c_ulonglong()

--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -2858,6 +2858,20 @@ class LowLevelILFunction:
 			core.BNFreeLLILVariablesList(registers)
 
 	@property
+	def is_thunk(self) -> bool:
+		"""Returns True if the function starts with a Tailcall (read-only)"""
+		depth = 5
+		instructions = self.instructions
+		try:
+			for _ in range(0, depth):
+				instruction = next(instructions)
+				if isinstance(instruction, Tailcall):
+					return True
+		except StopIteration:
+			pass
+		return False
+
+	@property
 	def register_stacks(self) -> List[ILRegisterStack]:
 		""" List of register stacks used in this IL """
 		count = ctypes.c_ulonglong()


### PR DESCRIPTION
## Problem

There is not currently a way to check whether or not a function is a thunk.

## Solution

I think, ideally, this would be exposed from the core. However, I think think it is valid to check whether or not a Tailcall occurs within X amount of LLIL expressions in the function. From testing with different architectures, I found this number to be five LLIL expressions. I implemented this in both the LLILFunction and Function classes. 

## Related

See PR #3212