### PR TITLE
Fix rust headless BinaryView not loading correctly

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -231,7 +231,7 @@ pub fn open_view<F: AsRef<Path>>(filename: F) -> Result<rc::Ref<binaryview::Bina
     let bv = custombinaryview::BinaryViewType::list_valid_types_for(&view)
         .iter()
         .find_map(|available_view| {
-            if available_view.name().as_ref() == b"Raw" {
+            if available_view.name().as_str() == "Raw" {
                 None
             } else if is_bndb {
                 Some(view.file().get_view_of_type(available_view.name()).unwrap())


### PR DESCRIPTION
As [toolCHAINZ](https://github.com/toolCHAINZ) mentioned in [issue-3811](https://github.com/Vector35/binaryninja-api/issues/3811) , BinaryView is not loading binaries correctly when running headless. This change resolves this issue and provides the expected behavior.