### PR TITLE
Make asserts from jsoncpp more descriptive

### DIFF
--- a/exceptions.cpp
+++ b/exceptions.cpp
@@ -1,0 +1,102 @@
+// Copyright (c) 2015-2023 Vector 35 Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#include "exceptions.h"
+#include "binaryninjacore.h"
+#include <stdlib.h>
+
+BinaryNinja::ExceptionWithStackTrace::ExceptionWithStackTrace(const std::string& message)
+{
+	m_originalMessage = message;
+	m_message = message;
+	if (getenv("BN_DEBUG_EXCEPTION_TRACES"))
+	{
+		char* stackTrace = BNGetCurrentStackTraceString();
+		if (stackTrace)
+		{
+			m_stackTrace = stackTrace;
+			m_message += "\n";
+			m_message += stackTrace;
+			BNFreeString(stackTrace);
+		}
+	}
+}
+
+
+BinaryNinja::ExceptionWithStackTrace::ExceptionWithStackTrace(std::exception_ptr exc1, std::exception_ptr exc2)
+{
+	m_originalMessage = "";
+	m_message = "";
+	if (exc1)
+	{
+		try
+		{
+			std::rethrow_exception(exc1);
+		}
+		catch (ExceptionWithStackTrace& stacky)
+		{
+			m_originalMessage = stacky.m_originalMessage;
+			m_message = stacky.m_message;
+		}
+		catch (std::exception& exc)
+		{
+			m_originalMessage = exc.what();
+			m_message = exc.what();
+		}
+		catch (...)
+		{
+			m_originalMessage = "Some unknown exception";
+			m_message = "Some unknown exception";
+		}
+	}
+	if (exc2)
+	{
+		try
+		{
+			std::rethrow_exception(exc2);
+		}
+		catch (ExceptionWithStackTrace& stacky)
+		{
+			m_originalMessage += "\n" + stacky.m_originalMessage;
+			m_message += "\n" + stacky.m_message;
+		}
+		catch (std::exception& exc)
+		{
+			m_originalMessage = exc.what();
+			m_message = exc.what();
+		}
+		catch (...)
+		{
+			m_originalMessage = "Some unknown exception";
+			m_message = "Some unknown exception";
+		}
+	}
+	if (getenv("BN_DEBUG_EXCEPTION_TRACES"))
+	{
+		char* stackTrace = BNGetCurrentStackTraceString();
+		if (stackTrace)
+		{
+			m_stackTrace = stackTrace;
+			m_message += "\n";
+			m_message += stackTrace;
+			BNFreeString(stackTrace);
+		}
+	}
+}

--- a/exceptions.h
+++ b/exceptions.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2015-2023 Vector 35 Inc
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+#pragma once
+
+#include <exception>
+#include <string>
+
+#ifndef BINARYNINJACORE_LIBRARY
+namespace BinaryNinja
+{
+	struct ExceptionWithStackTrace : std::exception
+	{
+		std::string m_originalMessage;
+		std::string m_message;
+		std::string m_stackTrace;
+		ExceptionWithStackTrace(const std::string& message);
+		ExceptionWithStackTrace(std::exception_ptr exc1, std::exception_ptr exc2);
+		const char* what() const noexcept override
+		{
+			return m_message.c_str();
+		}
+	};
+}
+#endif
+
+#ifdef BINARYNINJACORE_LIBRARY
+using ExceptionWithStackTrace = BinaryNinjaCore::ExceptionWithStackTrace;
+#else
+using ExceptionWithStackTrace = BinaryNinja::ExceptionWithStackTrace;
+#endif

--- a/json/json.h
+++ b/json/json.h
@@ -502,6 +502,12 @@ public:
 #pragma warning(disable : 4251)
 #endif // if defined(JSONCPP_DISABLE_DLL_INTERFACE_WARNING)
 
+// XXX: BN: Use our exception class for extra details
+#include "../exceptions.h"
+#define JSONCPP_EXCEPTION ExceptionWithStackTrace
+// #define JSONCPP_EXCEPTION std::runtime_error
+
+
 #pragma pack(push, 8)
 
 /** \brief JSON (JavaScript Object Notation).
@@ -512,14 +518,12 @@ namespace Json {
  *
  * We use nothing but these internally. Of course, STL can throw others.
  */
-class JSON_API Exception : public std::exception {
+class JSON_API Exception : public JSONCPP_EXCEPTION /* BN: subclass changed */ {
 public:
   Exception(JSONCPP_STRING const& msg);
   ~Exception() JSONCPP_NOEXCEPT JSONCPP_OVERRIDE;
-  char const* what() const JSONCPP_NOEXCEPT JSONCPP_OVERRIDE;
-
-protected:
-  JSONCPP_STRING msg_;
+  // BN: Member removed
+  // BN: what() removed
 };
 
 /** Exceptions which the user cannot easily avoid.
@@ -2222,7 +2226,7 @@ JSON_API JSONCPP_OSTREAM& operator<<(JSONCPP_OSTREAM&, const Value& root);
 #define JSON_ASSERT(condition)                                                 \
   {                                                                            \
     if (!(condition)) {                                                        \
-      Json::throwLogicError("assert json failed");                             \
+      Json::throwLogicError(#condition);                                       \
     }                                                                          \
   }
 

--- a/json/jsoncpp.cpp
+++ b/json/jsoncpp.cpp
@@ -2653,9 +2653,10 @@ static inline void releaseStringValue(char* value, unsigned) { free(value); }
 
 namespace Json {
 
-Exception::Exception(JSONCPP_STRING const& msg) : msg_(msg) {}
+// BN: subclass
+Exception::Exception(JSONCPP_STRING const& msg) : JSONCPP_EXCEPTION(msg) {}
 Exception::~Exception() JSONCPP_NOEXCEPT {}
-char const* Exception::what() const JSONCPP_NOEXCEPT { return msg_.c_str(); }
+// BN: removed what()
 RuntimeError::RuntimeError(JSONCPP_STRING const& msg) : Exception(msg) {}
 LogicError::LogicError(JSONCPP_STRING const& msg) : Exception(msg) {}
 JSONCPP_NORETURN void throwRuntimeError(JSONCPP_STRING const& msg) {


### PR DESCRIPTION
There is an Enterprise customer that currently cannot sync data to the server because they're hitting an assertion, somehow, in our JSON dependency (`jsoncpp`). These assertions are all over the place and don't have any identifying information, so we can't tell which one they're hitting.

This PR implements a way in which we can get a stack trace when the assertion is hit so we can try and figure out which one is being triggered and work backwards to figure out why. We would like, at minimum, to have a single `dev` channel build with this functionality ASAP so the customer can pull down the build and get us the information we need. We'd also like this to be in the next release, in case it happens to another customer, but we understand if this is too late in code freeze to be accepting this to the 3.5 stable.