### PR TITLE
Introduce a macro to implement `printf` attribute

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -491,9 +491,7 @@ namespace BinaryNinja {
 	    \param fmt C-style format string.
 	    \param ... Variable arguments corresponding to the format string.
 	*/
-#ifdef __GNUC__
-	__attribute__((format(printf, 2, 3)))
-#endif
+	BN_PRINTF_ATTRIBUTE(2, 3)
 	void Log(BNLogLevel level, const char* fmt, ...);
 
 	/*! LogTrace only writes text to the error console if the console is set to log level: DebugLog
@@ -504,9 +502,7 @@ namespace BinaryNinja {
 	    \param fmt C-style format string.
 	    \param ... Variable arguments corresponding to the format string.
 	*/
-#ifdef __GNUC__
-	__attribute__((format(printf, 1, 2)))
-#endif
+	BN_PRINTF_ATTRIBUTE(1, 2)
 	void LogTrace(const char* fmt, ...);
 
 
@@ -518,9 +514,7 @@ namespace BinaryNinja {
 	    \param fmt C-style format string.
 	    \param ... Variable arguments corresponding to the format string.
 	*/
-#ifdef __GNUC__
-	__attribute__((format(printf, 1, 2)))
-#endif
+	BN_PRINTF_ATTRIBUTE(1, 2)
 	void LogDebug(const char* fmt, ...);
 
 	/*! LogInfo always writes text to the error console, and corresponds to the log level: InfoLog.
@@ -531,9 +525,7 @@ namespace BinaryNinja {
 	    \param fmt C-style format string.
 	    \param ... Variable arguments corresponding to the format string.
 	*/
-#ifdef __GNUC__
-	__attribute__((format(printf, 1, 2)))
-#endif
+	BN_PRINTF_ATTRIBUTE(1, 2)
 	void LogInfo(const char* fmt, ...);
 
 	/*! LogWarn writes text to the error console including a warning icon,
@@ -544,9 +536,7 @@ namespace BinaryNinja {
 	    \param fmt C-style format string.
 	    \param ... Variable arguments corresponding to the format string.
 	*/
-#ifdef __GNUC__
-	__attribute__((format(printf, 1, 2)))
-#endif
+	BN_PRINTF_ATTRIBUTE(1, 2)
 	void LogWarn(const char* fmt, ...);
 
 	/*! LogError writes text to the error console and pops up the error console. Additionall,
@@ -557,9 +547,7 @@ namespace BinaryNinja {
 	    \param fmt C-style format string.
 	    \param ... Variable arguments corresponding to the format string.
 	*/
-#ifdef __GNUC__
-	__attribute__((format(printf, 1, 2)))
-#endif
+	BN_PRINTF_ATTRIBUTE(1, 2)
 	void LogError(const char* fmt, ...);
 
 	/*! LogAlert pops up a message box displaying the alert message and logs to the error console.
@@ -570,9 +558,7 @@ namespace BinaryNinja {
 	    \param fmt C-style format string.
 	    \param ... Variable arguments corresponding to the format string.
 	*/
-#ifdef __GNUC__
-	__attribute__((format(printf, 1, 2)))
-#endif
+	BN_PRINTF_ATTRIBUTE(1, 2)
 	void LogAlert(const char* fmt, ...);
 
 	/*! Redirects the minimum level passed to standard out

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -141,6 +141,20 @@
 #endif
 
 
+#ifdef __has_attribute
+	#define BN_HAVE_ATTRIBUTE(x) __has_attribute(x)
+#else
+	#define BN_HAVE_ATTRIBUTE(x) 0
+#endif
+
+#if BN_HAVE_ATTRIBUTE(format) || (defined(__GNUC__) && !defined(__clang__))
+	#define BN_PRINTF_ATTRIBUTE(string_index, first_to_check) \
+		__attribute__((format(__printf__, string_index, first_to_check)))
+#else
+	#define BN_PRINTF_ATTRIBUTE(string_index, first_to_check)
+#endif
+
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -2977,51 +2991,33 @@ extern "C"
 	BINARYNINJACOREAPI void BNAddOptionalPluginDependency(const char* name);
 
 	// Logging
-#ifdef __GNUC__
-	__attribute__((format(printf, 5, 6)))
-#endif
-	BINARYNINJACOREAPI void
-	    BNLog(size_t session, BNLogLevel level, const char* logger_name, size_t tid, const char* fmt, ...);
+	BN_PRINTF_ATTRIBUTE(5, 6)
+	BINARYNINJACOREAPI void BNLog(
+		size_t session, BNLogLevel level, const char* logger_name, size_t tid, const char* fmt, ...);
 
-#ifdef __GNUC__
-	__attribute__((format(printf, 1, 2)))
-#endif
-	BINARYNINJACOREAPI void
-	    BNLogDebug(const char* fmt, ...);
+	BN_PRINTF_ATTRIBUTE(1, 2)
+	BINARYNINJACOREAPI void BNLogDebug(const char* fmt, ...);
 
-#ifdef __GNUC__
-	__attribute__((format(printf, 1, 2)))
-#endif
-	BINARYNINJACOREAPI void
-	    BNLogInfo(const char* fmt, ...);
+	BN_PRINTF_ATTRIBUTE(1, 2)
+	BINARYNINJACOREAPI void BNLogInfo(const char* fmt, ...);
 
-#ifdef __GNUC__
-	__attribute__((format(printf, 1, 2)))
-#endif
-	BINARYNINJACOREAPI void
-	    BNLogWarn(const char* fmt, ...);
+	BN_PRINTF_ATTRIBUTE(1, 2)
+	BINARYNINJACOREAPI void BNLogWarn(const char* fmt, ...);
 
-#ifdef __GNUC__
-	__attribute__((format(printf, 1, 2)))
-#endif
-	BINARYNINJACOREAPI void
-	    BNLogError(const char* fmt, ...);
+	BN_PRINTF_ATTRIBUTE(1, 2)
+	BINARYNINJACOREAPI void BNLogError(const char* fmt, ...);
 
-#ifdef __GNUC__
-	__attribute__((format(printf, 1, 2)))
-#endif
-	BINARYNINJACOREAPI void
-	    BNLogAlert(const char* fmt, ...);
+	BN_PRINTF_ATTRIBUTE(1, 2)
+	BINARYNINJACOREAPI void BNLogAlert(const char* fmt, ...);
 
-	BINARYNINJACOREAPI void BNLogString(size_t session, BNLogLevel level, const char* logger_name, size_t tid, const char* str);
+	BINARYNINJACOREAPI void BNLogString(
+		size_t session, BNLogLevel level, const char* logger_name, size_t tid, const char* str);
 
 
 	BINARYNINJACOREAPI BNLogger* BNNewLoggerReference(BNLogger* logger);
 	BINARYNINJACOREAPI void BNFreeLogger(BNLogger* logger);
 
-#ifdef __GNUC__
-	__attribute__((format(printf, 3, 4)))
-#endif
+	BN_PRINTF_ATTRIBUTE(3, 4)
 	BINARYNINJACOREAPI void BNLoggerLog(BNLogger* logger, BNLogLevel level, const char* fmt, ...);
 	BINARYNINJACOREAPI void BNLoggerLogString(BNLogger* logger, BNLogLevel level, const char* msg);
 


### PR DESCRIPTION
This lets us remove a lot of `#ifdef __GNUC__` in function declarations, which makes them more readable.