### PR TITLE
Include C++ standard headers

### DIFF
--- a/architecture.cpp
+++ b/architecture.cpp
@@ -19,7 +19,7 @@
 // IN THE SOFTWARE.
 
 #define _CRT_SECURE_NO_WARNINGS
-#include <stdio.h>
+#include <cstdio>
 #include <cstdint>
 #include <inttypes.h>
 #include <vector>

--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -23,7 +23,7 @@
 	#define NOMINMAX
 	#include <windows.h>
 #endif
-#include <stddef.h>
+#include <cstddef>
 #include <string>
 #include <vector>
 #include <map>

--- a/examples/breakpoint/src/breakpoint.cpp
+++ b/examples/breakpoint/src/breakpoint.cpp
@@ -1,4 +1,4 @@
-#include <inttypes.h>
+#include <cinttypes>
 #include "binaryninjaapi.h"
 
 using namespace BinaryNinja;

--- a/examples/cmdline_disasm/src/disasm.cpp
+++ b/examples/cmdline_disasm/src/disasm.cpp
@@ -1,7 +1,7 @@
-#include <stdio.h>
-#include <stdlib.h>
-#include <stdint.h>
-#include <stdbool.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <cstdbool>
 
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/examples/llil_parser/src/llil_parser.cpp
+++ b/examples/llil_parser/src/llil_parser.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
-#include <inttypes.h>
+#include <cstdio>
+#include <cinttypes>
 #include "binaryninjacore.h"
 #include "binaryninjaapi.h"
 #include "lowlevelilinstruction.h"

--- a/examples/mlil_parser/src/mlil_parser.cpp
+++ b/examples/mlil_parser/src/mlil_parser.cpp
@@ -1,5 +1,5 @@
-#include <stdio.h>
-#include <inttypes.h>
+#include <cstdio>
+#include <cinttypes>
 #include "binaryninjacore.h"
 #include "binaryninjaapi.h"
 #include "mediumlevelilinstruction.h"

--- a/examples/triage/headers.cpp
+++ b/examples/triage/headers.cpp
@@ -1,4 +1,4 @@
-#include <string.h>
+#include <cstring>
 #include <time.h>
 #include "headers.h"
 #include "fontsettings.h"

--- a/examples/triage/imports.cpp
+++ b/examples/triage/imports.cpp
@@ -1,4 +1,4 @@
-#include <string.h>
+#include <cstring>
 #include <algorithm>
 #include "imports.h"
 #include "view.h"

--- a/examples/workflows/inliner/inliner.cpp
+++ b/examples/workflows/inliner/inliner.cpp
@@ -1,5 +1,4 @@
 #define _CRT_SECURE_NO_WARNINGS
-#define NOMINMAX
 
 #include <cinttypes>
 #include <cstdint>

--- a/examples/workflows/tailcall/tailcall.cpp
+++ b/examples/workflows/tailcall/tailcall.cpp
@@ -1,5 +1,4 @@
 #define _CRT_SECURE_NO_WARNINGS
-#define NOMINMAX
 
 #include <cinttypes>
 #include <cstdint>

--- a/examples/x86_extension/src/x86_extension.cpp
+++ b/examples/x86_extension/src/x86_extension.cpp
@@ -1,7 +1,7 @@
 #define _CRT_SECURE_NO_WARNINGS
-#include <inttypes.h>
-#include <stdio.h>
-#include <string.h>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
 #include "binaryninjaapi.h"
 #include "asmx86/asmx86.h"
 

--- a/http.cpp
+++ b/http.cpp
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-#include <string.h>
+#include <cstring>
 #include <chrono>
 #include <thread>
 #include <math.h>

--- a/http.h
+++ b/http.h
@@ -26,7 +26,7 @@
 #include <unordered_map>
 #include <functional>
 #include <utility>
-#include <stdint.h>
+#include <cstdint>
 
 #ifdef BINARYNINJACORE_LIBRARY
 	#include "downloadprovider.h"

--- a/interaction.cpp
+++ b/interaction.cpp
@@ -1,5 +1,5 @@
-#include <stdlib.h>
-#include <string.h>
+#include <cstdlib>
+#include <cstring>
 #include "binaryninjaapi.h"
 
 using namespace std;

--- a/log.cpp
+++ b/log.cpp
@@ -19,8 +19,8 @@
 // IN THE SOFTWARE.
 
 #define _CRT_SECURE_NO_WARNINGS
-#include <stdarg.h>
-#include <stdio.h>
+#include <cstdarg>
+#include <cstdio>
 #include <thread>
 #include "binaryninjaapi.h"
 

--- a/lowlevelilinstruction.cpp
+++ b/lowlevelilinstruction.cpp
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-#include <string.h>
+#include <cstring>
 #ifdef BINARYNINJACORE_LIBRARY
 	#include "lowlevelilfunction.h"
 	#include "lowlevelilssafunction.h"

--- a/mediumlevelilinstruction.cpp
+++ b/mediumlevelilinstruction.cpp
@@ -18,7 +18,7 @@
 // FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 // IN THE SOFTWARE.
 
-#include <string.h>
+#include <cstring>
 #ifdef BINARYNINJACORE_LIBRARY
 	#include "mediumlevelilfunction.h"
 	#include "mediumlevelilssafunction.h"

--- a/secretsprovider.cpp
+++ b/secretsprovider.cpp
@@ -19,7 +19,7 @@
 // IN THE SOFTWARE.
 
 #include "binaryninjaapi.h"
-#include <string.h>
+#include <cstring>
 
 using namespace BinaryNinja;
 

--- a/settings.cpp
+++ b/settings.cpp
@@ -1,6 +1,5 @@
 #include "binaryninjaapi.h"
-#include "json/json.h"
-#include <string.h>
+#include <cstring>
 
 using namespace BinaryNinja;
 using namespace std;

--- a/type.cpp
+++ b/type.cpp
@@ -19,7 +19,7 @@
 // IN THE SOFTWARE.
 
 #include "binaryninjaapi.h"
-#include <inttypes.h>
+#include <cinttypes>
 
 using namespace BinaryNinja;
 using namespace std;


### PR DESCRIPTION
When compiling in C++ mode, the C++ standard library headers should be included instead of their C counterparts.

Drive-by:
- Removed include of `json/json.h` from `settings.cpp`, where it was not used