### PR TITLE
Require Hash & Eq implementations for all Register and Flag implementations

### DIFF
--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -6,6 +6,7 @@
 
 use std::borrow::Cow;
 use std::fmt;
+use std::hash::Hash;
 use std::marker::PhantomData;
 
 use binaryninja::relocation::{Relocation, RelocationHandlerExt};
@@ -246,6 +247,20 @@ impl<'a, D: 'static + RiscVDisassembler + Send + Sync> LiftableWithSize<'a, Risc
         }
     }
 }
+
+impl<D: 'static + RiscVDisassembler> Hash for Register<D> {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+    }
+}
+
+impl<D: 'static + RiscVDisassembler> PartialEq for Register<D> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+    }
+}
+
+impl<D: 'static + RiscVDisassembler> Eq for Register<D> {}
 
 impl<D: 'static + RiscVDisassembler + Send + Sync> fmt::Debug for Register<D> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {

--- a/rust/src/architecture.rs
+++ b/rust/src/architecture.rs
@@ -190,7 +190,7 @@ pub trait RegisterInfo: Sized {
     fn implicit_extend(&self) -> ImplicitRegisterExtend;
 }
 
-pub trait Register: Sized + Clone + Copy {
+pub trait Register: Sized + Clone + Copy + Hash + Eq {
     type InfoType: RegisterInfo<RegType = Self>;
 
     fn name(&self) -> Cow<str>;
@@ -230,7 +230,7 @@ pub trait RegisterStack: Sized + Clone + Copy {
     fn id(&self) -> u32;
 }
 
-pub trait Flag: Sized + Clone + Copy {
+pub trait Flag: Sized + Clone + Copy + Hash + Eq {
     type FlagClass: FlagClass;
 
     fn name(&self) -> Cow<str>;


### PR DESCRIPTION
Already present in all the core implementations ([1], [2], [3]), however when being generic over `Architecture` you won't get them. I.e.

```rs
// A: Architecture
let registers: HashMap<A::Register, u128> = HashMap::new();
```

Requiring both Hash & Eq for `Register` and `Flag` implementations means we can use them as `HashMap` keys, which I have ran into on multiple occasions.

This is a very small PR and probably should be expanded on further later to more traits.

[1]: https://github.com/emesare/binaryninja-api/blob/91d762fb5c8666fbe830a48ce6354819cc802e08/rust/src/architecture.rs#L684
[2]: https://github.com/emesare/binaryninja-api/blob/91d762fb5c8666fbe830a48ce6354819cc802e08/rust/src/architecture.rs#L581
[3]: https://github.com/emesare/binaryninja-api/blob/91d762fb5c8666fbe830a48ce6354819cc802e08/rust/src/architecture.rs#L781