### PR TITLE
Bring BinaryReader.seek more in line with File

### DIFF
--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -8232,11 +8232,12 @@ class BinaryReader:
 			return None
 		return struct.unpack(">Q", result)[0]
 
-	def seek(self, offset: int) -> None:
+	def seek(self, offset: int, whence: int = 0) -> None:
 		"""
 		``seek`` update internal offset to ``offset``.
 
 		:param int offset: offset to set the internal offset to
+		:param int whence: optional, defaults to 0 for absolute file positioning, or 1 for relative to current location
 		:rtype: None
 		:Example:
 
@@ -8247,6 +8248,9 @@ class BinaryReader:
 			'0x100000000L'
 			>>>
 		"""
+		if whence:
+			self.seek_relative(offset)
+			return
 		core.BNSeekBinaryReader(self._handle, offset)
 
 	def seek_relative(self, offset: int) -> None:

--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -8232,7 +8232,7 @@ class BinaryReader:
 			return None
 		return struct.unpack(">Q", result)[0]
 
-	def seek(self, offset: int, whence: int = 0) -> None:
+	def seek(self, offset: int, whence: Optional[int] = 0) -> None:
 		"""
 		``seek`` update internal offset to ``offset``.
 


### PR DESCRIPTION
Adds a `whence` parameter to BinaryReader.seek which behaves similarly to FileObjects seek method, but defaults to 0, keeping backwards compatibility.