### PR TITLE
replace BStr with str

### DIFF
--- a/rust/examples/basic_script/src/main.rs
+++ b/rust/examples/basic_script/src/main.rs
@@ -26,9 +26,7 @@ fn main() {
                         .get_data(),
                     addr,
                 ) {
-                    tokens
-                        .iter()
-                        .for_each(|token| print!("{}", token.text().as_str()));
+                    tokens.iter().for_each(|token| print!("{}", token.text()));
                     println!();
                 }
             }

--- a/rust/examples/dwarf/dwarf_export/src/lib.rs
+++ b/rust/examples/dwarf/dwarf_export/src/lib.rs
@@ -739,7 +739,7 @@ fn export_dwarf(bv: &BinaryView) {
     } else {
         BnString::new("Unknown")
     };
-    let responses = present_form(&arch_name);
+    let responses = present_form(arch_name.as_str());
 
     let encoding = gimli::Encoding {
         format: gimli::Format::Dwarf32,

--- a/rust/examples/dwarf/dwarf_import/src/die_handlers.rs
+++ b/rust/examples/dwarf/dwarf_import/src/die_handlers.rs
@@ -301,17 +301,13 @@ pub(crate) fn handle_function<R: Reader<Offset = usize>>(
             name.clone(),
             Type::named_type_from_type(
                 name,
-                &Type::function::<String, &binaryninja::types::Type>(
-                    return_type.as_ref(),
-                    &[],
-                    false,
-                ),
+                &Type::function::<&binaryninja::types::Type>(return_type.as_ref(), &[], false),
             ),
             false,
         );
     }
 
-    let mut parameters: Vec<FunctionParameter<String>> = vec![];
+    let mut parameters: Vec<FunctionParameter> = vec![];
     let mut variable_arguments = false;
 
     // Get all the children and populate

--- a/rust/examples/dwarf/dwarf_import/src/dwarfdebuginfo.rs
+++ b/rust/examples/dwarf/dwarf_import/src/dwarfdebuginfo.rs
@@ -316,7 +316,7 @@ impl DebugInfoBuilder {
             _ => Conf::new(binaryninja::types::Type::void(), 0),
         };
 
-        let parameters: Vec<FunctionParameter<String>> = function
+        let parameters: Vec<FunctionParameter> = function
             .parameters
             .iter()
             .filter_map(|parameter| match parameter {

--- a/rust/examples/flowgraph/src/lib.rs
+++ b/rust/examples/flowgraph/src/lib.rs
@@ -3,16 +3,15 @@ use binaryninja::{
     command::register,
     disassembly::{DisassemblyTextLine, InstructionTextToken, InstructionTextTokenContents},
     flowgraph::{BranchType, EdgePenStyle, EdgeStyle, FlowGraph, FlowGraphNode, ThemeColor},
-    string::BnString,
 };
 
 fn test_graph(view: &BinaryView) {
     let graph = FlowGraph::new();
 
     let disassembly_lines_a = vec![DisassemblyTextLine::from(vec![
-        InstructionTextToken::new(BnString::new("Li"), InstructionTextTokenContents::Text),
-        InstructionTextToken::new(BnString::new("ne"), InstructionTextTokenContents::Text),
-        InstructionTextToken::new(BnString::new(" 1"), InstructionTextTokenContents::Text),
+        InstructionTextToken::new("Li", InstructionTextTokenContents::Text),
+        InstructionTextToken::new("ne", InstructionTextTokenContents::Text),
+        InstructionTextToken::new(" 1", InstructionTextTokenContents::Text),
     ])];
 
     let node_a = FlowGraphNode::new(&graph);

--- a/rust/examples/template/src/main.rs
+++ b/rust/examples/template/src/main.rs
@@ -31,9 +31,7 @@ fn main() {
                         .get_data(),
                     addr,
                 ) {
-                    tokens
-                        .iter()
-                        .for_each(|token| print!("{}", token.text().as_str()));
+                    tokens.iter().for_each(|token| print!("{}", token.text()));
                     println!();
                 }
             }

--- a/rust/src/binaryview.rs
+++ b/rust/src/binaryview.rs
@@ -674,7 +674,7 @@ pub trait BinaryViewExt: BinaryViewBase {
         let name_array = unsafe { Array::<QualifiedName>::new(result_names, result_count, ()) };
 
         for (id, name) in id_array.iter().zip(name_array.iter()) {
-            result.insert(id.as_str().to_owned(), name.clone());
+            result.insert(id.to_owned(), name.clone());
         }
 
         result

--- a/rust/src/callingconvention.rs
+++ b/rust/src/callingconvention.rs
@@ -448,24 +448,21 @@ impl<A: Architecture> CallingConvention<A> {
         unsafe { BnString::from_raw(BNGetCallingConventionName(self.handle)) }
     }
 
-    pub fn variables_for_parameters<S: Clone + BnStrCompatible>(
+    pub fn variables_for_parameters(
         &self,
-        params: &[FunctionParameter<S>],
+        params: &[FunctionParameter],
         permitted_registers: Option<&[A::Register]>,
     ) -> Vec<Variable> {
         let mut bn_params: Vec<BNFunctionParameter> = vec![];
-        let mut name_strings = vec![];
+        let name_strings = params.iter().map(|parameter| &parameter.name);
 
-        for parameter in params.iter() {
-            name_strings.push(parameter.name.clone().into_bytes_with_nul());
-        }
-        for (parameter, raw_name) in params.iter().zip(name_strings.iter_mut()) {
+        for (parameter, raw_name) in params.iter().zip(name_strings) {
             let location = match &parameter.location {
                 Some(location) => location.raw(),
                 None => unsafe { mem::zeroed() },
             };
             bn_params.push(BNFunctionParameter {
-                name: raw_name.as_ref().as_ptr() as *mut _,
+                name: BnString::new(raw_name).into_raw(),
                 type_: parameter.t.contents.handle,
                 typeConfidence: parameter.t.confidence,
                 defaultLocation: parameter.location.is_none(),
@@ -500,9 +497,6 @@ impl<A: Architecture> CallingConvention<A> {
                 )
             }
         };
-
-        // Gotta keep this around so the pointers are valid during the call
-        drop(name_strings);
 
         let vars_slice = unsafe { slice::from_raw_parts(vars, count) };
         let mut result = vec![];

--- a/rust/src/custombinaryview.rs
+++ b/rust/src/custombinaryview.rs
@@ -388,7 +388,7 @@ impl<'a, T: CustomBinaryViewType> CustomViewBuilder<'a, T> {
 
         let view_name = view_type.name();
 
-        if let Ok(bv) = file.get_view_of_type(view_name.as_cstr()) {
+        if let Ok(bv) = file.get_view_of_type(view_name.as_str()) {
             // while it seems to work most of the time, you can get really unlucky
             // if the a free of the existing view of the same type kicks off while
             // BNCreateBinaryViewOfType is still running. the freeObject callback
@@ -772,7 +772,7 @@ impl<'a, T: CustomBinaryViewType> CustomViewBuilder<'a, T> {
 
         unsafe {
             let res = BNCreateCustomBinaryView(
-                view_name.as_cstr().as_ptr(),
+                view_name.as_ptr(),
                 file.handle,
                 parent.handle,
                 &mut bn_obj,

--- a/rust/src/demangle.rs
+++ b/rust/src/demangle.rs
@@ -73,7 +73,7 @@ pub fn demangle_gnu3<S: BnStrCompatible>(
 
     let names = unsafe { ArrayGuard::<BnString>::new(out_name, out_size, ()) }
         .iter()
-        .map(|name| name.to_string())
+        .map(str::to_string)
         .collect();
 
     unsafe { BNFreeDemangledName(&mut out_name, out_size) };

--- a/rust/src/downloadprovider.rs
+++ b/rust/src/downloadprovider.rs
@@ -2,10 +2,10 @@ use crate::rc::{
     Array, CoreArrayProvider, CoreArrayWrapper, CoreOwnedArrayProvider, Ref, RefCountable,
 };
 use crate::settings::Settings;
-use crate::string::{BnStr, BnStrCompatible, BnString};
+use crate::string::{BnStrCompatible, BnString};
 use binaryninjacore_sys::*;
 use std::collections::HashMap;
-use std::ffi::c_void;
+use std::ffi::{c_void, CStr};
 use std::os::raw::c_char;
 use std::ptr::null_mut;
 use std::slice;
@@ -270,8 +270,8 @@ impl DownloadInstance {
                 .zip(response_header_values.iter())
             {
                 response_headers.insert(
-                    BnStr::from_raw(*key).to_string(),
-                    BnStr::from_raw(*value).to_string(),
+                    CStr::from_ptr(*key).to_str().unwrap().to_owned(),
+                    CStr::from_ptr(*value).to_str().unwrap().to_owned(),
                 );
             }
         }

--- a/rust/src/interaction.rs
+++ b/rust/src/interaction.rs
@@ -16,12 +16,13 @@
 
 use binaryninjacore_sys::*;
 
+use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
 use std::path::PathBuf;
 
 use crate::binaryview::BinaryView;
 use crate::rc::Ref;
-use crate::string::{BnStr, BnStrCompatible, BnString};
+use crate::string::{BnStrCompatible, BnString};
 
 pub fn get_text_line_input(prompt: &str, title: &str) -> Option<String> {
     let mut value: *mut libc::c_char = std::ptr::null_mut();
@@ -499,7 +500,10 @@ impl FormInputBuilder {
                     | BNFormInputFieldType::SaveFileNameFormField
                     | BNFormInputFieldType::DirectoryNameFormField => {
                         FormResponses::String(unsafe {
-                            BnStr::from_raw(form_field.stringResult).to_string()
+                            CStr::from_ptr(form_field.stringResult)
+                                .to_str()
+                                .unwrap()
+                                .to_owned()
                         })
                     }
 

--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -29,12 +29,11 @@
 //! ```
 //!
 
-use crate::string::BnStr;
-
 pub use binaryninjacore_sys::BNLogLevel as Level;
 use binaryninjacore_sys::{BNLogListener, BNUpdateLogListeners};
 
 use log;
+use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
 
 struct Logger;
@@ -84,7 +83,7 @@ pub fn init(filter: log::LevelFilter) -> Result<(), log::SetLoggerError> {
 }
 
 pub trait LogListener: 'static + Sync {
-    fn log(&self, session: usize, level: Level, msg: &BnStr, logger_name: &BnStr, tid: usize);
+    fn log(&self, session: usize, level: Level, msg: &CStr, logger_name: &CStr, tid: usize);
     fn level(&self) -> Level;
     fn close(&self) {}
 }
@@ -147,8 +146,8 @@ extern "C" fn cb_log<L>(
         listener.log(
             session,
             level,
-            BnStr::from_raw(msg),
-            BnStr::from_raw(logger_name),
+            CStr::from_ptr(msg),
+            CStr::from_ptr(logger_name),
             tid,
         );
     })

--- a/rust/src/string.rs
+++ b/rust/src/string.rs
@@ -14,7 +14,7 @@
 
 //! String wrappers for core-owned strings and strings being passed to the core
 
-use std::borrow::{Borrow, Cow};
+use std::borrow::Cow;
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::hash::{Hash, Hasher};
@@ -33,61 +33,9 @@ pub(crate) fn raw_to_string(ptr: *const raw::c_char) -> Option<String> {
     }
 }
 
-/// These are strings that the core will both allocate and free.
-/// We just have a reference to these strings and want to be able use them, but aren't responsible for cleanup
-#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
-#[repr(C)]
-pub struct BnStr {
-    raw: [u8],
-}
-
-impl BnStr {
-    pub(crate) unsafe fn from_raw<'a>(ptr: *const raw::c_char) -> &'a Self {
-        mem::transmute(CStr::from_ptr(ptr).to_bytes_with_nul())
-    }
-
-    pub fn as_str(&self) -> &str {
-        self.as_cstr().to_str().unwrap()
-    }
-
-    pub fn as_cstr(&self) -> &CStr {
-        unsafe { CStr::from_bytes_with_nul_unchecked(&self.raw) }
-    }
-}
-
-impl Deref for BnStr {
-    type Target = str;
-
-    fn deref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl AsRef<[u8]> for BnStr {
-    fn as_ref(&self) -> &[u8] {
-        &self.raw
-    }
-}
-
-impl AsRef<str> for BnStr {
-    fn as_ref(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl Borrow<str> for BnStr {
-    fn borrow(&self) -> &str {
-        self.as_str()
-    }
-}
-
-impl fmt::Display for BnStr {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_cstr().to_string_lossy())
-    }
-}
-
-#[repr(C)]
+/// Is the quivalent of `core::ffi::CString` but using the allocation and free
+/// functions provided by binaryninja_sys.
+#[repr(transparent)]
 pub struct BnString {
     raw: *mut raw::c_char,
 }
@@ -132,7 +80,19 @@ impl BnString {
     }
 
     pub fn as_str(&self) -> &str {
-        unsafe { BnStr::from_raw(self.raw).as_str() }
+        unsafe { CStr::from_ptr(self.raw).to_str().unwrap() }
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        self.as_str().as_bytes()
+    }
+
+    pub fn as_bytes_with_null(&self) -> &[u8] {
+        self.deref().to_bytes()
+    }
+
+    pub fn len(&self) -> usize {
+        self.as_ref().len()
     }
 }
 
@@ -158,16 +118,16 @@ impl Clone for BnString {
 }
 
 impl Deref for BnString {
-    type Target = BnStr;
+    type Target = CStr;
 
-    fn deref(&self) -> &BnStr {
-        unsafe { BnStr::from_raw(self.raw) }
+    fn deref(&self) -> &CStr {
+        unsafe { CStr::from_ptr(self.raw) }
     }
 }
 
 impl AsRef<[u8]> for BnString {
     fn as_ref(&self) -> &[u8] {
-        self.as_cstr().to_bytes_with_nul()
+        self.to_bytes_with_nul()
     }
 }
 
@@ -187,13 +147,13 @@ impl Eq for BnString {}
 
 impl fmt::Display for BnString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_cstr().to_string_lossy())
+        write!(f, "{}", self.to_string_lossy())
     }
 }
 
 impl fmt::Debug for BnString {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_cstr().to_string_lossy())
+        write!(f, "{}", self.to_string_lossy())
     }
 }
 
@@ -210,10 +170,10 @@ unsafe impl CoreOwnedArrayProvider for BnString {
 }
 
 unsafe impl<'a> CoreArrayWrapper<'a> for BnString {
-    type Wrapped = &'a BnStr;
+    type Wrapped = &'a str;
 
     unsafe fn wrap_raw(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped {
-        BnStr::from_raw(*raw)
+        CStr::from_ptr(*raw).to_str().unwrap()
     }
 }
 
@@ -222,11 +182,11 @@ pub unsafe trait BnStrCompatible {
     fn into_bytes_with_nul(self) -> Self::Result;
 }
 
-unsafe impl<'a> BnStrCompatible for &'a BnStr {
+unsafe impl<'a> BnStrCompatible for &'a CStr {
     type Result = &'a [u8];
 
     fn into_bytes_with_nul(self) -> Self::Result {
-        self.as_cstr().to_bytes_with_nul()
+        self.to_bytes_with_nul()
     }
 }
 
@@ -235,14 +195,6 @@ unsafe impl BnStrCompatible for BnString {
 
     fn into_bytes_with_nul(self) -> Self::Result {
         self
-    }
-}
-
-unsafe impl<'a> BnStrCompatible for &'a CStr {
-    type Result = &'a [u8];
-
-    fn into_bytes_with_nul(self) -> Self::Result {
-        self.to_bytes_with_nul()
     }
 }
 

--- a/rust/src/symbol.rs
+++ b/rust/src/symbol.rs
@@ -14,6 +14,7 @@
 
 //! Interfaces for the various kinds of symbols in a binary.
 
+use std::ffi::CStr;
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ptr;
@@ -252,17 +253,17 @@ impl Symbol {
         }
     }
 
-    pub fn short_name(&self) -> BnString {
+    pub fn short_name(&self) -> &str {
         unsafe {
             let name = BNGetSymbolShortName(self.handle);
-            BnString::from_raw(name)
+            CStr::from_ptr(name).to_str().unwrap()
         }
     }
 
-    pub fn raw_name(&self) -> BnString {
+    pub fn raw_name(&self) -> &str {
         unsafe {
             let name = BNGetSymbolRawName(self.handle);
-            BnString::from_raw(name)
+            CStr::from_ptr(name).to_str().unwrap()
         }
     }
 


### PR DESCRIPTION
The objective of this PR is to make the API more natural to use.

This PR:
* removes the BnStr completely, in favor of `core::ffi::CStr` internally and `str` publicly.
* remove the generic from `FunctionParameter`, now always implemented using String.
* changing the `name` field in both `EnumerationMember` and `StructureMember` to String.

Is also possible to have the BnString removed from the API, by removing it's `pub` flag, and using it only internally, this way, only `String` and `str` are exposed. But that should be implemented in a separated PR.