### PR TITLE
Correctly free demangled names

### DIFF
--- a/demangle.cpp
+++ b/demangle.cpp
@@ -22,9 +22,8 @@ namespace BinaryNinja {
 		for (size_t i = 0; i < localSize; i++)
 		{
 			outVarName.push_back(localVarName[i]);
-			BNFreeString(localVarName[i]);
 		}
-		delete[] localVarName;
+		BNFreeDemangledName(&localVarName, localSize);
 		return true;
 	}
 
@@ -48,9 +47,8 @@ namespace BinaryNinja {
 		for (size_t i = 0; i < localSize; i++)
 		{
 			outVarName.push_back(localVarName[i]);
-			BNFreeString(localVarName[i]);
 		}
-		delete[] localVarName;
+		BNFreeDemangledName(&localVarName, localSize);
 		return true;
 	}
 


### PR DESCRIPTION
When trying to use [MSDemangle](https://github.com/Vector35/binaryninja-api/blob/dcdc2f9e798f1c70ddae0e54fe74dd1d06a90520/demangle.cpp#L13) I encountered a nasty error: `Invalid address specified to RtlValidateHeap( 000001EBA20D0000, 000001EBAE1E13B0 )`. From what I could tell this is a result of `delete[]` causing a double free. Looking at both the python and rust helpers they both use `BNFreeDemangledName` so I just switched the c++ helper to use that.

https://github.com/Vector35/binaryninja-api/blob/dcdc2f9e798f1c70ddae0e54fe74dd1d06a90520/python/demangle.py#L91
https://github.com/Vector35/binaryninja-api/blob/dcdc2f9e798f1c70ddae0e54fe74dd1d06a90520/rust/src/demangle.rs#L135