### PR TITLE
Windows/MSVC: Avoid compiler warning if `NOMINMAX` is already set

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -20,7 +20,9 @@
 
 #pragma once
 #ifdef WIN32
+#ifndef NOMINMAX
 	#define NOMINMAX
+#endif
 	#include <windows.h>
 #endif
 #include <stddef.h>


### PR DESCRIPTION
In BinExport, we already set `NOMINMAX` prior to including `binaryninjaapi.h`, so with MSVC we always get
a `warning C4005: 'NOMINMAX': macro redefinition` message.
Let's check in the header whether the macro is already defined, so that people do not have to disable warnings.

As an aside: Is there any reason `binaryninjaapi.h` needs to include `windows.h` in the first place?