### PR TITLE
Fix binja_path in case the lib is a symlink

### DIFF
--- a/rust/src/headless.rs
+++ b/rust/src/headless.rs
@@ -59,6 +59,11 @@ fn binja_path() -> PathBuf {
         let path = CStr::from_ptr(info.dli_fname);
         let path = OsStr::from_bytes(path.to_bytes());
         let mut path = PathBuf::from(path);
+        while path.is_symlink() {
+            path = path
+                .read_link()
+                .expect("Failed to find libbinaryninjacore path!");
+        }
 
         path.pop();
         path


### PR DESCRIPTION
In case the binja lib is symlink, like `/usr/lib/libbinaryninjacore.so.1 -> /opt/binaryninja/libbinaryninjacore.so.1`, the function `binja_path` will return the wrong path, in this example `/usr/lib`.