### PR TITLE
Refactoring 'install_api.py'

### DIFF
--- a/scripts/install_api.py
+++ b/scripts/install_api.py
@@ -1,133 +1,200 @@
 #!/usr/bin/env python3
-#
-#    Thanks to @withzombies for letting us adapt his script
-#
 
 import importlib.util
 import os
 import sys
 from site import check_enableusersite
+from typing import Optional
 
 if sys.version_info[0] < 3:
-	print("Python 3 required")
-	sys.exit(1)
+    sys.stderr.print("Python 3 is required.")
+    sys.exit(1)
 
 # Handle both normal environments and virtualenvs
 try:
-	from site import getusersitepackages, getsitepackages
+    from site import getusersitepackages, getsitepackages
 except ImportError:
-	from sysconfig import get_path
-	getsitepackages = lambda: get_path('purelib')
-	getusersitepackages = getsitepackages
-
-# Hacky command line parsing to accept a silent-install -s flag like linux-setup.sh:
-INTERACTIVE = True
-if '-s' in sys.argv[1:]:
-	INTERACTIVE = False
-
-# Autodetect venv
-INSTALL_VENV = False
-if sys.prefix != sys.base_prefix:
-	if os.environ.get('VIRTUAL_ENV'):
-		INSTALL_VENV = True
-
-try:
-	binaryninja = importlib.util.find_spec('binaryninja')
-	assert binaryninja is not None
-	binaryninjaui = importlib.util.find_spec('binaryninjaui')
-	assert binaryninjaui is not None
-
-	if '-u' in sys.argv[1:]:
-		#Uninstall mode
-		userpth = os.path.join(getusersitepackages(), 'binaryninja.pth')
-		if os.path.exists(userpth):
-			print(f"Removing {userpth}")
-			os.unlink(userpth)
-		sitepth = os.path.join(getsitepackages()[0], 'binaryninja.pth')
-		if os.path.exists(sitepth):
-			print(f"Removing {sitepth}")
-			try:
-				os.unlink(sitepth)
-			except:
-				print("Unable to unlink, please re-run with appropriate permissions.")
-		sys.exit(0)
-	print("Binary Ninja API already in the path")
-	sys.exit(1)
-except ModuleNotFoundError:
-	pass
-except AssertionError:
-	pass
-
-if '-u' in sys.argv[1:]:
-	print("Uninstall specified, but binaryninja not in the current path")
-	sys.exit(1)
-
-dir_name = os.path.dirname(os.path.abspath(__file__))
-api_path = os.path.abspath(os.path.join(dir_name, "..", "python"))
-
-if (os.path.isdir(api_path)):
-	print(f"Found install folder of {api_path}")
-else:
-	print("Failed to find installed python expected at {}".format(api_path))
-	sys.exit(1)
+    from sysconfig import get_path
+    getsitepackages = lambda: get_path("purelib")
+    getusersitepackages = getsitepackages
 
 
-def validate_path(path):
-	try:
-		os.stat(path)
-	except OSError:
-		return False
-
-	old_path = sys.path
-	sys.path.append(path)
-
-	try:
-		from binaryninja import core_version
-		print("Found Binary Ninja core version: {}".format(core_version()))
-	except ImportError:
-		sys.path = old_path
-		return False
-
-	return True
+def print_error(*args, file=None, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
 
 
-while not validate_path(api_path):
-	print("\nBinary Ninja not found.")
-	if not INTERACTIVE:
-		print("Non-interactive mode selected, failing.")
-		sys.exit(-1)
+def check_virtual_environment() -> bool:
+    if sys.prefix != sys.base_prefix:
+        if os.environ.get("VIRTUAL_ENV"):
+            return True
+    return False
 
-	print("Please provide the path to Binary Ninja's install directory: \n [{}] : ".format(api_path))
-	new_path = sys.stdin.readline().strip()
-	if len(new_path) == 0:
-		print("\nInvalid path")
-		continue
 
-	if not new_path.endswith('python'):
-		new_path = os.path.join(new_path, 'python')
+def binaryninja_installed() -> bool:
+    try:
+        binaryninja = importlib.util.find_spec("binaryninja")
+        assert binaryninja is not None
+        binaryninjaui = importlib.util.find_spec("binaryninjaui")
+        assert binaryninjaui is not None
+        return True
+    except ModuleNotFoundError:
+        return False
+    except AssertionError:
+        return False
 
-	api_path = new_path
 
-if (len(sys.argv) > 1 and sys.argv[1].lower() == "root"):
-	#write to root site
-	install_path = getsitepackages()[0]
-	if not os.access(install_path, os.W_OK):
-		print("Root install specified but cannot write to {}".format(install_path))
-		sys.exit(1)
-elif INSTALL_VENV:
-	install_path = getsitepackages()[0]
-else:
-	if check_enableusersite():
-		install_path = getusersitepackages()
-		if not os.path.exists(install_path):
-			os.makedirs(install_path)
-	else:
-		print("Warning, trying to write to user site packages, but check_enableusersite fails.")
-		sys.exit(1)
+def get_binaryninja_installed_directory() -> Optional[str]:
+    dir_name = os.path.dirname(os.path.abspath(__file__))
+    api_path = os.path.abspath(os.path.join(dir_name, "..", "python"))
+    if os.path.isdir(api_path):
+        return api_path
 
-binaryninja_pth_path = os.path.join(install_path, 'binaryninja.pth')
-with open(binaryninja_pth_path, 'wb') as pth_file:
-	pth_file.write((api_path + "\n").encode('charmap'))
-	pth_file.write((api_path + sys.version[0] + "\n").encode('charmap'))  #support for QT bindings
 
-print("Binary Ninja API installed using {}".format(binaryninja_pth_path))
+def validate_path(path: str) -> bool:
+
+    try:
+        os.stat(path)
+    except OSError:
+        return False
+
+    old_path = sys.path
+    sys.path.append(path)
+
+    try:
+        from binaryninja import core_version
+        print("Found Binary Ninja core version: {}".format(core_version()))
+    except ModuleNotFoundError as e:
+        sys.path = old_path
+        if e.name == "packaging" and sys.version_info.minor >= 10:
+            raise e
+        return False
+    except ImportError as e:
+        sys.path = old_path
+        return False
+
+    return True
+
+
+def install(interactive=False, on_root=False, on_pyenv=False) -> bool:
+
+    if binaryninja_installed():
+        print_error("Binary Ninja API already in the path.")
+        return False
+
+    api_path = get_binaryninja_installed_directory()
+    if not api_path:
+        print_error("Failed to find installed python expected at {}".format(api_path))
+        return False
+
+    print(f"Found install folder of {api_path}")
+
+    while not validate_path(api_path):
+        
+        print(f"Binary Ninja not found: {api_path}")
+        
+        if not interactive:
+            print_error("silent mode selected (-s, --silent), failing.")
+            return False
+
+        try:
+            new_path = input("Please provide the path to Binary Ninja's install directory: \n [{}] : ".format(api_path))
+        except KeyboardInterrupt:
+            print_error("KeyboardInterrupt detected.")
+            return False
+
+        if not new_path:
+            print("Invalid path.")
+            continue
+
+        if not new_path.endswith("python"):
+            os.path.join(new_path, "python")
+
+        api_path = new_path
+
+    if on_root:
+        install_path = getsitepackages()[0]
+        if not os.access(install_path, os.W_OK):
+            print_error(f"Root install specified but cannot write to {install_path}")
+            return False
+        else:
+            print(f"Installing on root site: {install_path}")
+    
+    elif on_pyenv:
+        install_path = getsitepackages()[0]
+        print(f"Installing on pyenv site: {install_path}")
+
+    elif check_virtual_environment():
+        install_path = getsitepackages()[0]
+        print(f"Installing on virtual environment site: {install_path}")
+
+    else:
+        if not check_enableusersite():
+            print_error("Warning, trying to write to user site packages, but check_enableusersite fails.")
+            return False
+        else:
+            install_path = getusersitepackages()
+            if not os.path.exists(install_path):
+                os.makedirs(install_path)
+            print(f"Installing on user site: {install_path}")
+
+    binaryninja_pth_path = os.path.join(install_path, "binaryninja.pth")
+    with open(binaryninja_pth_path, 'wb') as pth_file:
+        pth_file.write((api_path + '\n').encode("charmap"))
+        pth_file.write((api_path + sys.version[0] + '\n').encode("charmap")) # support for QT bindings
+
+    return True
+
+
+def uninstall() -> bool:
+
+    if not binaryninja_installed():
+        print_error("Uninstall specified, but binaryninja not in the current path.")
+        return False
+
+    user_path = os.path.join(getusersitepackages(), "binaryninja.pth")
+    site_path = os.path.join(getsitepackages()[0], "binaryninja.pth")
+
+    for path_to_unlink in [user_path, site_path]:
+
+        if not os.path.exists(path_to_unlink):
+            print_error(f"{path_to_unlink} not found.")
+            continue
+
+        print(f"Removing {path_to_unlink}...")
+        try:
+            os.unlink(path_to_unlink)
+        except OSError as e:
+            print_error(f"Unable to unlink, please re-run with appropriate permissions: {str(e)}")
+            return False
+
+    return True
+
+
+if __name__ == '__main__':
+
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-s", "--silent", action='store_true') 
+    parser.add_argument("-u", "--uninstall", action='store_true')
+    parser.add_argument("--install-on-root", action='store_true')
+    parser.add_argument("--install-on-pyenv", action='store_true')
+    args = parser.parse_args()
+
+    if args.uninstall:
+        uninstall_result = uninstall()
+        if not uninstall_result:
+            print(f"Binary Ninja API uninstallation failed.")
+            sys.exit(-1)
+        else:
+            print(f"Binary Ninja API uninstallation success.")
+    else:
+        install_result = install(
+            interactive=(not args.silent),
+            on_root=args.install_on_root,
+            on_pyenv=args.install_on_pyenv
+        )
+        if not install_result:
+            print(f"Binary Ninja API installation failed.")
+            sys.exit(-1)
+        else:
+            print(f"Binary Ninja API installation success.")

--- a/scripts/install_api.py
+++ b/scripts/install_api.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python3
+#
+#   Thanks to @withzombies for letting us adapt his script
+#
 
 import importlib.util
 import os
@@ -173,6 +176,7 @@ def uninstall() -> bool:
 if __name__ == '__main__':
 
     import argparse
+
     parser = argparse.ArgumentParser()
     parser.add_argument("-s", "--silent", action='store_true') 
     parser.add_argument("-u", "--uninstall", action='store_true')

--- a/scripts/install_api.py
+++ b/scripts/install_api.py
@@ -46,11 +46,10 @@ def binaryninja_installed() -> bool:
         return False
 
 
-def get_binaryninja_installed_directory() -> Optional[str]:
+def get_expected_binaryninja_installed_directory() -> Optional[str]:
     dir_name = os.path.dirname(os.path.abspath(__file__))
     api_path = os.path.abspath(os.path.join(dir_name, "..", "python"))
-    if os.path.isdir(api_path):
-        return api_path
+    return api_path
 
 
 def validate_path(path: str) -> bool:
@@ -84,8 +83,8 @@ def install(interactive=False, on_root=False, on_pyenv=False) -> bool:
         print_error("Binary Ninja API already in the path.")
         return False
 
-    api_path = get_binaryninja_installed_directory()
-    if not api_path:
+    api_path = get_expected_binaryninja_installed_directory()
+    if not os.path.isdir(api_path):
         print_error("Failed to find installed python expected at {}".format(api_path))
         return False
 


### PR DESCRIPTION
## Problem: Can't install API on `pyenv` virtual environment

I tried to install binaryninja-api to my pyenv virtual environment like this:
```
❯ pyenv virtualenv 3.9.13 binaryninja-api-install-test
Looking in links: /var/folders/8v/hhs8lgc91456tjwffn7_ky8c0000gn/T/tmpx2tpn9h0
Requirement already satisfied: setuptools in /Users/[username]/.pyenv/versions/3.9.13/envs/binaryninja-api-install-test/lib/python3.9/site-packages (58.1.0)
Requirement already satisfied: pip in /Users/[username]/.pyenv/versions/3.9.13/envs/binaryninja-api-install-test/lib/python3.9/site-packages (22.0.4)

❯ pyenv shell binaryninja-api-install-test

❯ pyenv version
binaryninja-api-install-test (set by PYENV_VERSION environment variable)

❯ python3 --version
Python 3.9.13

❯ python3 /Applications/Binary\ Ninja.app/Contents/Resources/scripts/install_api.py
Found install folder of /Applications/Binary Ninja.app/Contents/Resources/python

Binary Ninja not found.
Please provide the path to Binary Ninja's install directory:
 [/Applications/Binary Ninja.app/Contents/Resources/python] :
^CTraceback (most recent call last):
  File "/Applications/Binary Ninja.app/Contents/Resources/scripts/install_api.py", line 101, in <module>
    new_path = sys.stdin.readline().strip()
KeyboardInterrupt
```

This occurs when 'packaging' package is not installed on environment to me:
```❯ python3
Python 3.9.13 (main, Sep 29 2022, 20:57:57)
[Clang 14.0.0 (clang-1400.0.29.102)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import sys
>>> sys.path.append("/Applications/Binary Ninja.app/Contents/Resources/python")
>>> from binaryninja import core_version
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Applications/Binary Ninja.app/Contents/Resources/python/binaryninja/__init__.py", line 33, in <module>
    from .filemetadata import *
  File "/Applications/Binary Ninja.app/Contents/Resources/python/binaryninja/filemetadata.py", line 31, in <module>
    from . import binaryview
  File "/Applications/Binary Ninja.app/Contents/Resources/python/binaryninja/binaryview.py", line 48, in <module>
    from . import typelibrary
  File "/Applications/Binary Ninja.app/Contents/Resources/python/binaryninja/typelibrary.py", line 27, in <module>
    from . import types
  File "/Applications/Binary Ninja.app/Contents/Resources/python/binaryninja/types.py", line 34, in <module>
    from . import callingconvention
  File "/Applications/Binary Ninja.app/Contents/Resources/python/binaryninja/callingconvention.py", line 29, in <module>
    from . import function
  File "/Applications/Binary Ninja.app/Contents/Resources/python/binaryninja/function.py", line 36, in <module>
    from . import architecture
  File "/Applications/Binary Ninja.app/Contents/Resources/python/binaryninja/architecture.py", line 34, in <module>
    from . import lowlevelil
  File "/Applications/Binary Ninja.app/Contents/Resources/python/binaryninja/lowlevelil.py", line 31, in <module>
    from . import mediumlevelil
  File "/Applications/Binary Ninja.app/Contents/Resources/python/binaryninja/mediumlevelil.py", line 34, in <module>
    from . import highlevelil
  File "/Applications/Binary Ninja.app/Contents/Resources/python/binaryninja/highlevelil.py", line 48, in <module>
    from . import deprecation
  File "/Applications/Binary Ninja.app/Contents/Resources/python/binaryninja/deprecation.py", line 17, in <module>
    from packaging import version
ModuleNotFoundError: No module named 'packaging'
```

This can fixable just by hit `pip install packaging` on my environment.

But there was another problem:
```
❯ python3 /Applications/Binary\ Ninja.app/Contents/Resources/scripts/install_api.py
Found install folder of /Applications/Binary Ninja.app/Contents/Resources/python
Found Binary Ninja core version: 3.3.3997-dev Enterprise
Binary Ninja API installed using /Users/[username]/Library/Python/3.9/lib/python/site-packages/binaryninja.pth

❯ pyenv which python3
/Users/dhkim/.pyenv/versions/binaryninja-api-install-test/bin/python3
```

As you can see above, installation script can't find appropriate install path. That's because pyenv's virtualenv doesn't use `VIRTUAL_ENV` env. (original code line 28 detects virtualenv by existance of `VIRTUAL_ENV`)

But after research, there were no any 'very good' solution for detecting pyenv's virtualenv, so I just decided to add simple flag and logics to force install.

Additionally, simply refactored with argparse.

## Changes:
- Add 'argparse' interface for command line parsing. (note: argparse is added in python 3.2) (L176~)
- Logics are refactored to function.
- Can install on pyenv's virtualenv too. (`--install-on-pyenv`, L125)