### PR TITLE
Expose get_expr_count() on python llil and mlil

### DIFF
--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -3650,6 +3650,14 @@ class LowLevelILFunction:
 			assert False, "flags type unsupported"
 		return ExpressionIndex(core.BNLowLevelILAddExpr(self.handle, operation, size, _flags, a, b, c, d))
 
+	def get_expr_count(self) -> int:
+		"""
+		``get_expr_count`` gives a the total number of expressions in this IL function
+
+		You can use this to enumerate all expressions in conjunction with LowLevelILInstruction.create()
+		"""
+		return core.BNGetLowLevelILExprCount(self.handle)
+
 	def replace_expr(self, original: InstructionOrExpression, new: InstructionOrExpression) -> None:
 		"""
 		``replace_expr`` allows modification of expressions but ONLY during lifting.

--- a/python/mediumlevelil.py
+++ b/python/mediumlevelil.py
@@ -3327,6 +3327,14 @@ class MediumLevelILFunction:
 			_operation = operation.value
 		return ExpressionIndex(core.BNMediumLevelILAddExpr(self.handle, _operation, size, a, b, c, d, e))
 
+	def get_expr_count(self) -> int:
+		"""
+		``get_expr_count`` gives a the total number of expressions in this IL function
+
+		You can use this to enumerate all expressions in conjunction with MediumLevelILInstruction.create()
+		"""
+		return core.BNGeMediumLevelILExprCount(self.handle)
+
 	def replace_expr(self, original: InstructionOrExpression, new: InstructionOrExpression) -> None:
 		"""
 		``replace_expr`` allows modification of MLIL expressions


### PR DESCRIPTION
This is already exposed in the CPP interface, and is useful for workflows for enumerating all expressions in an ILFunction