### PR TITLE
remove unecessary and crash causing zeroed call inits

### DIFF
--- a/rust/src/debuginfo.rs
+++ b/rust/src/debuginfo.rs
@@ -74,7 +74,7 @@ use crate::{
     types::{DataVariableAndName, NameAndType, Type},
 };
 
-use std::{hash::Hash, mem, os::raw::c_void, ptr, slice};
+use std::{hash::Hash, os::raw::c_void, ptr, slice};
 
 struct ProgressContext(Option<Box<dyn Fn(usize, usize) -> Result<(), ()>>>);
 
@@ -109,14 +109,14 @@ impl DebugInfoParser {
 
     /// List all debug-info parsers
     pub fn list() -> Array<DebugInfoParser> {
-        let mut count: usize = unsafe { mem::zeroed() };
+        let mut count = 0;
         let raw_parsers = unsafe { BNGetDebugInfoParsers(&mut count as *mut _) };
         unsafe { Array::new(raw_parsers, count, ()) }
     }
 
     /// Returns a list of debug-info parsers that are valid for the provided binary view
     pub fn parsers_for_view(bv: &BinaryView) -> Array<DebugInfoParser> {
-        let mut count: usize = unsafe { mem::zeroed() };
+        let mut count = 0;
         let raw_parsers = unsafe { BNGetDebugInfoParsersForView(bv.handle, &mut count as *mut _) };
         unsafe { Array::new(raw_parsers, count, ()) }
     }
@@ -414,10 +414,7 @@ impl DebugInfo {
     }
 
     /// Returns a generator of all functions provided by a named DebugInfoParser
-    pub fn functions_by_name<S: BnStrCompatible>(
-        &self,
-        parser_name: S,
-    ) -> Vec<DebugFunctionInfo> {
+    pub fn functions_by_name<S: BnStrCompatible>(&self, parser_name: S) -> Vec<DebugFunctionInfo> {
         let parser_name = parser_name.into_bytes_with_nul();
 
         let mut count: usize = 0;
@@ -758,21 +755,15 @@ impl DebugInfo {
         let short_name_bytes = new_func.short_name.map(|name| name.into_bytes_with_nul());
         let short_name = short_name_bytes
             .as_ref()
-            .map_or(ptr::null_mut() as *mut _, |name| {
-                name.as_ptr() as _
-            });
+            .map_or(ptr::null_mut() as *mut _, |name| name.as_ptr() as _);
         let full_name_bytes = new_func.full_name.map(|name| name.into_bytes_with_nul());
         let full_name = full_name_bytes
             .as_ref()
-            .map_or(ptr::null_mut() as *mut _, |name| {
-                name.as_ptr() as _
-            });
+            .map_or(ptr::null_mut() as *mut _, |name| name.as_ptr() as _);
         let raw_name_bytes = new_func.raw_name.map(|name| name.into_bytes_with_nul());
         let raw_name = raw_name_bytes
             .as_ref()
-            .map_or(ptr::null_mut() as *mut _, |name| {
-                name.as_ptr() as _
-            });
+            .map_or(ptr::null_mut() as *mut _, |name| name.as_ptr() as _);
 
         let mut components_array: Vec<*const ::std::os::raw::c_char> =
             Vec::with_capacity(new_func.components.len());

--- a/rust/src/demangle.rs
+++ b/rust/src/demangle.rs
@@ -33,8 +33,8 @@ pub fn demangle_gnu3<S: BnStrCompatible>(
 ) -> Result<(Option<Ref<Type>>, Vec<String>)> {
     let mangled_name_bwn = mangled_name.into_bytes_with_nul();
     let mangled_name_ptr = mangled_name_bwn.as_ref();
-    let mut out_type: *mut BNType = unsafe { std::mem::zeroed() };
-    let mut out_name: *mut *mut std::os::raw::c_char = unsafe { std::mem::zeroed() };
+    let mut out_type: *mut BNType = std::ptr::null_mut();
+    let mut out_name: *mut *mut std::os::raw::c_char = std::ptr::null_mut();
     let mut out_size: usize = 0;
     let res = unsafe {
         BNDemangleGNU3(
@@ -89,8 +89,8 @@ pub fn demangle_ms<S: BnStrCompatible>(
     let mangled_name_bwn = mangled_name.into_bytes_with_nul();
     let mangled_name_ptr = mangled_name_bwn.as_ref();
 
-    let mut out_type: *mut BNType = unsafe { std::mem::zeroed() };
-    let mut out_name: *mut *mut std::os::raw::c_char = unsafe { std::mem::zeroed() };
+    let mut out_type: *mut BNType = std::ptr::null_mut();
+    let mut out_name: *mut *mut std::os::raw::c_char = std::ptr::null_mut();
     let mut out_size: usize = 0;
     let res = unsafe {
         BNDemangleMS(

--- a/rust/src/relocation.rs
+++ b/rust/src/relocation.rs
@@ -8,6 +8,7 @@ use crate::{
 };
 use binaryninjacore_sys::*;
 use std::borrow::Borrow;
+use std::mem::MaybeUninit;
 use std::os::raw::c_void;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -501,12 +502,9 @@ where
 
     let name = name.into_bytes_with_nul();
 
-    let uninit_handler = RelocationHandlerBuilder {
-        handler: unsafe { std::mem::zeroed() },
-    };
-    let raw = Box::into_raw(Box::new(uninit_handler));
+    let raw = Box::leak(Box::new(MaybeUninit::<RelocationHandlerBuilder<_>>::zeroed()));
     let mut custom_handler = BNCustomRelocationHandler {
-        context: raw as *mut _,
+        context: raw.as_mut_ptr() as *mut _,
         freeObject: Some(cb_free::<R>),
         getRelocationInfo: Some(cb_get_relocation_info::<R>),
         applyRelocation: Some(cb_apply_relocation::<R>),
@@ -517,13 +515,12 @@ where
     assert!(!handle_raw.is_null());
     let handle = CoreRelocationHandler(handle_raw);
     let custom_handle = CustomRelocationHandlerHandle {
-        handle: raw as *mut R,
+        handle: raw.as_mut_ptr() as *mut R,
     };
     unsafe {
-        core::ptr::write(
-            &mut raw.as_mut().unwrap().handler,
-            func(custom_handle, CoreRelocationHandler(handle.0)),
-        );
+        raw.write(RelocationHandlerBuilder {
+            handler: func(custom_handle, CoreRelocationHandler(handle.0)),
+        });
 
         BNArchitectureRegisterRelocationHandler(
             arch.handle().as_ref().0,

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -422,7 +422,7 @@ impl TypeBuilder {
 
     pub fn parameters(&self) -> Result<Vec<FunctionParameter>> {
         unsafe {
-            let mut count: usize = mem::zeroed();
+            let mut count = 0;
             let parameters_raw = BNGetTypeBuilderParameters(self.handle, &mut count);
             if parameters_raw.is_null() {
                 Err(())
@@ -793,7 +793,7 @@ impl Type {
 
     pub fn parameters(&self) -> Result<Vec<FunctionParameter>> {
         unsafe {
-            let mut count: usize = mem::zeroed();
+            let mut count = 0;
             let parameters_raw: *mut BNFunctionParameter =
                 BNGetTypeParameters(self.handle, &mut count);
             if parameters_raw.is_null() {
@@ -1549,7 +1549,7 @@ impl EnumerationBuilder {
 
     pub fn members(&self) -> Vec<EnumerationMember> {
         unsafe {
-            let mut count: usize = mem::zeroed();
+            let mut count = 0;
             let members_raw = BNGetEnumerationBuilderMembers(self.handle, &mut count);
             let members: &[BNEnumerationMember] = slice::from_raw_parts(members_raw, count);
 
@@ -1606,7 +1606,7 @@ impl Enumeration {
 
     pub fn members(&self) -> Vec<EnumerationMember> {
         unsafe {
-            let mut count: usize = mem::zeroed();
+            let mut count = 0;
             let members_raw = BNGetEnumerationMembers(self.handle, &mut count);
             let members: &[BNEnumerationMember] = slice::from_raw_parts(members_raw, count);
 
@@ -1937,7 +1937,7 @@ impl Structure {
 
     pub fn members(&self) -> Result<Vec<StructureMember>> {
         unsafe {
-            let mut count: usize = mem::zeroed();
+            let mut count = 0;
             let members_raw: *mut BNStructureMember =
                 BNGetStructureMembers(self.handle, &mut count);
             if members_raw.is_null() {


### PR DESCRIPTION
- fix #5292
- similar possible crash on `register_view_type` and `register_relocation_handler`
- remove unnecessary zeroed calls with more adequate initializations.