### PR TITLE
Fix X86_64_RELOC_UNSIGNED not handling external symbols

### DIFF
--- a/arch/x86/arch_x86.cpp
+++ b/arch/x86/arch_x86.cpp
@@ -4187,14 +4187,11 @@ public:
 			dest32[0] = dest32[0] + target - (uint32_t)pcRelAddr;
 			break;
 		case X86_64_RELOC_UNSIGNED:
-			if (!info.external)
+			switch (info.size)
 			{
-				switch (info.size)
-				{
-					case 4: *dest32 += target - (uint32_t)pcRelAddr; break;
-					case 8: *dest64 += info.target - pcRelAddr; break;
-					default: break;
-				}
+				case 4: *dest32 += target - (uint32_t)pcRelAddr; break;
+				case 8: *dest64 += info.target - pcRelAddr; break;
+				default: break;
 			}
 			// TODO rebasing
 			break;


### PR DESCRIPTION
Moved from Vector35/arch-x86#37

Fixes #4869 

References to external symbols with relocations in, for instance, data sections and function calls had incorrect addresses, resulting in incorrect analysis.

(CC: @galenbwill)