### PR TITLE
Remove unecessary architecture impl requirements

### DIFF
--- a/rust/src/callingconvention.rs
+++ b/rust/src/callingconvention.rs
@@ -847,19 +847,19 @@ impl<A: Architecture> CallingConventionBase for ConventionBuilder<A> {
     }
 
     fn return_int_reg(&self) -> Option<A::Register> {
-        self.return_int_reg
+        self.return_int_reg.clone()
     }
 
     fn return_hi_int_reg(&self) -> Option<A::Register> {
-        self.return_hi_int_reg
+        self.return_hi_int_reg.clone()
     }
 
     fn return_float_reg(&self) -> Option<A::Register> {
-        self.return_float_reg
+        self.return_float_reg.clone()
     }
 
     fn global_pointer_reg(&self) -> Option<A::Register> {
-        self.global_pointer_reg
+        self.global_pointer_reg.clone()
     }
 
     fn implicitly_defined_registers(&self) -> Vec<A::Register> {

--- a/rust/src/llil/lifting.rs
+++ b/rust/src/llil/lifting.rs
@@ -298,7 +298,7 @@ impl<R: ArchReg> FlagWriteOp<R> {
 
         let mut operands: [BNRegisterOrConstant; 5] = unsafe { mem::zeroed() };
 
-        let count = match *self {
+        let count = match self.clone() {
             Pop(_) => 0,
 
             SetReg(_, op0)


### PR DESCRIPTION
Requiring the user to implement `Copy` in all types of `Architecture` is unnecessary and very limiting for the user. Not allowing non-copy types, like String, Vec, HashMap, etc.