### PR TITLE
Introduce a trait/derive macro for constructing Binja types out of Rust types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,14 +78,8 @@ plugins/
 # Rust
 rust/**/*.swp
 rust/**/*.rs.bk
-rust/Cargo.lock
-rust/target/
-rust/binaryninjacore-sys/Cargo.lock
-rust/binaryninjacore-sys/target/
-rust/examples/*/Cargo.lock
-rust/examples/*/target/
-rust/examples/dwarf/*/target/
-rust/examples/dwarf/*/Cargo.lock
+rust/**/target/
+rust/**/Cargo.lock
 
 # Debugger docs
 docs/img/debugger

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -13,6 +13,7 @@ log = "0.4"
 libc = "0.2"
 rayon = { version = "1.0", optional = true }
 binaryninjacore-sys = { path = "binaryninjacore-sys" }
+binaryninja-derive = { path = "binaryninja-derive" }
 
 [workspace]
 members = [

--- a/rust/binaryninja-derive/Cargo.toml
+++ b/rust/binaryninja-derive/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "binaryninja-derive"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+syn = "2.0"
+quote = "1"
+proc-macro2 = "1.0"
+proc-macro-error = "1.0.4"
+
+[lib]
+proc-macro = true

--- a/rust/binaryninja-derive/src/lib.rs
+++ b/rust/binaryninja-derive/src/lib.rs
@@ -1,7 +1,10 @@
 use proc_macro::TokenStream;
 use proc_macro_error::{abort, proc_macro_error};
 use quote::quote;
-use syn::{parse_macro_input, Data, DeriveInput, Fields, FieldsNamed, Ident};
+use syn::meta::ParseNestedMeta;
+use syn::{
+    parse_macro_input, Attribute, Data, DeriveInput, Fields, FieldsNamed, Ident, Path, Variant,
+};
 
 #[proc_macro_error]
 #[proc_macro_derive(BinaryNinjaType)]
@@ -10,36 +13,61 @@ pub fn binja_type_derive(input: TokenStream) -> TokenStream {
     impl_binja_type(input)
 }
 
-fn impl_binja_type(ast: DeriveInput) -> TokenStream {
-    let mut repr_c = false;
-    for attr in ast.attrs {
-        if attr.path().is_ident("repr") {
-            let _ = attr.parse_nested_meta(|meta| {
-                if meta.path.is_ident("C") {
-                    repr_c = true;
-                }
-                Ok(())
-            });
-        }
-    }
+#[derive(Default)]
+struct Repr {
+    c: bool,
+    primitive: Option<(Path, bool)>,
+}
 
-    if !repr_c {
-        abort!(ast.ident, "type must be `repr(C)`");
+impl Repr {
+    fn from_attrs(attrs: Vec<Attribute>) -> Self {
+        let mut c = false;
+        let mut primitive = None;
+        // Look for a `repr(...)` attribute on the type
+        for attr in attrs {
+            if attr.path().is_ident("repr") {
+                let _ = attr.parse_nested_meta(|meta| {
+                    if meta.path.is_ident("C") {
+                        c = true;
+                    }
+                    if meta_path_in_list(&meta, ["u8", "u16", "u32", "u64"]) {
+                        primitive = Some((meta.path.clone(), false));
+                    } else if meta_path_in_list(&meta, ["i8", "i16", "i32", "i64"]) {
+                        primitive = Some((meta.path.clone(), true));
+                    } else if meta_path_in_list(&meta, ["u128", "i128", "usize", "isize"]) {
+                        abort!(
+                            meta.path,
+                            "`repr({})` types are not supported",
+                            meta.path.get_ident().unwrap()
+                        )
+                    }
+                    Ok(())
+                });
+            }
+        }
+        Self { c, primitive }
     }
+}
+
+fn meta_path_in_list<const N: usize>(meta: &ParseNestedMeta, list: [&'static str; N]) -> bool {
+    list.iter().any(|&p| meta.path.is_ident(p))
+}
+
+fn impl_binja_type(ast: DeriveInput) -> TokenStream {
+    let repr = Repr::from_attrs(ast.attrs);
 
     if !ast.generics.params.is_empty() {
         abort!(ast.generics, "type must not be generic");
     }
 
-    let ident = ast.ident;
     match ast.data {
         Data::Struct(s) => match s.fields {
-            Fields::Named(fields) => impl_binja_struct_type(ident, fields),
+            Fields::Named(fields) => impl_binja_struct_type(ast.ident, fields, repr),
             Fields::Unnamed(_) => abort!(s.fields, "struct must have named fields"),
             Fields::Unit => abort!(s.fields, "unit structs are unsupported"),
         },
-        Data::Enum(_) => todo!(),
-        Data::Union(s) => impl_binja_union_type(ident, s.fields),
+        Data::Enum(e) => impl_binja_enum_type(ast.ident, e.variants.into_iter().collect(), repr),
+        Data::Union(u) => impl_binja_union_type(ast.ident, u.fields, repr),
     }
 }
 
@@ -51,12 +79,15 @@ fn named_fields_to_structure_args(fields: FieldsNamed) -> Vec<proc_macro2::Token
         .map(|field| {
             let ident = field.ident.as_ref().unwrap();
             let ty = &field.ty;
-            quote! { &<#ty>::binja_type(), stringify!(#ident) }
+            quote!(&<#ty>::binja_type(), stringify!(#ident))
         })
         .collect::<Vec<_>>()
 }
 
-fn impl_binja_struct_type(name: Ident, fields: FieldsNamed) -> TokenStream {
+fn impl_binja_struct_type(name: Ident, fields: FieldsNamed, repr: Repr) -> TokenStream {
+    if !repr.c {
+        abort!(name, "struct must be `repr(C)`");
+    }
     let args = named_fields_to_structure_args(fields);
     quote!(
         impl BinaryNinjaType for #name {
@@ -72,7 +103,10 @@ fn impl_binja_struct_type(name: Ident, fields: FieldsNamed) -> TokenStream {
     .into()
 }
 
-fn impl_binja_union_type(name: Ident, fields: FieldsNamed) -> TokenStream {
+fn impl_binja_union_type(name: Ident, fields: FieldsNamed, repr: Repr) -> TokenStream {
+    if !repr.c {
+        abort!(name, "union must be `repr(C)`");
+    }
     let args = named_fields_to_structure_args(fields);
     quote!(
         impl BinaryNinjaType for #name {
@@ -90,6 +124,45 @@ fn impl_binja_union_type(name: Ident, fields: FieldsNamed) -> TokenStream {
                         )*
                         .set_structure_type(::binaryninja::types::StructureType::UnionStructureType)
                         .finalize(),
+                )
+            }
+        }
+    )
+    .into()
+}
+
+fn impl_binja_enum_type(name: Ident, variants: Vec<Variant>, repr: Repr) -> TokenStream {
+    if repr.c {
+        abort!(name, "`repr(C)` enums are not supported")
+    }
+    let Some((primitive, sign)) = repr.primitive else {
+        abort!(name, "must provide a primitive `repr` type, e.g. `u32`")
+    };
+    let variants = variants
+        .iter()
+        .map(|variant| {
+            if !variant.fields.is_empty() {
+                abort!(variant, "variant must not have any fields")
+            }
+            if let Some((_, discriminant)) = &variant.discriminant {
+                let ident = &variant.ident;
+                quote!(stringify!(#ident), #discriminant)
+            } else {
+                abort!(variant, "variant must have an explicit discriminant")
+            }
+        })
+        .collect::<Vec<_>>();
+    quote!(
+        impl BinaryNinjaType for #name {
+            fn binja_type() -> ::binaryninja::rc::Ref<::binaryninja::types::Type> {
+                ::binaryninja::types::Type::enumeration(
+                    &::binaryninja::types::Enumeration::builder()
+                        #(
+                            .insert(#variants)
+                        )*
+                        .finalize(),
+                    std::mem::size_of::<#primitive>(),
+                    #sign,
                 )
             }
         }

--- a/rust/binaryninja-derive/src/lib.rs
+++ b/rust/binaryninja-derive/src/lib.rs
@@ -1,0 +1,67 @@
+use proc_macro::TokenStream;
+use proc_macro_error::{abort, proc_macro_error};
+use quote::quote;
+use syn::{parse_macro_input, Data, DeriveInput, Fields, FieldsNamed, Ident};
+
+#[proc_macro_error]
+#[proc_macro_derive(BinaryNinjaType)]
+pub fn binja_type_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    impl_binja_type(input)
+}
+
+fn impl_binja_type(ast: DeriveInput) -> TokenStream {
+    let repr_c = ast.attrs.iter().find(|attr| {
+        let ident = attr.path().get_ident();
+        match ident {
+            Some(ident) if ident == "repr" => {}
+            _ => return false,
+        }
+        match attr.parse_args::<Ident>() {
+            Ok(ident) if ident == "C" => true,
+            _ => false,
+        }
+    });
+
+    if repr_c.is_none() {
+        abort!(ast, "type must be `repr(C)`");
+    }
+
+    if !ast.generics.params.is_empty() {
+        abort!(ast.generics, "type must not be generic");
+    }
+
+    let ident = ast.ident;
+    match ast.data {
+        Data::Struct(s) => match s.fields {
+            Fields::Named(fields) => impl_binja_struct_type(ident, fields),
+            Fields::Unnamed(_) => abort!(s.fields, "struct must have named fields"),
+            Fields::Unit => abort!(s.fields, "unit structs are unsupported"),
+        },
+        _ => todo!(),
+    }
+}
+
+fn impl_binja_struct_type(name: Ident, fields: FieldsNamed) -> TokenStream {
+    let args = fields
+        .named
+        .iter()
+        .map(|field| {
+            let ident = field.ident.as_ref().unwrap();
+            let ty = &field.ty;
+            quote! { (&<#ty>::binja_type(), stringify!(#ident)) }
+        })
+        .collect::<Vec<_>>();
+    quote!(
+        impl BinaryNinjaType for #name {
+            fn binja_type() -> Ref<::binaryninja::types::Type> {
+                ::binaryninja::types::Type::structure(
+                    &::binaryninja::types::Structure::builder()
+                        .with_members([#(#args),*])
+                        .finalize(),
+                )
+            }
+        }
+    )
+    .into()
+}

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -697,6 +697,69 @@ impl Drop for TypeBuilder {
 //////////
 // Type
 
+pub use binaryninja_derive::*;
+pub trait BinaryNinjaType {
+    fn binja_type() -> Ref<Type>;
+}
+
+macro_rules! binja_type_unsigned_int {
+    ($($t:ty),+) => {
+        $(
+            impl BinaryNinjaType for $t {
+                fn binja_type() -> Ref<Type> {
+                    Type::int(std::mem::size_of::<$t>(), false)
+                }
+            }
+        )+
+    };
+}
+
+macro_rules! binja_type_signed_int {
+    ($($t:ty),+) => {
+        $(
+            impl BinaryNinjaType for $t {
+                fn binja_type() -> Ref<Type> {
+                    Type::int(std::mem::size_of::<$t>(), true)
+                }
+            }
+        )+
+    };
+}
+
+macro_rules! binja_type_float {
+    ($($t:ty),+) => {
+        $(
+            impl BinaryNinjaType for $t {
+                fn binja_type() -> Ref<Type> {
+                    Type::float(std::mem::size_of::<$t>())
+                }
+            }
+        )+
+    };
+}
+
+binja_type_unsigned_int! { u8, u16, u32, u64 }
+binja_type_signed_int! { i8, i16, i32, i64 }
+binja_type_float! { f32, f64 }
+
+impl BinaryNinjaType for bool {
+    fn binja_type() -> Ref<Type> {
+        Type::bool()
+    }
+}
+
+impl<T: BinaryNinjaType, const N: usize> BinaryNinjaType for [T; N] {
+    fn binja_type() -> Ref<Type> {
+        Type::array(&T::binja_type(), N as u64)
+    }
+}
+
+// impl<T: BinaryNinjaType> BinaryNinjaType for *const T {
+//     fn binja_type() -> Ref<Type> {
+//         Type::pointer(&T::binja_type())
+//     }
+// }
+
 pub struct Type {
     pub(crate) handle: *mut BNType,
 }


### PR DESCRIPTION
This work is not yet finished, but I'm opening a draft to get discussion going about design decisions. This PR introduces a trait `BinaryNinjaType` with the following definition:

```rust
pub trait BinaryNinjaType {
    fn binja_type() -> Ref<Type>;
}
```

Implementing this trait on a Rust type allows it to be converted into a Binja `Type` to be sent to a BinaryView. Accompanying the trait is a derive macro that allows automatic implementation of this trait for any Rust type, as long as it satisfies the following restrictions:

* Structs/Unions must be marked `repr(C)`. This is just a design decision aimed at making the trait's semantics more obvious. Unit structs and Tuple structs (with unnamed fields) are unsupported.
* Enums must **not** be `repr(C)`, and must instead be marked with a primitive type, e.g. `repr(u8)` or `repr(u32)`. They must also be fieldless (all variants must not contain extra data), in other words C-style. Additionally, all variants must be assigned an explicit discriminant value.
    * All primitive integer types are allowed for representation, except for `u128`, `i128`, `usize` and `isize`.

Currently, several features are missing which I hope to implement, but they are non-trivial and therefore require a bit of discussion around design:

* Pointers - The `Type::pointer` constructor requires an architecture and no others do.
* `repr(C)` on Enums - The underlying representation (width) is ABI-dependant, which basically means arch-dependant in Binja terms. So, in order for the semantics to make sense, this needs to rely on an architecture, the same as pointers.
* Named Types - Rather than having nested structs be inlined in the type definition, I'd like to be reference named types via an attribute on the field like `#[name = "..."]`. However, actually resolving this requires querying a BinaryView.

The following features are also currently missing but are more straightforward to implement:

* `repr(transparent)` on Structs and Enums - This is valid if there is only a single non-zero-sized field/variant. However, the complication is that any number of additional zero-sized fields can live alongside it (such as `PhantomData`), and determining *which* of the fields is the one with non-zero size seems tricky.
* `repr(align)` and `repr(packed)` - This would be nice to add, such that alignment and padding could be specified in Rust, but requires me reading up a bit more about how exactly these attributes work.

I would appreciate feedback and thoughts on addressing what's missing.