### PR TITLE
added all the ps and other ppc extensions, need to decide on getopt for windows stuff and resolve default architecture

### DIFF
--- a/arch/powerpc/CMakeLists.txt
+++ b/arch/powerpc/CMakeLists.txt
@@ -2,8 +2,14 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 project(arch_ppc)
 
+if((NOT BN_API_PATH) AND (NOT BN_INTERNAL_BUILD))
+	set(BN_API_PATH $ENV{BN_API_PATH})
+	if(NOT BN_API_PATH)
+		message(FATAL_ERROR "Provide path to Binary Ninja API source in BN_API_PATH")
+	endif()
+endif()
 if(NOT BN_INTERNAL_BUILD)
-	add_subdirectory(${PROJECT_SOURCE_DIR}/../.. ${PROJECT_BINARY_DIR}/api)
+	add_subdirectory(${BN_API_PATH} ${PROJECT_BINARY_DIR}/api)
 endif()
 
 file(GLOB SOURCES
@@ -46,4 +52,28 @@ if(BN_INTERNAL_BUILD)
 	set_target_properties(arch_ppc PROPERTIES
 		LIBRARY_OUTPUT_DIRECTORY ${BN_CORE_PLUGIN_DIR}
 		RUNTIME_OUTPUT_DIRECTORY ${BN_CORE_PLUGIN_DIR})
+endif()
+
+if (DEFINED FORCE_TEST)
+	set(TEST_INLCUDE_LIST )
+	set(TEST_LINK_DIRECTORIES )
+	set(TEST_LINK_LIBRARIES capstone)
+	
+	if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+		find_package(getopt_for_windows)
+		list(APPEND TEST_INCLUDE_LIST ${getopt_for_windows_INCLUDE_DIR})
+		list(APPEND TEST_LINK_DIRECTORIES ${getopt_for_windows_LIB_DIR})
+		list(APPEND TEST_LINK_LIBRARIES getopt_for_windows_static)
+	endif()
+
+	add_executable(test_disasm test_disasm.cpp disassembler.cpp)
+	add_executable(test_asm test_asm.cpp assembler.cpp)
+	
+	target_include_directories(test_disasm PRIVATE ${TEST_INCLUDE_LIST})
+	target_link_directories(test_disasm PRIVATE ${TEST_LINK_DIRECTORIES})
+	target_link_libraries(test_disasm PRIVATE ${TEST_LINK_LIBRARIES})
+
+	target_include_directories(test_asm PRIVATE ${TEST_INCLUDE_LIST})
+	target_link_directories(test_asm PRIVATE ${TEST_LINK_DIRECTORIES})
+	target_link_libraries(test_asm PRIVATE ${TEST_LINK_LIBRARIES})
 endif()

--- a/arch/powerpc/disassembler.cpp
+++ b/arch/powerpc/disassembler.cpp
@@ -19,7 +19,7 @@ thread_local csh handle_lil = 0;
 thread_local csh handle_big = 0;
 
 extern "C" int
-powerpc_init(void)
+powerpc_init(int cs_mode_arg)
 {
 	int rc = -1;
 
@@ -31,12 +31,12 @@ powerpc_init(void)
 	}
 
 	/* initialize capstone handle */
-	if(cs_open(CS_ARCH_PPC, CS_MODE_BIG_ENDIAN, &handle_big) != CS_ERR_OK) {
+	if(cs_open(CS_ARCH_PPC, (cs_mode)((int)CS_MODE_BIG_ENDIAN | cs_mode_arg), &handle_big) != CS_ERR_OK) {
 		MYLOG("ERROR: cs_open()\n");
 		goto cleanup;
 	}
 
-	if(cs_open(CS_ARCH_PPC, CS_MODE_LITTLE_ENDIAN, &handle_lil) != CS_ERR_OK) {
+	if(cs_open(CS_ARCH_PPC, (cs_mode)((int)CS_MODE_LITTLE_ENDIAN | cs_mode_arg), &handle_lil) != CS_ERR_OK) {
 		MYLOG("ERROR: cs_open()\n");
 		goto cleanup;
 	}
@@ -69,13 +69,13 @@ powerpc_release(void)
 
 extern "C" int
 powerpc_decompose(const uint8_t *data, int size, uint32_t addr, bool lil_end,
-	struct decomp_result *res)
+	struct decomp_result *res, int cs_mode_arg)
 {
 	int rc = -1;
 	res->status = STATUS_ERROR_UNSPEC;
 
 	if(!handle_lil) {
-		powerpc_init();
+		powerpc_init(cs_mode_arg);
 	}
 
 	//typedef struct cs_insn {
@@ -120,6 +120,7 @@ powerpc_decompose(const uint8_t *data, int size, uint32_t addr, bool lil_end,
 	// } cs_ppc_op;
 
 	csh handle;
+	struct cs_struct *hand_tmp = 0;
 	cs_insn *insn = 0; /* instruction information
 					cs_disasm() will allocate array of cs_insn here */
 
@@ -128,6 +129,9 @@ powerpc_decompose(const uint8_t *data, int size, uint32_t addr, bool lil_end,
 	handle = handle_big;
 	if(lil_end) handle = handle_lil;
 	res->handle = handle;
+
+	hand_tmp = (struct cs_struct *)handle;
+	hand_tmp->mode = (cs_mode)((int)hand_tmp->mode | cs_mode_arg);
 
 	/* call */
 	size_t n = cs_disasm(handle, data, size, addr, 1, &insn);
@@ -174,10 +178,10 @@ powerpc_disassemble(struct decomp_result *res, char *buf, size_t len)
 }
 
 extern "C" const char *
-powerpc_reg_to_str(uint32_t rid)
+powerpc_reg_to_str(uint32_t rid, int cs_mode_arg)
 {
 	if(!handle_lil) {
-		powerpc_init();
+		powerpc_init(cs_mode_arg);
 	}
 
 	return cs_reg_name(handle_lil, rid);

--- a/arch/powerpc/disassembler.h
+++ b/arch/powerpc/disassembler.h
@@ -23,6 +23,7 @@ Then some helpers if you need them:
 
 /* capstone stuff /usr/local/include/capstone */
 #include "capstone/capstone.h"
+#include "capstone/cs_priv.h"
 #include "capstone/ppc.h"
 
 //*****************************************************************************
@@ -59,11 +60,11 @@ struct decomp_result
 //*****************************************************************************
 // function prototypes
 //*****************************************************************************
-extern "C" int powerpc_init(void);
+extern "C" int powerpc_init(int);
 extern "C" void powerpc_release(void);
 extern "C" int powerpc_decompose(const uint8_t *data, int size, uint32_t addr, 
-	bool lil_end, struct decomp_result *result);
+	bool lil_end, struct decomp_result *result, int);
 extern "C" int powerpc_disassemble(struct decomp_result *, char *buf, size_t len);
 
-extern "C" const char *powerpc_reg_to_str(uint32_t rid);
+extern "C" const char *powerpc_reg_to_str(uint32_t rid, int);
 

--- a/arch/powerpc/test_asm.cpp
+++ b/arch/powerpc/test_asm.cpp
@@ -23,7 +23,11 @@ using namespace std;
 
 #include <sys/types.h>
 #include <sys/stat.h>
+#if defined(_WIN32)
+#include <winpos.h>
+#else
 #include <unistd.h>
+#endif
 
 #include "assembler.h"
 

--- a/arch/powerpc/test_disasm.cpp
+++ b/arch/powerpc/test_disasm.cpp
@@ -15,9 +15,16 @@ g++ -std=c++11 -O0 -g -I capstone/include -L./build/capstone test_disasm.cpp dis
 #include <stdlib.h>
 #include <time.h>
 
+#if defined(_WIN32)
+#include <winpos.h>
+#else
+#include <unistd.h>
+#endif
+
 #include "disassembler.h"
 
 int print_errors = 1;
+int cs_mode_local = 0;
 
 int disas_instr_word(uint32_t instr_word, char *buf)
 {
@@ -28,7 +35,7 @@ int disas_instr_word(uint32_t instr_word, char *buf)
 	struct cs_detail *detail = &(res.detail);
 	struct cs_ppc *ppc = &(detail->ppc);
 
-	if(powerpc_decompose((const uint8_t *)&instr_word, 4, 0, true, &res)) {
+	if(powerpc_decompose((const uint8_t *)&instr_word, 4, 0, true, &res, cs_mode_local)) {
 		if(print_errors) printf("ERROR: powerpc_decompose()\n");
 		goto cleanup;
 	}
@@ -106,21 +113,52 @@ int disas_instr_word(uint32_t instr_word, char *buf)
 	return rc;
 }
 
+void usage()
+{
+	printf("send argument \"repl\" or \"speed\"\n");
+}
+
 int main(int ac, char **av)
 {
 	int rc = -1;
 	char buf[256];
+	int index;
+	char* disasm_cmd = 0;
+	int c;
 
-	#define BATCH 10000000
+#define BATCH 10000000
+	opterr = 0;
 
-	powerpc_init();
+	while ((c = getopt(ac, av, "qsp")) != -1)
+	{
+		switch (c)
+		{
+		case 'q':
+			cs_mode_local = CS_MODE_QPX;
+			break;
+		case 's':
+			cs_mode_local = CS_MODE_SPE;
+			break;
+		case 'p':
+			cs_mode_local = CS_MODE_PS;
+			break;
+		default:
+			usage();
+			goto cleanup;
+		}
+	}
 
-	if(ac <= 1) {
-		printf("send argument \"repl\" or \"speed\"\n");
+	if (optind >= ac)
+	{
+		usage();
 		goto cleanup;
 	}
 
-	if(!strcasecmp(av[1], "repl")) {
+	disasm_cmd = av[optind];
+
+	powerpc_init(cs_mode_local);
+
+	if(!strcasecmp(disasm_cmd, "repl")) {
 		printf("REPL mode!\n");
 		printf("example inputs (write the words as if after endian fetch):\n");
 		printf("93e1fffc\n");
@@ -148,7 +186,7 @@ int main(int ac, char **av)
 			printf("%s\n", buf);
 		}
 	}
-	else if(!strcasecmp(av[1], "speed")) {
+	else if(!strcasecmp(disasm_cmd, "speed")) {
 		printf("SPEED TEST THAT COUNTS QUICK RETURNS FROM BAD INSTRUCTIONS AS DISASSEMBLED\n");
 		print_errors = 0;
 		uint32_t instr_word = 0x780b3f7c;
@@ -167,7 +205,7 @@ int main(int ac, char **av)
 			printf("current rate: %f instructions per second\n", (float)BATCH/ellapsed);
 		}
 	}
-	else if(!strcasecmp(av[1], "speed2")) {
+	else if(!strcasecmp(disasm_cmd, "speed2")) {
 		printf("SPEED TEST THAT IS GIVEN NO CREDIT FOR QUICK RETURNS FROM BAD INSTRUCTIONS\n");
 		print_errors = 0;
 		uint32_t instr_word = 0x780b3f7c;


### PR DESCRIPTION
Adding the other powerpc extensions, unfortunately unix to windows differences require some external libraries.

- Need to decide if its ok to either submodule https://github.com/v1X3Q0/getopt-for-windows.git or if we should not include windows support.
- Default to ppc_ps for the architecture right now, need to fix it so it defaults to ppc and correctly allows selection of each architecture arbitrarily.
- To have each architecture properly selected, may require adding platforms for each.