### PR TITLE
Add API to get all SSA versions of a variable

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -11850,6 +11850,7 @@ namespace BinaryNinja {
 		std::set<size_t> GetSSAMemoryUses(size_t version) const;
 		bool IsSSAVarLive(const SSAVariable& var) const;
 
+        std::set<size_t> GetVariableSSAVersions(const Variable& var) const;
 		std::set<size_t> GetVariableDefinitions(const Variable& var) const;
 		std::set<size_t> GetVariableUses(const Variable& var) const;
 
@@ -12162,6 +12163,7 @@ namespace BinaryNinja {
 		bool IsSSAVarLiveAt(const SSAVariable& var, const size_t instr) const;
 		bool IsVarLiveAt(const Variable& var, const size_t instr) const;
 
+        std::set<size_t> GetVariableSSAVersions(const Variable& var) const;
 		std::set<size_t> GetVariableDefinitions(const Variable& var) const;
 		std::set<size_t> GetVariableUses(const Variable& var) const;
 		size_t GetSSAVarVersionAtInstruction(const Variable& var, size_t instr) const;

--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -11850,7 +11850,7 @@ namespace BinaryNinja {
 		std::set<size_t> GetSSAMemoryUses(size_t version) const;
 		bool IsSSAVarLive(const SSAVariable& var) const;
 
-        std::set<size_t> GetVariableSSAVersions(const Variable& var) const;
+		std::set<size_t> GetVariableSSAVersions(const Variable& var) const;
 		std::set<size_t> GetVariableDefinitions(const Variable& var) const;
 		std::set<size_t> GetVariableUses(const Variable& var) const;
 
@@ -12163,7 +12163,7 @@ namespace BinaryNinja {
 		bool IsSSAVarLiveAt(const SSAVariable& var, const size_t instr) const;
 		bool IsVarLiveAt(const Variable& var, const size_t instr) const;
 
-        std::set<size_t> GetVariableSSAVersions(const Variable& var) const;
+		std::set<size_t> GetVariableSSAVersions(const Variable& var) const;
 		std::set<size_t> GetVariableDefinitions(const Variable& var) const;
 		std::set<size_t> GetVariableUses(const Variable& var) const;
 		size_t GetSSAVarVersionAtInstruction(const Variable& var, size_t instr) const;

--- a/highlevelil.cpp
+++ b/highlevelil.cpp
@@ -350,6 +350,7 @@ set<size_t> HighLevelILFunction::GetVariableSSAVersions(const Variable& var) con
 	for (size_t i = 0; i < count; i++)
 		result.insert(versions[i]);
 
+    BNFreeILInstructionList(versions);
 	return result;
 }
 

--- a/highlevelil.cpp
+++ b/highlevelil.cpp
@@ -341,6 +341,19 @@ bool HighLevelILFunction::IsVarLiveAt(const Variable& var, const size_t instr) c
 }
 
 
+set<size_t> HighLevelILFunction::GetVariableSSAVersions(const Variable& var) const
+{
+	size_t count;
+	size_t* versions = BNGetHighLevelILVariableSSAVersions(m_object, &var, &count);
+
+	set<size_t> result;
+	for (size_t i = 0; i < count; i++)
+		result.insert(versions[i]);
+
+	return result;
+}
+
+
 set<size_t> HighLevelILFunction::GetVariableDefinitions(const Variable& var) const
 {
 	size_t count;

--- a/highlevelil.cpp
+++ b/highlevelil.cpp
@@ -350,7 +350,7 @@ set<size_t> HighLevelILFunction::GetVariableSSAVersions(const Variable& var) con
 	for (size_t i = 0; i < count; i++)
 		result.insert(versions[i]);
 
-    BNFreeILInstructionList(versions);
+	BNFreeILInstructionList(versions);
 	return result;
 }
 

--- a/mediumlevelil.cpp
+++ b/mediumlevelil.cpp
@@ -513,6 +513,7 @@ set<size_t> MediumLevelILFunction::GetVariableSSAVersions(const Variable& var) c
 	for (size_t i = 0; i < count; i++)
 		result.insert(versions[i]);
 
+	BNFreeILInstructionList(versions);
 	return result;
 }
 

--- a/mediumlevelil.cpp
+++ b/mediumlevelil.cpp
@@ -504,6 +504,19 @@ bool MediumLevelILFunction::IsSSAVarLive(const SSAVariable& var) const
 }
 
 
+set<size_t> MediumLevelILFunction::GetVariableSSAVersions(const Variable& var) const
+{
+	size_t count;
+	size_t* versions = BNGetMediumLevelILVariableSSAVersions(m_object, &var, &count);
+
+	set<size_t> result;
+	for (size_t i = 0; i < count; i++)
+		result.insert(versions[i]);
+
+	return result;
+}
+
+
 set<size_t> MediumLevelILFunction::GetVariableDefinitions(const Variable& var) const
 {
 	size_t count;


### PR DESCRIPTION
Added a missing helper for both `MediumLevelILFunction` and `HighLevelILFunction` classes to get a list of all SSA versions of a variable.