### PR TITLE
Allow constructing BaseStructure from NamedTypeReference type

### DIFF
--- a/type.cpp
+++ b/type.cpp
@@ -517,7 +517,7 @@ BaseStructure::BaseStructure(NamedTypeReference* _type, uint64_t _offset, uint64
 
 BaseStructure::BaseStructure(Type* _type, uint64_t _offset)
 {
-	type = _type->GetRegisteredName();
+	type = _type->IsNamedTypeRefer() ? _type->GetNamedTypeReference() : _type->GetRegisteredName();
 	offset = _offset;
 	width = _type->GetWidth();
 }


### PR DESCRIPTION
When passing a type of `NamedTypeReference`, I would notice that the base structures `type` is null. Upon checking the constructor, it was clear that `NamedTypeReference` would need to pull its type from `GetNamedTypeReference` instead of `GetRegisteredName`. 

This isn't a blocking issue per se, you can of course construct the `BaseStructure` like so:
```cpp
BaseStructure(namedty->GetNamedTypeReference(), offset, namedty->GetWidth());
```