### PR TITLE
Fix mismatching operand size when lifting `movd/movq/vmovd/vmovq` instructions

### DIFF
--- a/arch/x86/il.cpp
+++ b/arch/x86/il.cpp
@@ -2110,7 +2110,7 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 	case XED_ICLASS_MOVDIR64B:
 		il.AddInstruction(
 			WriteILOperand(il, xedd, addr, 0, 0,
-				ReadILOperand(il, xedd, addr, 1, 1)));
+				ReadILOperand(il, xedd, addr, 1, 1, opOneLen)));
 		break;
 
 	case XED_ICLASS_MOVSX:

--- a/arch/x86/test_lifting.py
+++ b/arch/x86/test_lifting.py
@@ -26,9 +26,15 @@ tests_basics = [
     (b'\x90', 'LLIL_NOP()')
 ]
 
+tests_movd = [
+    # vmovd eax, xmm0
+    (b'\xC5\xF9\x7E\xC0', 'LLIL_SET_REG.d(eax,LLIL_REG.d(xmm0))'),
+]
+
 test_cases = \
     tests_interrupts + \
-    tests_basics
+    tests_basics + \
+    tests_movd
 
 import re
 import sys


### PR DESCRIPTION
Moved from https://github.com/Vector35/arch-x86/pull/38.