### PR TITLE
add sources and link to rust online docs

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -16,7 +16,7 @@
 #![allow(clippy::missing_safety_doc)]
 #![allow(clippy::result_unit_err)]
 #![allow(clippy::type_complexity)]
-#![doc(html_no_source)]
+#![doc(html_root_url = "https://dev-rust.binary.ninja/")]
 #![doc(html_favicon_url = "/favicon.ico")]
 #![doc(html_logo_url = "/logo.png")]
 #![doc(issue_tracker_base_url = "https://github.com/Vector35/binaryninja-api/issues/")]


### PR DESCRIPTION
After a quick exchange on Slack, I'm back with a PR.

This PR aims to enhance the DX of the docs.

When working with the api, you regularly need to look up implementations because you write your own wrapping functions for things not yet part of the official api and it quickly becomes tedious to go to the github code search for every single struct or method.

Additionally, if you skip deps when building docs for a plugin, setting `html_root_url` will cause rustdoc to instead generate a link to the struct hosted on that page.
