### PR TITLE
Fix struct member confidence

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -8383,7 +8383,7 @@ namespace BinaryNinja {
 	*/
 	struct StructureMember
 	{
-		Ref<Type> type;
+		Confidence<Ref<Type>> type;
 		std::string name;
 		uint64_t offset;
 		BNMemberAccess access;

--- a/python/scriptingprovider.py
+++ b/python/scriptingprovider.py
@@ -1249,7 +1249,7 @@ class PythonScriptingProvider(ScriptingProvider):
 	def _python_bin(self) -> Optional[str]:
 		python_lib = settings.Settings().get_string("python.interpreter")
 		python_bin_override = settings.Settings().get_string("python.binaryOverride")
-		python_env = self._get_python_environemnt(using_bundled_python=not python_lib)
+		python_env = self._get_python_environment(using_bundled_python=not python_lib)
 		python_bin, status = self._get_executable_for_libpython(python_lib, python_bin_override, python_env=python_env)
 		return python_bin
 

--- a/type.cpp
+++ b/type.cpp
@@ -2139,6 +2139,8 @@ vector<StructureMember> Structure::GetMembers() const
 		member.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(members[i].type)), members[i].typeConfidence);
 		member.name = members[i].name;
 		member.offset = members[i].offset;
+		member.access = members[i].access;
+		member.scope = members[i].scope;
 		result.push_back(member);
 	}
 
@@ -2162,6 +2164,8 @@ vector<InheritedStructureMember> Structure::GetMembersIncludingInherited(const T
 		member.member.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(members[i].member.type)), members[i].member.typeConfidence);
 		member.member.name = members[i].member.name;
 		member.member.offset = members[i].member.offset;
+		member.member.access = members[i].member.access;
+		member.member.scope = members[i].member.scope;
 		member.memberIndex = members[i].memberIndex;
 		result.push_back(member);
 	}
@@ -2183,6 +2187,8 @@ bool Structure::GetMemberIncludingInheritedAtOffset(BinaryView* view, int64_t of
 	result.member.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(member->member.type)), member->member.typeConfidence);
 	result.member.name = member->member.name;
 	result.member.offset = member->member.offset;
+	result.member.access = member->member.access;
+	result.member.scope = member->member.scope;
 	result.memberIndex = member->memberIndex;
 
 	BNFreeInheritedStructureMember(member);
@@ -2198,6 +2204,8 @@ bool Structure::GetMemberByName(const string& name, StructureMember& result) con
 		result.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(member->type)), member->typeConfidence);
 		result.name = member->name;
 		result.offset = member->offset;
+		result.access = member->access;
+		result.scope = member->scope;
 		BNFreeStructureMember(member);
 		return true;
 	}
@@ -2220,6 +2228,8 @@ bool Structure::GetMemberAtOffset(int64_t offset, StructureMember& result, size_
 		result.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(member->type)), member->typeConfidence);
 		result.name = member->name;
 		result.offset = member->offset;
+		result.access = member->access;
+		result.scope = member->scope;
 		BNFreeStructureMember(member);
 		return true;
 	}
@@ -2428,6 +2438,8 @@ vector<StructureMember> StructureBuilder::GetMembers() const
 		member.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(members[i].type)), members[i].typeConfidence);
 		member.name = members[i].name;
 		member.offset = members[i].offset;
+		member.access = members[i].access;
+		member.scope = members[i].scope;
 		result.push_back(member);
 	}
 
@@ -2444,6 +2456,8 @@ bool StructureBuilder::GetMemberByName(const string& name, StructureMember& resu
 		result.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(member->type)), member->typeConfidence);
 		result.name = member->name;
 		result.offset = member->offset;
+		result.access = member->access;
+		result.scope = member->scope;
 		BNFreeStructureMember(member);
 		return true;
 	}
@@ -2466,6 +2480,8 @@ bool StructureBuilder::GetMemberAtOffset(int64_t offset, StructureMember& result
 		result.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(member->type)), member->typeConfidence);
 		result.name = member->name;
 		result.offset = member->offset;
+		result.access = member->access;
+		result.scope = member->scope;
 		BNFreeStructureMember(member);
 		return true;
 	}

--- a/type.cpp
+++ b/type.cpp
@@ -2136,7 +2136,7 @@ vector<StructureMember> Structure::GetMembers() const
 	for (size_t i = 0; i < count; i++)
 	{
 		StructureMember member;
-		member.type = new Type(BNNewTypeReference(members[i].type));
+		member.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(members[i].type)), members[i].typeConfidence);
 		member.name = members[i].name;
 		member.offset = members[i].offset;
 		result.push_back(member);
@@ -2159,7 +2159,7 @@ vector<InheritedStructureMember> Structure::GetMembersIncludingInherited(const T
 		InheritedStructureMember member;
 		member.base = members[i].base ? new NamedTypeReference(BNNewNamedTypeReference(members[i].base)) : nullptr;
 		member.baseOffset = members[i].baseOffset;
-		member.member.type = new Type(BNNewTypeReference(members[i].member.type));
+		member.member.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(members[i].member.type)), members[i].member.typeConfidence);
 		member.member.name = members[i].member.name;
 		member.member.offset = members[i].member.offset;
 		member.memberIndex = members[i].memberIndex;
@@ -2180,7 +2180,7 @@ bool Structure::GetMemberIncludingInheritedAtOffset(BinaryView* view, int64_t of
 
 	result.base = member->base ? new NamedTypeReference(BNNewNamedTypeReference(member->base)) : nullptr;
 	result.baseOffset = member->baseOffset;
-	result.member.type = new Type(BNNewTypeReference(member->member.type));
+	result.member.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(member->member.type)), member->member.typeConfidence);
 	result.member.name = member->member.name;
 	result.member.offset = member->member.offset;
 	result.memberIndex = member->memberIndex;
@@ -2195,7 +2195,7 @@ bool Structure::GetMemberByName(const string& name, StructureMember& result) con
 	BNStructureMember* member = BNGetStructureMemberByName(m_object, name.c_str());
 	if (member)
 	{
-		result.type = new Type(BNNewTypeReference(member->type));
+		result.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(member->type)), member->typeConfidence);
 		result.name = member->name;
 		result.offset = member->offset;
 		BNFreeStructureMember(member);
@@ -2217,7 +2217,7 @@ bool Structure::GetMemberAtOffset(int64_t offset, StructureMember& result, size_
 	BNStructureMember* member = BNGetStructureMemberAtOffset(m_object, offset, &idx);
 	if (member)
 	{
-		result.type = new Type(BNNewTypeReference(member->type));
+		result.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(member->type)), member->typeConfidence);
 		result.name = member->name;
 		result.offset = member->offset;
 		BNFreeStructureMember(member);
@@ -2425,7 +2425,7 @@ vector<StructureMember> StructureBuilder::GetMembers() const
 	for (size_t i = 0; i < count; i++)
 	{
 		StructureMember member;
-		member.type = new Type(BNNewTypeReference(members[i].type));
+		member.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(members[i].type)), members[i].typeConfidence);
 		member.name = members[i].name;
 		member.offset = members[i].offset;
 		result.push_back(member);
@@ -2441,7 +2441,7 @@ bool StructureBuilder::GetMemberByName(const string& name, StructureMember& resu
 	BNStructureMember* member = BNGetStructureBuilderMemberByName(m_object, name.c_str());
 	if (member)
 	{
-		result.type = new Type(BNNewTypeReference(member->type));
+		result.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(member->type)), member->typeConfidence);
 		result.name = member->name;
 		result.offset = member->offset;
 		BNFreeStructureMember(member);
@@ -2463,7 +2463,7 @@ bool StructureBuilder::GetMemberAtOffset(int64_t offset, StructureMember& result
 	BNStructureMember* member = BNGetStructureBuilderMemberAtOffset(m_object, offset, &idx);
 	if (member)
 	{
-		result.type = new Type(BNNewTypeReference(member->type));
+		result.type = Confidence<Ref<Type>>(new Type(BNNewTypeReference(member->type)), member->typeConfidence);
 		result.name = member->name;
 		result.offset = member->offset;
 		BNFreeStructureMember(member);


### PR DESCRIPTION
Fixes #4543 so that all StructMember structs in the C++ API now have type confidence that core provides.
Also fixes #4703 as it was a simple typo in the PythonScriptingProvider.