### PR TITLE
reduce complexity by removing rc::Ref

### DIFF
--- a/rust/examples/decompile/src/main.rs
+++ b/rust/examples/decompile/src/main.rs
@@ -47,7 +47,7 @@ fn main() {
     eprintln!("Function count: {}", bv.functions().len());
 
     for func in &bv.functions() {
-        decompile_to_c(bv.as_ref(), func.as_ref());
+        decompile_to_c(bv.as_ref(), func);
     }
 
     binaryninja::headless::shutdown();

--- a/rust/examples/dwarf/dwarf_import/src/die_handlers.rs
+++ b/rust/examples/dwarf/dwarf_import/src/die_handlers.rs
@@ -16,10 +16,7 @@ use crate::dwarfdebuginfo::{DebugInfoBuilder, DebugInfoBuilderContext, TypeUID};
 use crate::helpers::*;
 use crate::types::get_type;
 
-use binaryninja::{
-    rc::*,
-    types::{EnumerationBuilder, FunctionParameter, ReferenceType, Type, TypeBuilder},
-};
+use binaryninja::types::{EnumerationBuilder, FunctionParameter, ReferenceType, Type, TypeBuilder};
 
 use gimli::{constants, AttributeValue::Encoding, DebuggingInformationEntry, Reader, Unit};
 
@@ -27,7 +24,7 @@ pub(crate) fn handle_base_type<R: Reader<Offset = usize>>(
     unit: &Unit<R>,
     entry: &DebuggingInformationEntry<R>,
     debug_info_builder_context: &DebugInfoBuilderContext<R>,
-) -> Option<Ref<Type>> {
+) -> Option<Type> {
     // All base types have:
     //   DW_AT_encoding (our concept of type_class)
     //   DW_AT_byte_size and/or DW_AT_bit_size
@@ -73,7 +70,7 @@ pub(crate) fn handle_enum<R: Reader<Offset = usize>>(
     unit: &Unit<R>,
     entry: &DebuggingInformationEntry<R>,
     debug_info_builder_context: &DebugInfoBuilderContext<R>,
-) -> Option<Ref<Type>> {
+) -> Option<Type> {
     // All base types have:
     //   DW_AT_byte_size
     //   *DW_AT_name
@@ -132,7 +129,7 @@ pub(crate) fn handle_typedef(
     debug_info_builder: &mut DebugInfoBuilder,
     entry_type: Option<TypeUID>,
     typedef_name: String,
-) -> (Option<Ref<Type>>, bool) {
+) -> (Option<Type>, bool) {
     // All base types have:
     //   DW_AT_name
     //   *DW_AT_type
@@ -159,7 +156,7 @@ pub(crate) fn handle_pointer<R: Reader<Offset = usize>>(
     debug_info_builder: &mut DebugInfoBuilder,
     entry_type: Option<TypeUID>,
     reference_type: ReferenceType,
-) -> Option<Ref<Type>> {
+) -> Option<Type> {
     // All pointer types have:
     //   DW_AT_type
     //   *DW_AT_byte_size
@@ -174,7 +171,7 @@ pub(crate) fn handle_pointer<R: Reader<Offset = usize>>(
         if let Some(entry_type_offset) = entry_type {
             let parent_type = debug_info_builder.get_type(entry_type_offset).unwrap().1;
             Some(Type::pointer_of_width(
-                parent_type.as_ref(),
+                &parent_type,
                 pointer_size,
                 false,
                 false,
@@ -182,7 +179,7 @@ pub(crate) fn handle_pointer<R: Reader<Offset = usize>>(
             ))
         } else {
             Some(Type::pointer_of_width(
-                Type::void().as_ref(),
+                &Type::void(),
                 pointer_size,
                 false,
                 false,
@@ -192,7 +189,7 @@ pub(crate) fn handle_pointer<R: Reader<Offset = usize>>(
     } else if let Some(entry_type_offset) = entry_type {
         let parent_type = debug_info_builder.get_type(entry_type_offset).unwrap().1;
         Some(Type::pointer_of_width(
-            parent_type.as_ref(),
+            &parent_type,
             debug_info_builder_context.default_address_size(),
             false,
             false,
@@ -200,7 +197,7 @@ pub(crate) fn handle_pointer<R: Reader<Offset = usize>>(
         ))
     } else {
         Some(Type::pointer_of_width(
-            Type::void().as_ref(),
+            &Type::void(),
             debug_info_builder_context.default_address_size(),
             false,
             false,
@@ -214,7 +211,7 @@ pub(crate) fn handle_array<R: Reader<Offset = usize>>(
     entry: &DebuggingInformationEntry<R>,
     debug_info_builder: &mut DebugInfoBuilder,
     entry_type: Option<TypeUID>,
-) -> Option<Ref<Type>> {
+) -> Option<Type> {
     // All array types have:
     //    DW_AT_type
     //   *DW_AT_name
@@ -234,22 +231,16 @@ pub(crate) fn handle_array<R: Reader<Offset = usize>>(
         let mut children = tree.root().unwrap().children();
 
         // TODO : This is currently applying the size in reverse order
-        let mut result_type: Option<Ref<Type>> = None;
+        let mut result_type: Option<Type> = None;
         while let Ok(Some(child)) = children.next() {
             if let Some(inner_type) = result_type {
-                result_type = Some(Type::array(
-                    inner_type.as_ref(),
-                    get_subrange_size(child.entry()),
-                ));
+                result_type = Some(Type::array(&inner_type, get_subrange_size(child.entry())));
             } else {
-                result_type = Some(Type::array(
-                    parent_type.as_ref(),
-                    get_subrange_size(child.entry()),
-                ));
+                result_type = Some(Type::array(&parent_type, get_subrange_size(child.entry())));
             }
         }
 
-        result_type.map_or(Some(Type::array(parent_type.as_ref(), 0)), Some)
+        result_type.map_or(Some(Type::array(&parent_type, 0)), Some)
     } else {
         None
     }
@@ -261,7 +252,7 @@ pub(crate) fn handle_function<R: Reader<Offset = usize>>(
     debug_info_builder_context: &DebugInfoBuilderContext<R>,
     debug_info_builder: &mut DebugInfoBuilder,
     entry_type: Option<TypeUID>,
-) -> Option<Ref<Type>> {
+) -> Option<Type> {
     // All subroutine types have:
     //   *DW_AT_name
     //   *DW_AT_type (if not provided, void)
@@ -301,11 +292,7 @@ pub(crate) fn handle_function<R: Reader<Offset = usize>>(
             name.clone(),
             Type::named_type_from_type(
                 name,
-                &Type::function::<String, &binaryninja::types::Type>(
-                    return_type.as_ref(),
-                    &[],
-                    false,
-                ),
+                &Type::function::<String, &binaryninja::types::Type>(&return_type, &[], false),
             ),
             false,
         );
@@ -343,7 +330,7 @@ pub(crate) fn handle_function<R: Reader<Offset = usize>>(
     }
 
     Some(Type::function(
-        return_type.as_ref(),
+        &return_type,
         &parameters,
         variable_arguments,
     ))
@@ -352,7 +339,7 @@ pub(crate) fn handle_function<R: Reader<Offset = usize>>(
 pub(crate) fn handle_const(
     debug_info_builder: &mut DebugInfoBuilder,
     entry_type: Option<TypeUID>,
-) -> Option<Ref<Type>> {
+) -> Option<Type> {
     // All const types have:
     //   ?DW_AT_allocated
     //   ?DW_AT_associated
@@ -363,7 +350,7 @@ pub(crate) fn handle_const(
 
     if let Some(entry_type_offset) = entry_type {
         let parent_type = debug_info_builder.get_type(entry_type_offset).unwrap().1;
-        Some((*parent_type).to_builder().set_const(true).finalize())
+        Some(parent_type.to_builder().set_const(true).finalize())
     } else {
         Some(TypeBuilder::void().set_const(true).finalize())
     }
@@ -372,7 +359,7 @@ pub(crate) fn handle_const(
 pub(crate) fn handle_volatile(
     debug_info_builder: &mut DebugInfoBuilder,
     entry_type: Option<TypeUID>,
-) -> Option<Ref<Type>> {
+) -> Option<Type> {
     // All const types have:
     //   ?DW_AT_allocated
     //   ?DW_AT_associated
@@ -383,7 +370,7 @@ pub(crate) fn handle_volatile(
 
     if let Some(entry_type_offset) = entry_type {
         let parent_type = debug_info_builder.get_type(entry_type_offset).unwrap().1;
-        Some((*parent_type).to_builder().set_volatile(true).finalize())
+        Some(parent_type.to_builder().set_volatile(true).finalize())
     } else {
         Some(TypeBuilder::void().set_volatile(true).finalize())
     }

--- a/rust/examples/dwarf/dwarf_import/src/lib.rs
+++ b/rust/examples/dwarf/dwarf_import/src/lib.rs
@@ -106,8 +106,7 @@ fn recover_names<R: Reader<Offset = usize>>(
                                 }
                             }
                         } else {
-                            namespace_qualifiers
-                                .push((depth, "anonymous_namespace".to_string()));
+                            namespace_qualifiers.push((depth, "anonymous_namespace".to_string()));
                         }
                     }
 
@@ -129,22 +128,24 @@ fn recover_names<R: Reader<Offset = usize>>(
                             depth,
                             match entry.tag() {
                                 constants::DW_TAG_class_type => "anonymous_class".to_string(),
-                                constants::DW_TAG_structure_type => "anonymous_structure".to_string(),
+                                constants::DW_TAG_structure_type => {
+                                    "anonymous_structure".to_string()
+                                }
                                 constants::DW_TAG_union_type => "anonymous_union".to_string(),
                                 _ => unreachable!(),
-                            }
+                            },
                         ))
                     }
                     debug_info_builder_context.set_name(
                         get_uid(&unit, entry),
-                            simplify_str_to_str(
-                                namespace_qualifiers
-                                    .iter()
-                                    .map(|(_, namespace)| namespace.to_owned())
-                                    .collect::<Vec<String>>()
-                                    .join("::"),
-                            )
-                            .to_string(),
+                        simplify_str_to_str(
+                            namespace_qualifiers
+                                .iter()
+                                .map(|(_, namespace)| namespace.to_owned())
+                                .collect::<Vec<String>>()
+                                .join("::"),
+                        )
+                        .to_string(),
                     );
                 }
                 constants::DW_TAG_typedef
@@ -153,17 +154,15 @@ fn recover_names<R: Reader<Offset = usize>>(
                     if let Some(name) = get_name(&unit, entry, debug_info_builder_context) {
                         debug_info_builder_context.set_name(
                             get_uid(&unit, entry),
-                                simplify_str_to_str(
-                                    namespace_qualifiers
-                                        .iter()
-                                        .chain(vec![&(-1, name)].into_iter())
-                                        .map(|(_, namespace)| {
-                                            namespace.to_owned()
-                                        })
-                                        .collect::<Vec<String>>()
-                                        .join("::"),
-                                )
-                                .to_string(),
+                            simplify_str_to_str(
+                                namespace_qualifiers
+                                    .iter()
+                                    .chain(vec![&(-1, name)].into_iter())
+                                    .map(|(_, namespace)| namespace.to_owned())
+                                    .collect::<Vec<String>>()
+                                    .join("::"),
+                            )
+                            .to_string(),
                         );
                     }
                 }

--- a/rust/examples/dwarf/dwarf_import/src/types.rs
+++ b/rust/examples/dwarf/dwarf_import/src/types.rs
@@ -16,11 +16,8 @@ use crate::die_handlers::*;
 use crate::dwarfdebuginfo::{DebugInfoBuilder, DebugInfoBuilderContext, TypeUID};
 use crate::helpers::*;
 
-use binaryninja::{
-    rc::*,
-    types::{
-        MemberAccess, MemberScope, ReferenceType, StructureBuilder, StructureType, Type, TypeClass,
-    },
+use binaryninja::types::{
+    MemberAccess, MemberScope, ReferenceType, StructureBuilder, StructureType, Type, TypeClass,
 };
 
 use gimli::{constants, DebuggingInformationEntry, Reader, Unit};
@@ -164,7 +161,7 @@ fn do_structure_parse<R: Reader<Offset = usize>>(
                                 });
 
                             structure_builder.insert(
-                                child_type.as_ref(),
+                                &child_type,
                                 child_name,
                                 struct_offset,
                                 false,
@@ -173,7 +170,7 @@ fn do_structure_parse<R: Reader<Offset = usize>>(
                             );
                         } else {
                             structure_builder.append(
-                                child_type.as_ref(),
+                                &child_type,
                                 child_name,
                                 MemberAccess::NoAccess,
                                 MemberScope::NoScope,
@@ -270,7 +267,7 @@ pub(crate) fn get_type<R: Reader<Offset = usize>>(
 
     // Collect the required information to create a type and add it to the type map. Also, add the dependencies of this type to the type's typeinfo
     // Create the type, make a TypeInfo for it, and add it to the debug info
-    let (type_def, mut commit): (Option<Ref<Type>>, bool) = match entry.tag() {
+    let (type_def, mut commit): (Option<Type>, bool) = match entry.tag() {
         constants::DW_TAG_base_type => (
             handle_base_type(unit, entry, debug_info_builder_context),
             false,

--- a/rust/examples/dwarf/dwarfdump/src/lib.rs
+++ b/rust/examples/dwarf/dwarfdump/src/lib.rs
@@ -34,7 +34,7 @@ use gimli::{
     UnitSectionOffset,
 };
 
-static PADDING: [&'static str; 23] = [
+static PADDING: [&str; 23] = [
     "",
     " ",
     "  ",
@@ -190,7 +190,7 @@ fn get_info_string<R: Reader>(
             let value_string = format!("{}", value);
             attr_line.push(InstructionTextToken::new(
                 BnString::new(value_string),
-                InstructionTextTokenContents::Integer(value.into()),
+                InstructionTextTokenContents::Integer(value),
             ));
         } else if let Some(value) = attr.sdata_value() {
             let value_string = format!("{}", value);

--- a/rust/examples/hlil_visitor/src/main.rs
+++ b/rust/examples/hlil_visitor/src/main.rs
@@ -146,7 +146,7 @@ fn print_variable(func: &HighLevelILFunction, var: &Variable) {
 fn print_il_expr(instr: &HighLevelILLiftedInstruction, mut indent: usize) {
     print_indent(indent);
     print_operation(instr);
-    println!("");
+    println!();
 
     indent += 1;
 

--- a/rust/examples/minidump/src/view.rs
+++ b/rust/examples/minidump/src/view.rs
@@ -128,7 +128,7 @@ struct SegmentMemoryProtection {
 /// This contains the main logic to load the memory segments inside a minidump file into the binary view.
 pub struct MinidumpBinaryView {
     /// The handle to the "real" BinaryView object, in the Binary Ninja core.
-    inner: binaryninja::rc::Ref<BinaryView>,
+    inner: BinaryView,
 }
 
 impl MinidumpBinaryView {
@@ -319,7 +319,7 @@ impl MinidumpBinaryView {
         minidump_cpu_arch: minidump::system_info::Cpu,
         minidump_endian: minidump::Endian,
         minidump_os: minidump::system_info::Os,
-    ) -> Option<binaryninja::rc::Ref<Platform>> {
+    ) -> Option<Platform> {
         match minidump_os {
             minidump::system_info::Os::Windows => match minidump_cpu_arch {
                 minidump::system_info::Cpu::Arm64 => Platform::by_name("windows-aarch64"),

--- a/rust/examples/mlil_visitor/src/main.rs
+++ b/rust/examples/mlil_visitor/src/main.rs
@@ -154,7 +154,7 @@ fn print_variable(func: &MediumLevelILFunction, var: &Variable) {
 fn print_il_expr(instr: &MediumLevelILLiftedInstruction, mut indent: usize) {
     print_indent(indent);
     print_operation(instr);
-    println!("");
+    println!();
 
     indent += 1;
 

--- a/rust/src/architecture.rs
+++ b/rust/src/architecture.rs
@@ -35,7 +35,6 @@ use crate::{
         get_default_flag_cond_llil, get_default_flag_write_llil, FlagWriteOp, LiftedExpr, Lifter,
     },
     platform::Platform,
-    rc::*,
     relocation::CoreRelocationHandler,
     string::BnStrCompatible,
     string::*,
@@ -316,7 +315,7 @@ pub trait Intrinsic: Sized + Clone + Copy {
     fn inputs(&self) -> Vec<NameAndType<String>>;
 
     /// Returns the list of the output types for this intrinsic.
-    fn outputs(&self) -> Vec<Conf<Ref<Type>>>;
+    fn outputs(&self) -> Vec<Conf<Type>>;
 }
 
 pub trait Architecture: 'static + Sized + AsRef<CoreArchitecture> {
@@ -653,7 +652,7 @@ impl Intrinsic for UnusedIntrinsic {
     fn inputs(&self) -> Vec<NameAndType<String>> {
         unreachable!()
     }
-    fn outputs(&self) -> Vec<Conf<Ref<Type>>> {
+    fn outputs(&self) -> Vec<Conf<Type>> {
         unreachable!()
     }
 }
@@ -1009,7 +1008,7 @@ impl Intrinsic for crate::architecture::CoreIntrinsic {
         }
     }
 
-    fn outputs(&self) -> Vec<Conf<Ref<Type>>> {
+    fn outputs(&self) -> Vec<Conf<Type>> {
         let mut count: usize = 0;
 
         unsafe {
@@ -1172,7 +1171,7 @@ impl Architecture for CoreArchitecture {
             }
         }
     }
-    
+
     fn instruction_llil(
         &self,
         data: &[u8],
@@ -1552,7 +1551,7 @@ impl Architecture for CoreArchitecture {
 
 macro_rules! cc_func {
     ($get_name:ident, $get_api:ident, $set_name:ident, $set_api:ident) => {
-        fn $get_name(&self) -> Option<Ref<CallingConvention<Self>>> {
+        fn $get_name(&self) -> Option<CallingConvention<Self>> {
             let handle = self.as_ref();
 
             unsafe {
@@ -1622,7 +1621,7 @@ pub trait ArchitectureExt: Architecture {
         BNSetArchitectureFastcallCallingConvention
     );
 
-    fn standalone_platform(&self) -> Option<Ref<Platform>> {
+    fn standalone_platform(&self) -> Option<Platform> {
         unsafe {
             let handle = BNGetArchitectureStandalonePlatform(self.as_ref().0);
 
@@ -1630,11 +1629,11 @@ pub trait ArchitectureExt: Architecture {
                 return None;
             }
 
-            Some(Platform::ref_from_raw(handle))
+            Some(Platform::from_raw(handle))
         }
     }
 
-    fn relocation_handler(&self, view_name: &str) -> Option<Ref<CoreRelocationHandler>> {
+    fn relocation_handler(&self, view_name: &str) -> Option<CoreRelocationHandler> {
         let view_name = match CString::new(view_name) {
             Ok(view_name) => view_name,
             Err(_) => return None,
@@ -1647,7 +1646,7 @@ pub trait ArchitectureExt: Architecture {
                 return None;
             }
 
-            Some(CoreRelocationHandler::ref_from_raw(handle))
+            Some(CoreRelocationHandler::from_raw(handle))
         }
     }
 

--- a/rust/src/demangle.rs
+++ b/rust/src/demangle.rs
@@ -30,7 +30,7 @@ pub fn demangle_gnu3<S: BnStrCompatible>(
     arch: &CoreArchitecture,
     mangled_name: S,
     simplify: bool,
-) -> Result<(Option<Ref<Type>>, Vec<String>)> {
+) -> Result<(Option<Type>, Vec<String>)> {
     let mangled_name_bwn = mangled_name.into_bytes_with_nul();
     let mangled_name_ptr = mangled_name_bwn.as_ref();
     let mut out_type: *mut BNType = unsafe { std::mem::zeroed() };
@@ -63,7 +63,7 @@ pub fn demangle_gnu3<S: BnStrCompatible>(
             log::debug!("demangle_gnu3: out_type is NULL");
             None
         }
-        false => Some(unsafe { Type::ref_from_raw(out_type) }),
+        false => Some(unsafe { Type::from_raw(out_type) }),
     };
 
     if out_name.is_null() {
@@ -85,7 +85,7 @@ pub fn demangle_ms<S: BnStrCompatible>(
     arch: &CoreArchitecture,
     mangled_name: S,
     simplify: bool,
-) -> Result<(Option<Ref<Type>>, Vec<String>)> {
+) -> Result<(Option<Type>, Vec<String>)> {
     let mangled_name_bwn = mangled_name.into_bytes_with_nul();
     let mangled_name_ptr = mangled_name_bwn.as_ref();
 
@@ -119,7 +119,7 @@ pub fn demangle_ms<S: BnStrCompatible>(
             log::debug!("demangle_ms: out_type is NULL");
             None
         }
-        false => Some(unsafe { Type::ref_from_raw(out_type) }),
+        false => Some(unsafe { Type::from_raw(out_type) }),
     };
 
     if out_name.is_null() {

--- a/rust/src/function.rs
+++ b/rust/src/function.rs
@@ -30,7 +30,6 @@ pub use binaryninjacore_sys::BNAnalysisSkipReason as AnalysisSkipReason;
 pub use binaryninjacore_sys::BNFunctionAnalysisSkipOverride as FunctionAnalysisSkipOverride;
 pub use binaryninjacore_sys::BNFunctionUpdateType as FunctionUpdateType;
 
-
 use std::hash::Hash;
 use std::{fmt, mem};
 
@@ -56,7 +55,7 @@ impl From<(CoreArchitecture, u64)> for Location {
 
 pub struct NativeBlockIter {
     arch: CoreArchitecture,
-    bv: Ref<BinaryView>,
+    bv: BinaryView,
     cur: u64,
     end: u64,
 }
@@ -113,6 +112,7 @@ impl BlockContext for NativeBlock {
     }
 }
 
+#[repr(transparent)]
 #[derive(Eq)]
 pub struct Function {
     pub(crate) handle: *mut BNFunction,
@@ -122,8 +122,8 @@ unsafe impl Send for Function {}
 unsafe impl Sync for Function {}
 
 impl Function {
-    pub(crate) unsafe fn from_raw(handle: *mut BNFunction) -> Ref<Self> {
-        Ref::new(Self { handle })
+    pub(crate) unsafe fn from_raw(handle: *mut BNFunction) -> Self {
+        Self { handle }
     }
 
     pub fn arch(&self) -> CoreArchitecture {
@@ -133,24 +133,24 @@ impl Function {
         }
     }
 
-    pub fn platform(&self) -> Ref<Platform> {
+    pub fn platform(&self) -> Platform {
         unsafe {
             let plat = BNGetFunctionPlatform(self.handle);
-            Platform::ref_from_raw(plat)
+            Platform::from_raw(plat)
         }
     }
 
-    pub fn view(&self) -> Ref<BinaryView> {
+    pub fn view(&self) -> BinaryView {
         unsafe {
             let view = BNGetFunctionData(self.handle);
             BinaryView::from_raw(view)
         }
     }
 
-    pub fn symbol(&self) -> Ref<Symbol> {
+    pub fn symbol(&self) -> Symbol {
         unsafe {
             let sym = BNGetFunctionSymbol(self.handle);
-            Symbol::ref_from_raw(sym)
+            Symbol::from_raw(sym)
         }
     }
 
@@ -219,7 +219,7 @@ impl Function {
         &self,
         arch: &CoreArchitecture,
         addr: u64,
-    ) -> Option<Ref<BasicBlock<NativeBlock>>> {
+    ) -> Option<BasicBlock<NativeBlock>> {
         unsafe {
             let block = BNGetFunctionBasicBlockAtAddress(self.handle, arch.0, addr);
             let context = NativeBlock { _priv: () };
@@ -228,7 +228,7 @@ impl Function {
                 return None;
             }
 
-            Some(Ref::new(BasicBlock::from_raw(block, context)))
+            Some(BasicBlock::from_raw(block, context))
         }
     }
 
@@ -240,7 +240,7 @@ impl Function {
         }
     }
 
-    pub fn high_level_il(&self, full_ast: bool) -> Result<Ref<hlil::HighLevelILFunction>, ()> {
+    pub fn high_level_il(&self, full_ast: bool) -> Result<hlil::HighLevelILFunction, ()> {
         unsafe {
             let hlil = BNGetFunctionHighLevelIL(self.handle);
 
@@ -248,11 +248,11 @@ impl Function {
                 return Err(());
             }
 
-            Ok(hlil::HighLevelILFunction::ref_from_raw(hlil, full_ast))
+            Ok(hlil::HighLevelILFunction::from_raw(hlil, full_ast))
         }
     }
 
-    pub fn medium_level_il(&self) -> Result<Ref<mlil::MediumLevelILFunction>, ()> {
+    pub fn medium_level_il(&self) -> Result<mlil::MediumLevelILFunction, ()> {
         unsafe {
             let mlil = BNGetFunctionMediumLevelIL(self.handle);
 
@@ -260,11 +260,11 @@ impl Function {
                 return Err(());
             }
 
-            Ok(mlil::MediumLevelILFunction::ref_from_raw(mlil))
+            Ok(mlil::MediumLevelILFunction::from_raw(mlil))
         }
     }
 
-    pub fn low_level_il(&self) -> Result<Ref<llil::RegularFunction<CoreArchitecture>>, ()> {
+    pub fn low_level_il(&self) -> Result<llil::RegularFunction<CoreArchitecture>, ()> {
         unsafe {
             let llil = BNGetFunctionLowLevelIL(self.handle);
 
@@ -276,7 +276,7 @@ impl Function {
         }
     }
 
-    pub fn lifted_il(&self) -> Result<Ref<llil::LiftedFunction<CoreArchitecture>>, ()> {
+    pub fn lifted_il(&self) -> Result<llil::LiftedFunction<CoreArchitecture>, ()> {
         unsafe {
             let llil = BNGetFunctionLiftedIL(self.handle);
 
@@ -288,17 +288,14 @@ impl Function {
         }
     }
 
-    pub fn return_type(&self) -> Conf<Ref<Type>> {
+    pub fn return_type(&self) -> Conf<Type> {
         let result = unsafe { BNGetFunctionReturnType(self.handle) };
 
-        Conf::new(
-            unsafe { Type::ref_from_raw(result.type_) },
-            result.confidence,
-        )
+        Conf::new(unsafe { Type::from_raw(result.type_) }, result.confidence)
     }
 
-    pub fn function_type(&self) -> Ref<Type> {
-        unsafe { Type::ref_from_raw(BNGetFunctionType(self.handle)) }
+    pub fn function_type(&self) -> Type {
+        unsafe { Type::from_raw(BNGetFunctionType(self.handle)) }
     }
 
     pub fn set_user_type(&self, t: Type) {
@@ -376,23 +373,15 @@ impl fmt::Debug for Function {
     }
 }
 
-impl ToOwned for Function {
-    type Owned = Ref<Self>;
-
-    fn to_owned(&self) -> Self::Owned {
-        unsafe { RefCountable::inc_ref(self) }
+impl Clone for Function {
+    fn clone(&self) -> Self {
+        unsafe { Self::from_raw(BNNewFunctionReference(self.handle)) }
     }
 }
 
-unsafe impl RefCountable for Function {
-    unsafe fn inc_ref(handle: &Self) -> Ref<Self> {
-        Ref::new(Self {
-            handle: BNNewFunctionReference(handle.handle),
-        })
-    }
-
-    unsafe fn dec_ref(handle: &Self) {
-        BNFreeFunction(handle.handle);
+impl Drop for Function {
+    fn drop(&mut self) {
+        unsafe { BNFreeFunction(self.handle) }
     }
 }
 
@@ -407,11 +396,14 @@ unsafe impl CoreOwnedArrayProvider for Function {
     }
 }
 
+// NOTE the wrapped value is a Reference 'a, because we should not Drop the
+// value after utilize it, because the list need to be freed by
+// `BNFreeFunctionList`
 unsafe impl<'a> CoreArrayWrapper<'a> for Function {
-    type Wrapped = Guard<'a, Function>;
+    type Wrapped = &'a Function;
 
-    unsafe fn wrap_raw(raw: &'a *mut BNFunction, context: &'a ()) -> Guard<'a, Function> {
-        Guard::new(Function { handle: *raw }, context)
+    unsafe fn wrap_raw(raw: &'a *mut BNFunction, _context: &'a ()) -> &'a Function {
+        &*((*raw) as *mut Self)
     }
 }
 

--- a/rust/src/functionrecognizer.rs
+++ b/rust/src/functionrecognizer.rs
@@ -55,7 +55,7 @@ where
         }
         let arch = unsafe { CoreArchitecture::from_raw(arch) };
         let llil = unsafe { llil::RegularFunction::from_raw(arch, llil) };
-        custom_handler.recognize_low_level_il(bv.as_ref(), func.as_ref(), &llil)
+        custom_handler.recognize_low_level_il(bv.as_ref(), &func, &llil)
     }
 
     extern "C" fn cb_recognize_medium_level_il<R>(
@@ -70,8 +70,8 @@ where
         let custom_handler = unsafe { &*(ctxt as *mut R) };
         let bv = unsafe { BinaryView::from_raw(BNNewViewReference(bv)) };
         let func = unsafe { Function::from_raw(BNNewFunctionReference(func)) };
-        let mlil = unsafe { mlil::MediumLevelILFunction::ref_from_raw(mlil) };
-        custom_handler.recognize_medium_level_il(bv.as_ref(), func.as_ref(), &mlil)
+        let mlil = unsafe { mlil::MediumLevelILFunction::from_raw(mlil) };
+        custom_handler.recognize_medium_level_il(bv.as_ref(), &func, &mlil)
     }
 
     let recognizer = FunctionRecognizerHandlerContext { recognizer };

--- a/rust/src/headless.rs
+++ b/rust/src/headless.rs
@@ -12,12 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-    binaryview,
-    metadata::Metadata,
-    rc::{self, Ref},
-    string::BnStrCompatible,
-};
+use crate::{binaryview, metadata::Metadata, string::BnStrCompatible};
 
 use std::env;
 use std::path::PathBuf;
@@ -124,7 +119,7 @@ impl Session {
     ///
     /// let bv = headless_session.load("/bin/cat").expect("Couldn't open `/bin/cat`");
     /// ```
-    pub fn load(&self, filename: &str) -> Option<rc::Ref<binaryview::BinaryView>> {
+    pub fn load(&self, filename: &str) -> Option<binaryview::BinaryView> {
         crate::load(filename)
     }
 
@@ -139,8 +134,8 @@ impl Session {
         &self,
         filename: &str,
         update_analysis_and_wait: bool,
-        options: Option<Ref<Metadata>>,
-    ) -> Option<rc::Ref<binaryview::BinaryView>> {
+        options: Option<Metadata>,
+    ) -> Option<binaryview::BinaryView> {
         crate::load_with_options(filename, update_analysis_and_wait, options)
     }
 }

--- a/rust/src/hlil/block.rs
+++ b/rust/src/hlil/block.rs
@@ -3,12 +3,11 @@ use std::ops::Range;
 use binaryninjacore_sys::BNGetHighLevelILIndexForInstruction;
 
 use crate::basicblock::{BasicBlock, BlockContext};
-use crate::rc::Ref;
 
 use super::{HighLevelILFunction, HighLevelILInstruction};
 
 pub struct HighLevelILBlockIter {
-    function: Ref<HighLevelILFunction>,
+    function: HighLevelILFunction,
     range: Range<u64>,
 }
 
@@ -26,7 +25,7 @@ impl Iterator for HighLevelILBlockIter {
 }
 
 pub struct HighLevelILBlock {
-    pub(crate) function: Ref<HighLevelILFunction>,
+    pub(crate) function: HighLevelILFunction,
 }
 
 impl core::fmt::Debug for HighLevelILBlock {

--- a/rust/src/hlil/lift.rs
+++ b/rust/src/hlil/lift.rs
@@ -1,6 +1,5 @@
 use super::{operation::*, HighLevelILFunction};
 
-use crate::rc::Ref;
 use crate::types::{ConstantData, ILIntrinsic, SSAVariable, Variable};
 
 #[derive(Clone)]
@@ -21,7 +20,7 @@ pub enum HighLevelILLiftedOperand {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct HighLevelILLiftedInstruction {
-    pub function: Ref<HighLevelILFunction>,
+    pub function: HighLevelILFunction,
     pub address: u64,
     pub kind: HighLevelILLiftedInstructionKind,
 }

--- a/rust/src/hlil/operation.rs
+++ b/rust/src/hlil/operation.rs
@@ -1,14 +1,13 @@
 use binaryninjacore_sys::BNGetGotoLabelName;
 
 use crate::function::Function;
-use crate::rc::Ref;
 use crate::types::{ConstantData, ILIntrinsic, SSAVariable, Variable};
 
 use super::HighLevelILLiftedInstruction;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GotoLabel {
-    pub(crate) function: Ref<Function>,
+    pub(crate) function: Function,
     pub(crate) target: u64,
 }
 

--- a/rust/src/interaction.rs
+++ b/rust/src/interaction.rs
@@ -20,7 +20,6 @@ use std::os::raw::{c_char, c_void};
 use std::path::PathBuf;
 
 use crate::binaryview::BinaryView;
-use crate::rc::Ref;
 use crate::string::{BnStr, BnStrCompatible, BnString};
 
 pub fn get_text_line_input(prompt: &str, title: &str) -> Option<String> {
@@ -285,7 +284,7 @@ impl FormInputBuilder {
     pub fn address_field(
         mut self,
         prompt: &str,
-        view: Option<Ref<BinaryView>>,
+        view: Option<BinaryView>,
         current_address: Option<u64>,
         default: Option<u64>,
     ) -> Self {

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -173,7 +173,6 @@ pub use binaryninjacore_sys::BNEndianness as Endianness;
 use binaryview::BinaryView;
 use metadata::Metadata;
 use metadata::MetadataType;
-use rc::Ref;
 use string::BnStrCompatible;
 
 // Commented out to suppress unused warnings
@@ -197,7 +196,7 @@ const BN_FULL_CONFIDENCE: u8 = 255;
 const BN_INVALID_EXPR: usize = usize::MAX;
 
 /// The main way to open and load files into Binary Ninja. Make sure you've properly initialized the core before calling this function. See [`crate::headless::init()`]
-pub fn load<S: BnStrCompatible>(filename: S) -> Option<rc::Ref<binaryview::BinaryView>> {
+pub fn load<S: BnStrCompatible>(filename: S) -> Option<binaryview::BinaryView> {
     let filename = filename.into_bytes_with_nul();
     let metadata = Metadata::new_of_type(MetadataType::KeyValueDataType);
 
@@ -228,8 +227,8 @@ pub fn load<S: BnStrCompatible>(filename: S) -> Option<rc::Ref<binaryview::Binar
 pub fn load_with_options<S: BnStrCompatible>(
     filename: S,
     update_analysis_and_wait: bool,
-    options: Option<Ref<Metadata>>,
-) -> Option<rc::Ref<binaryview::BinaryView>> {
+    options: Option<Metadata>,
+) -> Option<binaryview::BinaryView> {
     let filename = filename.into_bytes_with_nul();
 
     let options_or_default = if let Some(opt) = options {
@@ -243,7 +242,7 @@ pub fn load_with_options<S: BnStrCompatible>(
             filename.as_ref().as_ptr() as *mut _,
             update_analysis_and_wait,
             None,
-            options_or_default.as_ref().handle,
+            options_or_default.handle,
         )
     };
 

--- a/rust/src/linearview.rs
+++ b/rust/src/linearview.rs
@@ -30,13 +30,13 @@ pub struct LinearViewObject {
 }
 
 impl LinearViewObject {
-    pub(crate) unsafe fn from_raw(handle: *mut BNLinearViewObject) -> Ref<Self> {
+    pub(crate) unsafe fn from_raw(handle: *mut BNLinearViewObject) -> Self {
         debug_assert!(!handle.is_null());
 
-        Ref::new(Self { handle })
+        Self { handle }
     }
 
-    pub fn data_only(view: &BinaryView, settings: &DisassemblySettings) -> Ref<Self> {
+    pub fn data_only(view: &BinaryView, settings: &DisassemblySettings) -> Self {
         unsafe {
             let handle =
                 binaryninjacore_sys::BNCreateLinearViewDataOnly(view.handle, settings.handle);
@@ -45,7 +45,7 @@ impl LinearViewObject {
         }
     }
 
-    pub fn disassembly(view: &BinaryView, settings: &DisassemblySettings) -> Ref<Self> {
+    pub fn disassembly(view: &BinaryView, settings: &DisassemblySettings) -> Self {
         unsafe {
             let handle =
                 binaryninjacore_sys::BNCreateLinearViewDisassembly(view.handle, settings.handle);
@@ -54,7 +54,7 @@ impl LinearViewObject {
         }
     }
 
-    pub fn lifted_il(view: &BinaryView, settings: &DisassemblySettings) -> Ref<Self> {
+    pub fn lifted_il(view: &BinaryView, settings: &DisassemblySettings) -> Self {
         unsafe {
             let handle =
                 binaryninjacore_sys::BNCreateLinearViewLiftedIL(view.handle, settings.handle);
@@ -63,7 +63,7 @@ impl LinearViewObject {
         }
     }
 
-    pub fn mlil(view: &BinaryView, settings: &DisassemblySettings) -> Ref<Self> {
+    pub fn mlil(view: &BinaryView, settings: &DisassemblySettings) -> Self {
         unsafe {
             let handle =
                 binaryninjacore_sys::BNCreateLinearViewMediumLevelIL(view.handle, settings.handle);
@@ -72,7 +72,7 @@ impl LinearViewObject {
         }
     }
 
-    pub fn mlil_ssa(view: &BinaryView, settings: &DisassemblySettings) -> Ref<Self> {
+    pub fn mlil_ssa(view: &BinaryView, settings: &DisassemblySettings) -> Self {
         unsafe {
             let handle = binaryninjacore_sys::BNCreateLinearViewMediumLevelILSSAForm(
                 view.handle,
@@ -83,7 +83,7 @@ impl LinearViewObject {
         }
     }
 
-    pub fn hlil(view: &BinaryView, settings: &DisassemblySettings) -> Ref<Self> {
+    pub fn hlil(view: &BinaryView, settings: &DisassemblySettings) -> Self {
         unsafe {
             let handle =
                 binaryninjacore_sys::BNCreateLinearViewHighLevelIL(view.handle, settings.handle);
@@ -92,7 +92,7 @@ impl LinearViewObject {
         }
     }
 
-    pub fn hlil_ssa(view: &BinaryView, settings: &DisassemblySettings) -> Ref<Self> {
+    pub fn hlil_ssa(view: &BinaryView, settings: &DisassemblySettings) -> Self {
         unsafe {
             let handle = binaryninjacore_sys::BNCreateLinearViewHighLevelILSSAForm(
                 view.handle,
@@ -103,7 +103,7 @@ impl LinearViewObject {
         }
     }
 
-    pub fn language_representation(view: &BinaryView, settings: &DisassemblySettings) -> Ref<Self> {
+    pub fn language_representation(view: &BinaryView, settings: &DisassemblySettings) -> Self {
         unsafe {
             let handle = binaryninjacore_sys::BNCreateLinearViewLanguageRepresentation(
                 view.handle,
@@ -117,7 +117,7 @@ impl LinearViewObject {
     pub fn single_function_disassembly(
         function: &Function,
         settings: &DisassemblySettings,
-    ) -> Ref<Self> {
+    ) -> Self {
         unsafe {
             let handle = binaryninjacore_sys::BNCreateLinearViewSingleFunctionDisassembly(
                 function.handle,
@@ -128,10 +128,7 @@ impl LinearViewObject {
         }
     }
 
-    pub fn single_function_lifted_il(
-        function: &Function,
-        settings: &DisassemblySettings,
-    ) -> Ref<Self> {
+    pub fn single_function_lifted_il(function: &Function, settings: &DisassemblySettings) -> Self {
         unsafe {
             let handle = binaryninjacore_sys::BNCreateLinearViewSingleFunctionLiftedIL(
                 function.handle,
@@ -142,7 +139,7 @@ impl LinearViewObject {
         }
     }
 
-    pub fn single_function_mlil(function: &Function, settings: &DisassemblySettings) -> Ref<Self> {
+    pub fn single_function_mlil(function: &Function, settings: &DisassemblySettings) -> Self {
         unsafe {
             let handle = binaryninjacore_sys::BNCreateLinearViewSingleFunctionMediumLevelIL(
                 function.handle,
@@ -153,10 +150,7 @@ impl LinearViewObject {
         }
     }
 
-    pub fn single_function_mlil_ssa(
-        function: &Function,
-        settings: &DisassemblySettings,
-    ) -> Ref<Self> {
+    pub fn single_function_mlil_ssa(function: &Function, settings: &DisassemblySettings) -> Self {
         unsafe {
             let handle = binaryninjacore_sys::BNCreateLinearViewSingleFunctionMediumLevelILSSAForm(
                 function.handle,
@@ -167,7 +161,7 @@ impl LinearViewObject {
         }
     }
 
-    pub fn single_function_hlil(function: &Function, settings: &DisassemblySettings) -> Ref<Self> {
+    pub fn single_function_hlil(function: &Function, settings: &DisassemblySettings) -> Self {
         unsafe {
             let handle = binaryninjacore_sys::BNCreateLinearViewSingleFunctionHighLevelIL(
                 function.handle,
@@ -178,10 +172,7 @@ impl LinearViewObject {
         }
     }
 
-    pub fn single_function_hlil_ssa(
-        function: &Function,
-        settings: &DisassemblySettings,
-    ) -> Ref<Self> {
+    pub fn single_function_hlil_ssa(function: &Function, settings: &DisassemblySettings) -> Self {
         unsafe {
             let handle = binaryninjacore_sys::BNCreateLinearViewSingleFunctionHighLevelILSSAForm(
                 function.handle,
@@ -195,7 +186,7 @@ impl LinearViewObject {
     pub fn single_function_language_representation(
         function: &Function,
         settings: &DisassemblySettings,
-    ) -> Ref<Self> {
+    ) -> Self {
         unsafe {
             let handle =
                 binaryninjacore_sys::BNCreateLinearViewSingleFunctionLanguageRepresentation(
@@ -208,23 +199,15 @@ impl LinearViewObject {
     }
 }
 
-unsafe impl RefCountable for LinearViewObject {
-    unsafe fn inc_ref(handle: &Self) -> Ref<Self> {
-        Ref::new(Self {
-            handle: BNNewLinearViewObjectReference(handle.handle),
-        })
-    }
-
-    unsafe fn dec_ref(handle: &Self) {
-        BNFreeLinearViewObject(handle.handle);
+impl Clone for LinearViewObject {
+    fn clone(&self) -> Self {
+        unsafe { Self::from_raw(BNNewLinearViewObjectReference(self.handle)) }
     }
 }
 
-impl ToOwned for LinearViewObject {
-    type Owned = Ref<Self>;
-
-    fn to_owned(&self) -> Self::Owned {
-        unsafe { RefCountable::inc_ref(self) }
+impl Drop for LinearViewObject {
+    fn drop(&mut self) {
+        unsafe { BNFreeLinearViewObject(self.handle) }
     }
 }
 
@@ -237,13 +220,13 @@ pub struct LinearViewCursor {
 }
 
 impl LinearViewCursor {
-    pub(crate) unsafe fn from_raw(handle: *mut BNLinearViewCursor) -> Ref<Self> {
+    pub(crate) unsafe fn from_raw(handle: *mut BNLinearViewCursor) -> Self {
         debug_assert!(!handle.is_null());
 
-        Ref::new(Self { handle })
+        Self { handle }
     }
 
-    pub fn new(root: &LinearViewObject) -> Ref<Self> {
+    pub fn new(root: &LinearViewObject) -> Self {
         unsafe {
             let handle = BNCreateLinearViewCursor(root.handle);
             Self::from_raw(handle)
@@ -251,7 +234,7 @@ impl LinearViewCursor {
     }
 
     /// Gets the current [LinearViewObject] associated with this cursor.
-    pub fn current_object(&self) -> Ref<LinearViewObject> {
+    pub fn current_object(&self) -> LinearViewObject {
         unsafe {
             let handle = BNGetLinearViewCursorCurrentObject(self.handle);
             LinearViewObject::from_raw(handle)
@@ -259,7 +242,7 @@ impl LinearViewCursor {
     }
 
     // FIXME: can we implement clone without shadowing ToOwned?
-    pub fn duplicate(&self) -> Ref<Self> {
+    pub fn duplicate(&self) -> Self {
         unsafe {
             let handle = BNDuplicateLinearViewCursor(self.handle);
             Self::from_raw(handle)
@@ -344,23 +327,15 @@ impl Ord for LinearViewCursor {
     }
 }
 
-unsafe impl RefCountable for LinearViewCursor {
-    unsafe fn inc_ref(handle: &Self) -> Ref<Self> {
-        Ref::new(Self {
-            handle: BNNewLinearViewCursorReference(handle.handle),
-        })
-    }
-
-    unsafe fn dec_ref(handle: &Self) {
-        BNFreeLinearViewCursor(handle.handle);
+impl Clone for LinearViewCursor {
+    fn clone(&self) -> Self {
+        unsafe { Self::from_raw(BNNewLinearViewCursorReference(self.handle)) }
     }
 }
 
-impl ToOwned for LinearViewCursor {
-    type Owned = Ref<Self>;
-
-    fn to_owned(&self) -> Self::Owned {
-        unsafe { RefCountable::inc_ref(self) }
+impl Drop for LinearViewCursor {
+    fn drop(&mut self) {
+        unsafe { BNFreeLinearViewCursor(self.handle) }
     }
 }
 
@@ -374,7 +349,7 @@ pub struct LinearDisassemblyLine {
 
     // These will be cleaned up by BNFreeLinearDisassemblyLines, so we
     // don't drop them in the relevant deconstructors.
-    function: mem::ManuallyDrop<Ref<Function>>,
+    function: mem::ManuallyDrop<Function>,
     contents: mem::ManuallyDrop<DisassemblyTextLine>,
 }
 
@@ -391,7 +366,7 @@ impl LinearDisassemblyLine {
     }
 
     pub fn function(&self) -> &Function {
-        self.function.as_ref()
+        &self.function
     }
 
     pub fn line_type(&self) -> LinearDisassemblyLineType {

--- a/rust/src/llil/instruction.rs
+++ b/rust/src/llil/instruction.rs
@@ -99,7 +99,7 @@ where
         let expr_idx =
             unsafe { BNGetLowLevelILIndexForInstruction(self.function.handle, self.instr_idx) };
         let op = unsafe { BNGetLowLevelILByIndex(self.function.handle, expr_idx) };
-        return op.address;
+        op.address
     }
 
     pub fn info(&self) -> InstrInfo<'func, A, M, NonSSA<V>> {

--- a/rust/src/llil/operation.rs
+++ b/rust/src/llil/operation.rs
@@ -89,10 +89,10 @@ pub struct Syscall;
 pub struct Intrinsic;
 
 impl<'func, A, M, V> Operation<'func, A, M, NonSSA<V>, Intrinsic>
-    where
-        A: 'func + Architecture,
-        M: FunctionMutability,
-        V: NonSSAVariant,
+where
+    A: 'func + Architecture,
+    M: FunctionMutability,
+    V: NonSSAVariant,
 {
     // TODO: Support register and expression lists
     pub fn intrinsic(&self) -> Option<A::Intrinsic> {

--- a/rust/src/mlil/block.rs
+++ b/rust/src/mlil/block.rs
@@ -3,12 +3,11 @@ use std::ops::Range;
 use binaryninjacore_sys::BNGetMediumLevelILIndexForInstruction;
 
 use crate::basicblock::{BasicBlock, BlockContext};
-use crate::rc::Ref;
 
 use super::{MediumLevelILFunction, MediumLevelILInstruction};
 
 pub struct MediumLevelILBlockIter {
-    function: Ref<MediumLevelILFunction>,
+    function: MediumLevelILFunction,
     range: Range<u64>,
 }
 
@@ -26,7 +25,7 @@ impl Iterator for MediumLevelILBlockIter {
 }
 
 pub struct MediumLevelILBlock {
-    pub(crate) function: Ref<MediumLevelILFunction>,
+    pub(crate) function: MediumLevelILFunction,
 }
 
 impl core::fmt::Debug for MediumLevelILBlock {

--- a/rust/src/mlil/lift.rs
+++ b/rust/src/mlil/lift.rs
@@ -1,6 +1,5 @@
 use std::collections::BTreeMap;
 
-use crate::rc::Ref;
 use crate::types::{ConstantData, ILIntrinsic, SSAVariable, Variable};
 
 use super::operation::*;
@@ -24,7 +23,7 @@ pub enum MediumLevelILLiftedOperand {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct MediumLevelILLiftedInstruction {
-    pub function: Ref<MediumLevelILFunction>,
+    pub function: MediumLevelILFunction,
     pub address: u64,
     pub kind: MediumLevelILLiftedInstructionKind,
 }

--- a/rust/src/operand_iter.rs
+++ b/rust/src/operand_iter.rs
@@ -6,7 +6,6 @@ use binaryninjacore_sys::BNMediumLevelILOperation;
 
 use crate::hlil::{HighLevelILFunction, HighLevelILInstruction};
 use crate::mlil::{MediumLevelILFunction, MediumLevelILInstruction};
-use crate::rc::{Ref, RefCountable};
 use crate::types::{SSAVariable, Variable};
 
 pub trait ILFunction {
@@ -44,25 +43,27 @@ impl ILFunction for HighLevelILFunction {
     }
 }
 
-pub struct OperandIter<F: ILFunction + RefCountable> {
-    function: Ref<F>,
+pub struct OperandIter<F: ILFunction> {
+    function: F,
     remaining: usize,
     next_iter_idx: Option<usize>,
     current_iter: OperandIterInner,
 }
 
-impl<F: ILFunction + RefCountable> OperandIter<F> {
+impl<F: ILFunction + Clone> OperandIter<F> {
     pub(crate) fn new(function: &F, idx: usize, number: usize) -> Self {
         // Zero-length lists immediately finish iteration
         let next_iter_idx = if number > 0 { Some(idx) } else { None };
         Self {
-            function: function.to_owned(),
+            function: function.clone(),
             remaining: number,
             next_iter_idx,
             current_iter: OperandIterInner::empty(),
         }
     }
+}
 
+impl<F: ILFunction> OperandIter<F> {
     pub fn pairs(self) -> OperandPairIter<F> {
         assert_eq!(self.len() % 2, 0);
         OperandPairIter(self)
@@ -81,7 +82,7 @@ impl<F: ILFunction + RefCountable> OperandIter<F> {
     }
 }
 
-impl<F: ILFunction + RefCountable> Iterator for OperandIter<F> {
+impl<F: ILFunction> Iterator for OperandIter<F> {
     type Item = u64;
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(item) = self.current_iter.next() {
@@ -105,7 +106,7 @@ impl<F: ILFunction + RefCountable> Iterator for OperandIter<F> {
         }
     }
 }
-impl<F: ILFunction + RefCountable> ExactSizeIterator for OperandIter<F> {
+impl<F: ILFunction> ExactSizeIterator for OperandIter<F> {
     fn len(&self) -> usize {
         self.remaining + self.current_iter.len()
     }
@@ -152,8 +153,8 @@ impl ExactSizeIterator for OperandIterInner {
     }
 }
 
-pub struct OperandPairIter<F: ILFunction + RefCountable>(OperandIter<F>);
-impl<F: ILFunction + RefCountable> Iterator for OperandPairIter<F> {
+pub struct OperandPairIter<F: ILFunction>(OperandIter<F>);
+impl<F: ILFunction> Iterator for OperandPairIter<F> {
     type Item = (u64, u64);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -162,14 +163,14 @@ impl<F: ILFunction + RefCountable> Iterator for OperandPairIter<F> {
         Some((first, second))
     }
 }
-impl<F: ILFunction + RefCountable> ExactSizeIterator for OperandPairIter<F> {
+impl<F: ILFunction> ExactSizeIterator for OperandPairIter<F> {
     fn len(&self) -> usize {
         self.0.len() / 2
     }
 }
 
-pub struct OperandExprIter<F: ILFunction + RefCountable>(OperandIter<F>);
-impl<F: ILFunction + RefCountable> Iterator for OperandExprIter<F> {
+pub struct OperandExprIter<F: ILFunction>(OperandIter<F>);
+impl<F: ILFunction> Iterator for OperandExprIter<F> {
     type Item = F::Instruction;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -178,28 +179,28 @@ impl<F: ILFunction + RefCountable> Iterator for OperandExprIter<F> {
             .map(|idx| self.0.function.il_instruction_from_idx(idx as usize))
     }
 }
-impl<F: ILFunction + RefCountable> ExactSizeIterator for OperandExprIter<F> {
+impl<F: ILFunction> ExactSizeIterator for OperandExprIter<F> {
     fn len(&self) -> usize {
         self.0.len()
     }
 }
 
-pub struct OperandVarIter<F: ILFunction + RefCountable>(OperandIter<F>);
-impl<F: ILFunction + RefCountable> Iterator for OperandVarIter<F> {
+pub struct OperandVarIter<F: ILFunction>(OperandIter<F>);
+impl<F: ILFunction> Iterator for OperandVarIter<F> {
     type Item = Variable;
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(get_var)
     }
 }
-impl<F: ILFunction + RefCountable> ExactSizeIterator for OperandVarIter<F> {
+impl<F: ILFunction> ExactSizeIterator for OperandVarIter<F> {
     fn len(&self) -> usize {
         self.0.len()
     }
 }
 
-pub struct OperandSSAVarIter<F: ILFunction + RefCountable>(OperandPairIter<F>);
-impl<F: ILFunction + RefCountable> Iterator for OperandSSAVarIter<F> {
+pub struct OperandSSAVarIter<F: ILFunction>(OperandPairIter<F>);
+impl<F: ILFunction> Iterator for OperandSSAVarIter<F> {
     type Item = SSAVariable;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -208,7 +209,7 @@ impl<F: ILFunction + RefCountable> Iterator for OperandSSAVarIter<F> {
             .map(|(id, version)| get_var_ssa(id, version as usize))
     }
 }
-impl<F: ILFunction + RefCountable> ExactSizeIterator for OperandSSAVarIter<F> {
+impl<F: ILFunction> ExactSizeIterator for OperandSSAVarIter<F> {
     fn len(&self) -> usize {
         self.0.len()
     }

--- a/rust/src/references.rs
+++ b/rust/src/references.rs
@@ -1,6 +1,6 @@
 use crate::architecture::CoreArchitecture;
 use crate::function::Function;
-use crate::rc::{CoreArrayProvider, CoreArrayWrapper, CoreOwnedArrayProvider, Ref};
+use crate::rc::{CoreArrayProvider, CoreArrayWrapper, CoreOwnedArrayProvider};
 use binaryninjacore_sys::{BNFreeCodeReferences, BNFreeDataReferences, BNReferenceSource};
 use std::mem::ManuallyDrop;
 
@@ -12,7 +12,7 @@ use std::mem::ManuallyDrop;
 #[derive(Debug)]
 pub struct CodeReference {
     arch: CoreArchitecture,
-    func: ManuallyDrop<Ref<Function>>,
+    func: ManuallyDrop<Function>,
     pub address: u64,
 }
 
@@ -36,12 +36,12 @@ impl CodeReference {
     }
 }
 
-impl<'a> CodeReference {
+impl CodeReference {
     /// A handle to the referenced function bound by the [CodeReference] object's lifetime.
     /// A user can call `.to_owned()` to promote this into its own ref-counted struct
     /// and use it after the lifetime of the [CodeReference].
-    pub fn function(&'a self) -> &'a Function {
-        self.func.as_ref()
+    pub fn function(&self) -> &Function {
+        &self.func
     }
 
     /// A handle to the [CodeReference]'s [CoreArchitecture]. This type is [Copy] so reference


### PR DESCRIPTION
Types that use `rc::Ref` only exists as References, so it makes sense to replace all occurrences of `Ref<T>` with `T` and move the `Ref::inc_ref` and `Ref::dec_ref` implementations to `Clone` and `Drop`.