### PR TITLE
Change type from array->string.

### DIFF
--- a/python/settings.py
+++ b/python/settings.py
@@ -65,8 +65,8 @@ class Settings:
 		"title"              string                                   None                 No         Concise Setting Title
 		"type"               string                                   None                 No         {"array", "boolean", "number", "string"}
 		"elementType"        string                                   "type" is "array"    No         {"string"}
-		"enum"               array : {string}                         "type" is "array"    Yes        Enumeration definitions
-		"enumDescriptions"   array : {string}                         "type" is "array"    Yes        Enumeration descriptions that match "enum" array
+		"enum"               array : {string}                         "type" is "string"   Yes        Enumeration definitions
+		"enumDescriptions"   array : {string}                         "type" is "string"   Yes        Enumeration descriptions that match "enum" array
 		"minValue"           number                                   "type" is "number"   Yes        Specify 0 to infer unsigned (default is signed)
 		"maxValue"           number                                   "type" is "number"   Yes        Values less than or equal to INT_MAX result in a QSpinBox UI element
 		"precision"          number                                   "type" is "number"   Yes        Specify precision for a QDoubleSpinBox


### PR DESCRIPTION
`enum` seems to be the list of strings that are possible values for the `string` type. When the type is set to `array` and `enum` is present, Settings fails to load. Additionally, I could not find any examples of Settings where the type is set `array` and `enum` is added.

I confirmed that the list of strings defined in `enum` populate a drop down list when the `type` is set to `string`. For reference, check out the example at [openai-binaryninja](https://github.com/WhatTheFuzz/binaryninja-openai/blob/main/src/settings.py#L45-L55).