### PR TITLE
Improve TE Header type definitions

### DIFF
--- a/view/pe/teview.cpp
+++ b/view/pe/teview.cpp
@@ -160,7 +160,8 @@ void TEView::AssignHeaderTypes()
 	headerBuilder.AddMember(Type::IntegerType(4, false), "addressOfEntryPoint");
 	headerBuilder.AddMember(Type::IntegerType(4, false), "baseOfCode");
 	headerBuilder.AddMember(Type::IntegerType(8, false), "imageBase");
-	headerBuilder.AddMember(Type::ArrayType(Type::NamedType(this, dataDirectoryTypeName), 2), "dataDirectory");
+	headerBuilder.AddMember(Type::NamedType(this, dataDirectoryTypeName), "baseRelocationTableEntry");
+	headerBuilder.AddMember(Type::NamedType(this, dataDirectoryTypeName), "debugEntry");
 
 	auto headerStruct = headerBuilder.Finalize();
 	auto headerType = Type::StructureType(headerStruct);


### PR DESCRIPTION
Brings the TE header definitions more in-line with the PE view:
1. Rename header fields to camelCase
2. Use arrays when applicable
3. Define some named data symbols

What remains to be done is to define the three enum types used for the "machine", "subsystem", and "characteristics" fields. Since these enums are unmodified from the PE standard, I'm not sure I want to redefine them on their own in the TE view, or if they should somehow be imported/re-used between the two views.