### PR TITLE
Rust: fix clippy warnings

### DIFF
--- a/rust/examples/decompile/src/main.rs
+++ b/rust/examples/decompile/src/main.rs
@@ -26,7 +26,7 @@ fn decompile_to_c(view: &BinaryView, func: &Function) {
     let last = view.get_next_linear_disassembly_lines(&mut cursor.duplicate());
     let first = view.get_previous_linear_disassembly_lines(&mut cursor);
 
-    let lines = first.into_iter().chain(last.into_iter());
+    let lines = first.into_iter().chain(&last);
 
     for line in lines {
         println!("{}", line.as_ref());

--- a/rust/examples/dwarf/dwarf_export/src/lib.rs
+++ b/rust/examples/dwarf/dwarf_export/src/lib.rs
@@ -522,13 +522,11 @@ fn export_data_vars(
 
     for data_variable in &bv.data_variables() {
         if let Some(symbol) = data_variable.symbol(bv) {
-            if symbol.sym_type() == SymbolType::External {
-                continue;
-            } else if symbol.sym_type() == SymbolType::Function {
-                continue;
-            } else if symbol.sym_type() == SymbolType::ImportedFunction {
-                continue;
-            } else if symbol.sym_type() == SymbolType::LibraryFunction {
+            if let SymbolType::External
+            | SymbolType::Function
+            | SymbolType::ImportedFunction
+            | SymbolType::LibraryFunction = symbol.sym_type()
+            {
                 continue;
             }
         }

--- a/rust/examples/dwarf/dwarf_import/src/lib.rs
+++ b/rust/examples/dwarf/dwarf_import/src/lib.rs
@@ -106,8 +106,7 @@ fn recover_names<R: Reader<Offset = usize>>(
                                 }
                             }
                         } else {
-                            namespace_qualifiers
-                                .push((depth, "anonymous_namespace".to_string()));
+                            namespace_qualifiers.push((depth, "anonymous_namespace".to_string()));
                         }
                     }
 
@@ -129,22 +128,24 @@ fn recover_names<R: Reader<Offset = usize>>(
                             depth,
                             match entry.tag() {
                                 constants::DW_TAG_class_type => "anonymous_class".to_string(),
-                                constants::DW_TAG_structure_type => "anonymous_structure".to_string(),
+                                constants::DW_TAG_structure_type => {
+                                    "anonymous_structure".to_string()
+                                }
                                 constants::DW_TAG_union_type => "anonymous_union".to_string(),
                                 _ => unreachable!(),
-                            }
+                            },
                         ))
                     }
                     debug_info_builder_context.set_name(
                         get_uid(&unit, entry),
-                            simplify_str_to_str(
-                                namespace_qualifiers
-                                    .iter()
-                                    .map(|(_, namespace)| namespace.to_owned())
-                                    .collect::<Vec<String>>()
-                                    .join("::"),
-                            )
-                            .to_string(),
+                        simplify_str_to_str(
+                            namespace_qualifiers
+                                .iter()
+                                .map(|(_, namespace)| namespace.to_owned())
+                                .collect::<Vec<String>>()
+                                .join("::"),
+                        )
+                        .to_string(),
                     );
                 }
                 constants::DW_TAG_typedef
@@ -153,17 +154,15 @@ fn recover_names<R: Reader<Offset = usize>>(
                     if let Some(name) = get_name(&unit, entry, debug_info_builder_context) {
                         debug_info_builder_context.set_name(
                             get_uid(&unit, entry),
-                                simplify_str_to_str(
-                                    namespace_qualifiers
-                                        .iter()
-                                        .chain(vec![&(-1, name)].into_iter())
-                                        .map(|(_, namespace)| {
-                                            namespace.to_owned()
-                                        })
-                                        .collect::<Vec<String>>()
-                                        .join("::"),
-                                )
-                                .to_string(),
+                            simplify_str_to_str(
+                                namespace_qualifiers
+                                    .iter()
+                                    .chain(vec![&(-1, name)].into_iter())
+                                    .map(|(_, namespace)| namespace.to_owned())
+                                    .collect::<Vec<String>>()
+                                    .join("::"),
+                            )
+                            .to_string(),
                         );
                     }
                 }

--- a/rust/examples/dwarf/dwarfdump/src/lib.rs
+++ b/rust/examples/dwarf/dwarfdump/src/lib.rs
@@ -33,7 +33,7 @@ use gimli::{
     UnitSectionOffset,
 };
 
-static PADDING: [&'static str; 23] = [
+static PADDING: [&str; 23] = [
     "",
     " ",
     "  ",
@@ -189,7 +189,7 @@ fn get_info_string<R: Reader>(
             let value_string = format!("{}", value);
             attr_line.push(InstructionTextToken::new(
                 &value_string,
-                InstructionTextTokenContents::Integer(value.into()),
+                InstructionTextTokenContents::Integer(value),
             ));
         } else if let Some(value) = attr.sdata_value() {
             let value_string = format!("{}", value);

--- a/rust/examples/hlil_visitor/src/main.rs
+++ b/rust/examples/hlil_visitor/src/main.rs
@@ -20,7 +20,7 @@ fn print_variable(func: &HighLevelILFunction, var: &Variable) {
 fn print_il_expr(instr: &HighLevelILLiftedInstruction, mut indent: usize) {
     print_indent(indent);
     print_operation(instr);
-    println!("");
+    println!();
 
     indent += 1;
 

--- a/rust/examples/minidump/src/command.rs
+++ b/rust/examples/minidump/src/command.rs
@@ -5,14 +5,11 @@ use minidump::{Minidump, MinidumpMemoryInfoList};
 
 use binaryninja::binaryview::{BinaryView, BinaryViewBase, BinaryViewExt};
 
-use crate::view::DataBufferWrapper;
-
 pub fn print_memory_information(bv: &BinaryView) {
     debug!("Printing memory information");
     if let Ok(minidump_bv) = bv.parent_view() {
         if let Ok(read_buffer) = minidump_bv.read_buffer(0, minidump_bv.len()) {
-            let read_buffer = DataBufferWrapper::new(read_buffer);
-            if let Ok(minidump_obj) = Minidump::read(read_buffer) {
+            if let Ok(minidump_obj) = Minidump::read(read_buffer.get_data()) {
                 if let Ok(memory_info_list) = minidump_obj.get_stream::<MinidumpMemoryInfoList>() {
                     let mut memory_info_list_writer = Vec::new();
                     match memory_info_list.print(&mut memory_info_list_writer) {

--- a/rust/examples/mlil_visitor/src/main.rs
+++ b/rust/examples/mlil_visitor/src/main.rs
@@ -20,7 +20,7 @@ fn print_variable(func: &MediumLevelILFunction, var: &Variable) {
 fn print_il_expr(instr: &MediumLevelILLiftedInstruction, mut indent: usize) {
     print_indent(indent);
     print_operation(instr);
-    println!("");
+    println!();
 
     indent += 1;
 

--- a/rust/src/architecture.rs
+++ b/rust/src/architecture.rs
@@ -1172,7 +1172,7 @@ impl Architecture for CoreArchitecture {
             }
         }
     }
-    
+
     fn instruction_llil(
         &self,
         data: &[u8],

--- a/rust/src/binaryview.rs
+++ b/rust/src/binaryview.rs
@@ -1576,11 +1576,9 @@ where
         ctx: *mut ::std::os::raw::c_void,
         view: *mut BNBinaryView,
     ) {
-        ffi_wrap!("EventHandler::on_event", unsafe {
-            let mut context = &mut *(ctx as *mut Handler);
-
-            let handle = BinaryView::from_raw(BNNewViewReference(view));
-            Handler::on_event(&mut context, handle.as_ref());
+        ffi_wrap!("EventHandler::on_event", {
+            let context = unsafe { &*(ctx as *const Handler) };
+            context.on_event(&BinaryView::from_raw(BNNewViewReference(view)));
         })
     }
 

--- a/rust/src/debuginfo.rs
+++ b/rust/src/debuginfo.rs
@@ -414,10 +414,7 @@ impl DebugInfo {
     }
 
     /// Returns a generator of all functions provided by a named DebugInfoParser
-    pub fn functions_by_name<S: BnStrCompatible>(
-        &self,
-        parser_name: S,
-    ) -> Vec<DebugFunctionInfo> {
+    pub fn functions_by_name<S: BnStrCompatible>(&self, parser_name: S) -> Vec<DebugFunctionInfo> {
         let parser_name = parser_name.into_bytes_with_nul();
 
         let mut count: usize = 0;
@@ -758,21 +755,15 @@ impl DebugInfo {
         let short_name_bytes = new_func.short_name.map(|name| name.into_bytes_with_nul());
         let short_name = short_name_bytes
             .as_ref()
-            .map_or(ptr::null_mut() as *mut _, |name| {
-                name.as_ptr() as _
-            });
+            .map_or(ptr::null_mut() as *mut _, |name| name.as_ptr() as _);
         let full_name_bytes = new_func.full_name.map(|name| name.into_bytes_with_nul());
         let full_name = full_name_bytes
             .as_ref()
-            .map_or(ptr::null_mut() as *mut _, |name| {
-                name.as_ptr() as _
-            });
+            .map_or(ptr::null_mut() as *mut _, |name| name.as_ptr() as _);
         let raw_name_bytes = new_func.raw_name.map(|name| name.into_bytes_with_nul());
         let raw_name = raw_name_bytes
             .as_ref()
-            .map_or(ptr::null_mut() as *mut _, |name| {
-                name.as_ptr() as _
-            });
+            .map_or(ptr::null_mut() as *mut _, |name| name.as_ptr() as _);
 
         let mut components_array: Vec<*const ::std::os::raw::c_char> =
             Vec::with_capacity(new_func.components.len());

--- a/rust/src/flowgraph.rs
+++ b/rust/src/flowgraph.rs
@@ -68,7 +68,7 @@ impl<'a> FlowGraphNode<'a> {
         unsafe { FlowGraphNode::from_raw(BNCreateFlowGraphNode(graph.handle)) }
     }
 
-    pub fn set_disassembly_lines(&self, lines: &'a Vec<DisassemblyTextLine>) {
+    pub fn set_disassembly_lines(&self, lines: &'a [DisassemblyTextLine]) {
         unsafe {
             BNSetFlowGraphNodeLines(self.handle, lines.as_ptr() as *mut _, lines.len());
             // BNFreeDisassemblyTextLines(lines.as_ptr() as *mut _, lines.len());  // Shouldn't need...would be a double free?
@@ -79,7 +79,7 @@ impl<'a> FlowGraphNode<'a> {
         let lines = lines
             .iter()
             .map(|&line| DisassemblyTextLine::from(&vec![line]))
-            .collect();
+            .collect::<Vec<_>>();
         self.set_disassembly_lines(&lines);
     }
 

--- a/rust/src/function.rs
+++ b/rust/src/function.rs
@@ -30,7 +30,6 @@ pub use binaryninjacore_sys::BNAnalysisSkipReason as AnalysisSkipReason;
 pub use binaryninjacore_sys::BNFunctionAnalysisSkipOverride as FunctionAnalysisSkipOverride;
 pub use binaryninjacore_sys::BNFunctionUpdateType as FunctionUpdateType;
 
-
 use std::hash::Hash;
 use std::{fmt, mem};
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -74,16 +74,12 @@
 //! ### `main.rs`
 //! Standalone binaries need to initialize Binary Ninja before they can work. You can do this through [`headless::Session`], [`headless::script_helper`], or [`headless::init()`] at start and [`headless::shutdown()`] at shutdown.
 //! ```rust
-//! fn main() {
-//!     // This loads all the core architecture, platform, etc plugins
-//!     // Standalone executables need to call this, but plugins do not
-//!     let headless_session = binaryninja::headless::Session::new();
+//! // This loads all the core architecture, platform, etc plugins
+//! // Standalone executables need to call this, but plugins do not
+//! let headless_session = binaryninja::headless::Session::new();
 //!
-//!     println!("Loading binary...");
-//!     let bv = headless_session.load("/bin/cat").expect("Couldn't open `/bin/cat`");
-//!
-//!     // Your code here...
-//! }
+//! println!("Loading binary...");
+//! let bv = headless_session.load("/bin/cat").expect("Couldn't open `/bin/cat`");
 //! ```
 //!
 //! ### `Cargo.toml`

--- a/rust/src/llil/instruction.rs
+++ b/rust/src/llil/instruction.rs
@@ -99,7 +99,7 @@ where
         let expr_idx =
             unsafe { BNGetLowLevelILIndexForInstruction(self.function.handle, self.instr_idx) };
         let op = unsafe { BNGetLowLevelILByIndex(self.function.handle, expr_idx) };
-        return op.address;
+        op.address
     }
 
     pub fn info(&self) -> InstrInfo<'func, A, M, NonSSA<V>> {

--- a/rust/src/llil/operation.rs
+++ b/rust/src/llil/operation.rs
@@ -89,10 +89,10 @@ pub struct Syscall;
 pub struct Intrinsic;
 
 impl<'func, A, M, V> Operation<'func, A, M, NonSSA<V>, Intrinsic>
-    where
-        A: 'func + Architecture,
-        M: FunctionMutability,
-        V: NonSSAVariant,
+where
+    A: 'func + Architecture,
+    M: FunctionMutability,
+    V: NonSSAVariant,
 {
     // TODO: Support register and expression lists
     pub fn intrinsic(&self) -> Option<A::Intrinsic> {

--- a/rust/src/mlil/instruction.rs
+++ b/rust/src/mlil/instruction.rs
@@ -704,7 +704,12 @@ impl MediumLevelILInstruction {
             }),
             // translated directly into a list for Expression or Variables
             // TODO MLIL_MEMORY_INTRINSIC_SSA needs to be handled properly
-            MLIL_CALL_OUTPUT | MLIL_CALL_PARAM | MLIL_CALL_PARAM_SSA | MLIL_CALL_OUTPUT_SSA | MLIL_MEMORY_INTRINSIC_OUTPUT_SSA | MLIL_MEMORY_INTRINSIC_SSA => {
+            MLIL_CALL_OUTPUT
+            | MLIL_CALL_PARAM
+            | MLIL_CALL_PARAM_SSA
+            | MLIL_CALL_OUTPUT_SSA
+            | MLIL_MEMORY_INTRINSIC_OUTPUT_SSA
+            | MLIL_MEMORY_INTRINSIC_SSA => {
                 unreachable!()
             }
         };

--- a/rust/src/string.rs
+++ b/rust/src/string.rs
@@ -94,6 +94,10 @@ impl BnString {
     pub fn len(&self) -> usize {
         self.as_ref().len()
     }
+
+    pub fn is_empty(&self) -> bool {
+        self.as_ref().is_empty()
+    }
 }
 
 impl Drop for BnString {


### PR DESCRIPTION
Since clippy is part of CI now, the existing clippy warnings should be fixed so other unrelated PRs don't start failing CI. Also ran `cargo fmt` since this is a miscellaneous PR.