### PR TITLE
Show repr of BasicBlock in hex

### DIFF
--- a/python/basicblock.py
+++ b/python/basicblock.py
@@ -68,9 +68,9 @@ class BasicBlock:
 	def __repr__(self):
 		arch = self.arch
 		if arch:
-			return f"<{self.__class__.__name__}: {arch.name}@{self.start}-{self.end}>"
+			return f"<{self.__class__.__name__}: {arch.name}@{self.start:#x}-{self.end:#x}>"
 		else:
-			return f"<{self.__class__.__name__}: {self.start}-{self.end}>"
+			return f"<{self.__class__.__name__}: {self.start:#x}-{self.end:#x}>"
 
 	def __len__(self):
 		return int(core.BNGetBasicBlockLength(self.handle))

--- a/python/highlevelil.py
+++ b/python/highlevelil.py
@@ -3013,6 +3013,13 @@ class HighLevelILBasicBlock(basicblock.BasicBlock):
 		else:
 			return False
 
+	def __repr__(self):
+		arch = self.arch
+		if arch:
+			return f"<{self.__class__.__name__}: {arch.name}@{self.start}-{self.end}>"
+		else:
+			return f"<{self.__class__.__name__}: {self.start}-{self.end}>"
+
 	@property
 	def instruction_count(self) -> int:
 		return self.end - self.start

--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -5291,6 +5291,13 @@ class LowLevelILBasicBlock(basicblock.BasicBlock):
 		else:
 			return self._il_function[self.end + idx]
 
+	def __repr__(self):
+		arch = self.arch
+		if arch:
+			return f"<{self.__class__.__name__}: {arch.name}@{self.start}-{self.end}>"
+		else:
+			return f"<{self.__class__.__name__}: {self.start}-{self.end}>"
+
 	def _create_instance(self, handle):
 		"""Internal method by super to instantiate child instances"""
 		return LowLevelILBasicBlock(handle, self._il_function, self.view)

--- a/python/mediumlevelil.py
+++ b/python/mediumlevelil.py
@@ -3752,6 +3752,13 @@ class MediumLevelILBasicBlock(basicblock.BasicBlock):
 		else:
 			return False
 
+	def __repr__(self):
+		arch = self.arch
+		if arch:
+			return f"<{self.__class__.__name__}: {arch.name}@{self.start}-{self.end}>"
+		else:
+			return f"<{self.__class__.__name__}: {self.start}-{self.end}>"
+
 	def _create_instance(
 	    self, handle: core.BNBasicBlockHandle) -> 'MediumLevelILBasicBlock':
 		"""Internal method by super to instantiate child instances"""


### PR DESCRIPTION
Fixes #4708. The hex conversion only applies to non-IL basic blocks. All IL basic blocks now have their own repr method that displays the start and end indices in decimal.