### PR TITLE
Fixed segment / section misalignment in TE view

### DIFF
--- a/view/pe/teview.h
+++ b/view/pe/teview.h
@@ -59,6 +59,7 @@ namespace BinaryNinja
 		Ref<Logger> m_logger;
 		bool m_backedByDatabase;
 		uint64_t m_imageBase;
+		uint64_t m_headersOffset;
 		Ref<Architecture> m_arch;
 		uint64_t m_entryPoint;
 		


### PR DESCRIPTION
This commit fixes an issue in the TE view while creating segments and sections. Segments and sections are calculated from the base of the original PE file, prior to the PE headers being stripped and replaced with the TE header