### PR TITLE
rust: Add `StructureBuilder::with_members` method

### DIFF
--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1786,6 +1786,16 @@ impl StructureBuilder {
         self
     }
 
+    pub fn with_members<'a, S: BnStrCompatible, T: Into<Conf<&'a Type>>>(
+        &self,
+        members: impl IntoIterator<Item = (T, S)>,
+    ) -> &Self {
+        for (t, name) in members.into_iter() {
+            self.append(t, name, MemberAccess::NoAccess, MemberScope::NoScope);
+        }
+        self
+    }
+
     // Getters
 
     pub fn width(&self) -> u64 {

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -188,6 +188,12 @@ impl<'a, T: RefCountable> From<&'a Conf<Ref<T>>> for Conf<&'a T> {
     }
 }
 
+impl<'a, T: RefCountable> From<&'a Ref<T>> for Conf<&'a T> {
+    fn from(r: &'a Ref<T>) -> Self {
+        r.as_ref().into()
+    }
+}
+
 #[inline]
 pub fn min_confidence() -> u8 {
     u8::MIN


### PR DESCRIPTION
To allow for better inline creation of structures with many fields, this method takes a sequence of tuples `(type, name)` and appends them to the structure all at once.

Also, added an impl of `From<&'a Ref<T>>` for `Conf<&'a T>` so that converting between the two can be done implicitly without having to call `Ref::as_ref` or to reborrow using `&*`. Unfortunately, an owned impl that converts directly from `Ref<T>` doesn't seem to be possible to write (I tried for quite a long time and the borrow checker kept screaming at me).