### PR TITLE
Remove `From<Conf<Ref<Type>>> for BNTypeWithConfidence`

### DIFF
--- a/rust/src/architecture.rs
+++ b/rust/src/architecture.rs
@@ -2474,8 +2474,8 @@ where
         if let Some(intrinsic) = custom_arch.intrinsic_from_id(intrinsic) {
             let inputs = intrinsic.outputs();
             let mut res = Vec::with_capacity(inputs.len());
-            for input in inputs {
-                res.push(input.into());
+            for input in inputs.iter() {
+                res.push(input.as_ref().into());
             }
 
             unsafe {

--- a/rust/src/binaryview.rs
+++ b/rust/src/binaryview.rs
@@ -576,14 +576,14 @@ pub trait BinaryViewExt: BinaryViewBase {
 
     fn define_auto_data_var(&self, dv: DataVariable) {
         unsafe {
-            BNDefineDataVariable(self.as_ref().handle, dv.address, &mut dv.t.into());
+            BNDefineDataVariable(self.as_ref().handle, dv.address, &mut dv.t.as_ref().into());
         }
     }
 
     /// You likely would also like to call [`Self::define_user_symbol`] to bind this data variable with a name
     fn define_user_data_var(&self, dv: DataVariable) {
         unsafe {
-            BNDefineUserDataVariable(self.as_ref().handle, dv.address, &mut dv.t.into());
+            BNDefineUserDataVariable(self.as_ref().handle, dv.address, &mut dv.t.as_ref().into());
         }
     }
 

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -260,15 +260,6 @@ impl From<BNOffsetWithConfidence> for Conf<i64> {
     }
 }
 
-impl From<Conf<Ref<Type>>> for BNTypeWithConfidence {
-    fn from(conf: Conf<Ref<Type>>) -> Self {
-        Self {
-            type_: conf.contents.handle,
-            confidence: conf.confidence,
-        }
-    }
-}
-
 impl From<Conf<&Type>> for BNTypeWithConfidence {
     fn from(conf: Conf<&Type>) -> Self {
         Self {


### PR DESCRIPTION
The implementation `From<Conf<Ref<Type>>> for BNTypeWithConfidence` leaks the received value `Conf<Ref<Type>>`, it should only operate with references, so the owned value is not dropped.