### PR TITLE
RISC-V: Fix disassembly of compressed JAL instruction

### DIFF
--- a/arch/riscv/disasm/src/lib.rs
+++ b/arch/riscv/disasm/src/lib.rs
@@ -2395,7 +2395,7 @@ pub trait RiscVDisassembler: Sized + Copy + Clone {
                     }
                     0b001_01 if int_width == 4 => {
                         // JAL
-                        Op::Jal(JTypeInst::new(IntReg::new(0), inst.cj_imm())?)
+                        Op::Jal(JTypeInst::new(IntReg::new(1), inst.cj_imm())?)
                     }
                     0b001_01 => {
                         // ADDIW


### PR DESCRIPTION
Change integer register involved via compressed JAL instruction from 0 (x0 (zero)) to 1 (x1 (ra))