### PR TITLE
fix leak creation of invalid BinaryView handle

### DIFF
--- a/rust/src/interaction.rs
+++ b/rust/src/interaction.rs
@@ -296,7 +296,9 @@ impl FormInputBuilder {
         result.type_ = BNFormInputFieldType::AddressFormField;
         result.prompt = prompt.as_ref().as_ptr() as *const c_char;
         if let Some(view) = view {
-            result.view = view.handle;
+            // the view is being moved into result, there is no need to clone
+            // and drop is intentionally being avoided with `Ref::into_raw`
+            result.view = unsafe { Ref::into_raw(view) }.handle;
         }
         result.currentAddress = current_address.unwrap_or(0);
         result.hasDefault = default.is_some();


### PR DESCRIPTION
The parameter `view: Option<Ref<BinaryView>>` is being dropped by the `if let` statement, making the handle to it invalid.

This fix the problem with `Ref::into_raw`.