### PR TITLE
Improved open_view for bndb with invalid view

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -234,7 +234,10 @@ pub fn open_view<F: AsRef<Path>>(filename: F) -> Result<rc::Ref<binaryview::Bina
             if available_view.name().as_str() == "Raw" {
                 None
             } else if is_bndb {
-                Some(view.file().get_view_of_type(available_view.name()).unwrap())
+                match view.file().get_view_of_type(available_view.name()){
+                    Ok(view) => Some(view),
+                    _ => None
+                }
             } else {
                 // TODO : add log prints
                 println!("Opening view of type: `{}`", available_view.name());


### PR DESCRIPTION
calling open_view on a bndb with an invalid view would panic as unwrap was called. Fixed by matching to handle the error case.