### PR TITLE
More descriptive DownloadException when installing via `download_headless.py`

### DIFF
--- a/scripts/download_headless.py
+++ b/scripts/download_headless.py
@@ -61,7 +61,7 @@ def download_headless(serial: str, output_path: str = None, dev: bool = False) -
 	r = requests.get(url, {'serial': serial, 'dev': str(dev).lower()})
 	results = json.loads(r.text)
 	if not results['ok']:
-		message = results['message'] if 'message' in results else ''
+		message = results.get('message', 'No additional information available.')
 		raise DownloadException('Download failed: {}'.format(message))
 
 	req_url = results['url']

--- a/scripts/download_headless.py
+++ b/scripts/download_headless.py
@@ -62,7 +62,7 @@ def download_headless(serial: str, output_path: str = None, dev: bool = False) -
 	results = json.loads(r.text)
 	if not results['ok']:
 		message = results.get('message', 'No additional information available.')
-		raise DownloadException('Download failed: {}'.format(message))
+		raise DownloadException(f'Download failed: {message}')
 
 	req_url = results['url']
 	content = requests.get(req_url, allow_redirects=True)

--- a/scripts/download_headless.py
+++ b/scripts/download_headless.py
@@ -61,7 +61,8 @@ def download_headless(serial: str, output_path: str = None, dev: bool = False) -
 	r = requests.get(url, {'serial': serial, 'dev': str(dev).lower()})
 	results = json.loads(r.text)
 	if not results['ok']:
-		raise DownloadException('Download failed.')
+		message = results['message'] if 'message' in results else ''
+		raise DownloadException('Download failed: {}'.format(message))
 
 	req_url = results['url']
 	content = requests.get(req_url, allow_redirects=True)


### PR DESCRIPTION
Include the message returned from https://master.binary.ninja/headless-download when trying to install with an invalid license.