### PR TITLE
[Rust] Nightly fix, QoL for clangd, add BinaryView function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ python/generator.*.log
 python/generator.exe
 python/generator.log
 python/generator.tlog
+.cache/
 
 # Unit Tests
 suite/unit.py

--- a/rust/binaryninjacore-sys/Cargo.toml
+++ b/rust/binaryninjacore-sys/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Ryan Snyder <ryan@vector35.com>", "Kyle Martin <kyle@vector35.com>"]
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "^0.62"
+bindgen = "^0.66"

--- a/rust/src/binaryview.rs
+++ b/rust/src/binaryview.rs
@@ -750,6 +750,17 @@ pub trait BinaryViewExt: BinaryViewBase {
         }
     }
 
+    // List of functions containing `addr`
+    fn functions_containing(&self, addr: u64) -> Array<Function> {
+        unsafe {
+            let mut count = 0;
+            let functions =
+                BNGetAnalysisFunctionsContainingAddress(self.as_ref().handle, addr, &mut count);
+
+            Array::new(functions, count, ())
+        }
+    }
+
     fn function_at(&self, platform: &Platform, addr: u64) -> Result<Ref<Function>> {
         unsafe {
             let handle = BNGetAnalysisFunction(self.as_ref().handle, platform.handle, addr);


### PR DESCRIPTION
This PR is relatively small but I'm looking to spend some time in the future getting the Rust API more on par with the C++ API, so expect more to come. It changes 3 things that are relatively unrelated, but opening 3 seperate PRs seemed counterproductive.

This PR does the following:
- add the clangd compilation cache to .gitignore
- bump the bindgen version for binaryninjaapi-sys from ^0.62 to ^0.66, which uses a new version of syn, which uses a new version of proc-macro2, which used a feature flag that is now merged with another. (proc_macro_span & proc_macro_span_shrink). This fixes the build for the current nightly builds of rustc. There is no change for stable builds.
- add BinaryView::functions_containing.