### PR TITLE
Fix non-escaped CStr

### DIFF
--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1234,7 +1234,7 @@ impl fmt::Debug for Type {
                     BNGetTypeLines(
                         self.handle,
                         container,
-                        "".as_ptr() as *const c_char,
+                        "\x00".as_ptr() as *const c_char,
                         64,
                         false,
                         BNTokenEscapingType::NoTokenEscapingType,


### PR DESCRIPTION
While running the code below, I noticed that binja would get possessed and output random strings:
```rust
use binaryninja::types::Type;
fn main() {
    binaryninja::headless::init();
    let my_type = Type::bool();
    let my_named_type = Type::named_type_from_type("MyName", &my_type);
    println!("my_named_type: |{my_named_type:?}|");
    binaryninja::headless::shutdown();
    println!("shutdown");
}
```
Output something like:
```
my_named_type: |typedef MyName
called `Result::unwrap()` on an `Err` valueBINJA_DIR/home/rbran/src/binaryninja-api/rust/src/headless.rsFailed to find libbinaryninjacore path!plugins;|
shutdown
```

On closer inspection, I noticed that was cause by this simple string being passed as Rust Str and not C Str, missing the null char.