### PR TITLE
hide array implementation details

### DIFF
--- a/rust/src/backgroundtask.rs
+++ b/rust/src/backgroundtask.rs
@@ -104,21 +104,14 @@ unsafe impl RefCountable for BackgroundTask {
 impl CoreArrayProvider for BackgroundTask {
     type Raw = *mut BNBackgroundTask;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, BackgroundTask>;
 }
 
-unsafe impl CoreOwnedArrayProvider for BackgroundTask {
+unsafe impl CoreArrayProviderInner for BackgroundTask {
     unsafe fn free(raw: *mut *mut BNBackgroundTask, count: usize, _context: &()) {
         BNFreeBackgroundTaskList(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for BackgroundTask {
-    type Wrapped<'a> = Guard<'a, BackgroundTask>;
-
-    unsafe fn wrap_raw<'a>(
-        raw: &'a *mut BNBackgroundTask,
-        context: &'a (),
-    ) -> Self::Wrapped<'a> {
+    unsafe fn wrap_raw<'a>(raw: &'a *mut BNBackgroundTask, context: &'a ()) -> Self::Wrapped<'a> {
         Guard::new(BackgroundTask::from_raw(*raw), context)
     }
 }

--- a/rust/src/basicblock.rs
+++ b/rust/src/basicblock.rs
@@ -68,17 +68,13 @@ pub struct EdgeContext<'a, C: 'a + BlockContext> {
 impl<'a, C: 'a + BlockContext> CoreArrayProvider for Edge<'a, C> {
     type Raw = BNBasicBlockEdge;
     type Context = EdgeContext<'a, C>;
+    type Wrapped<'b> = Edge<'b, C> where 'a: 'b;
 }
 
-unsafe impl<'a, C: 'a + BlockContext> CoreOwnedArrayProvider for Edge<'a, C> {
+unsafe impl<'a, C: 'a + BlockContext> CoreArrayProviderInner for Edge<'a, C> {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         BNFreeBasicBlockEdgeList(raw, count);
     }
-}
-
-unsafe impl<'a, C: BlockContext> CoreArrayWrapper for Edge<'a, C> {
-    type Wrapped<'b> = Edge<'b, C> where 'a: 'b;
-
     unsafe fn wrap_raw<'b>(raw: &'b Self::Raw, context: &'b Self::Context) -> Self::Wrapped<'b> {
         let edge_target = Guard::new(
             BasicBlock::from_raw(raw.target, context.orig_block.context.clone()),
@@ -301,17 +297,13 @@ unsafe impl<C: BlockContext> RefCountable for BasicBlock<C> {
 impl<C: BlockContext> CoreArrayProvider for BasicBlock<C> {
     type Raw = *mut BNBasicBlock;
     type Context = C;
+    type Wrapped<'a> = Guard<'a, BasicBlock<C>> where C: 'a;
 }
 
-unsafe impl<C: BlockContext> CoreOwnedArrayProvider for BasicBlock<C> {
+unsafe impl<C: BlockContext> CoreArrayProviderInner for BasicBlock<C> {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         BNFreeBasicBlockList(raw, count);
     }
-}
-
-unsafe impl<C: BlockContext> CoreArrayWrapper for BasicBlock<C> {
-    type Wrapped<'a> = Guard<'a, BasicBlock<C>> where C: 'a;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, context: &'a Self::Context) -> Self::Wrapped<'a> {
         Guard::new(BasicBlock::from_raw(*raw, context.clone()), context)
     }

--- a/rust/src/callingconvention.rs
+++ b/rust/src/callingconvention.rs
@@ -26,7 +26,7 @@ use binaryninjacore_sys::*;
 
 use crate::architecture::{Architecture, ArchitectureExt, CoreArchitecture, Register};
 use crate::rc::{
-    CoreArrayProvider, CoreArrayWrapper, CoreOwnedArrayProvider, Guard, Ref, RefCountable,
+    CoreArrayProvider, CoreArrayProviderInner, Guard, Ref, RefCountable,
 };
 use crate::string::*;
 
@@ -678,17 +678,13 @@ unsafe impl<A: Architecture> RefCountable for CallingConvention<A> {
 impl<A: Architecture> CoreArrayProvider for CallingConvention<A> {
     type Raw = *mut BNCallingConvention;
     type Context = A::Handle;
+    type Wrapped<'a> = Guard<'a, CallingConvention<A>>;
 }
 
-unsafe impl<A: Architecture> CoreOwnedArrayProvider for CallingConvention<A> {
+unsafe impl<A: Architecture> CoreArrayProviderInner for CallingConvention<A> {
     unsafe fn free(raw: *mut *mut BNCallingConvention, count: usize, _content: &Self::Context) {
         BNFreeCallingConventionList(raw, count);
     }
-}
-
-unsafe impl<A: Architecture> CoreArrayWrapper for CallingConvention<A> {
-    type Wrapped<'a> = Guard<'a, CallingConvention<A>>;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, context: &'a Self::Context) -> Self::Wrapped<'a> {
         Guard::new(
             CallingConvention {

--- a/rust/src/custombinaryview.rs
+++ b/rust/src/custombinaryview.rs
@@ -290,17 +290,13 @@ impl BinaryViewTypeBase for BinaryViewType {
 impl CoreArrayProvider for BinaryViewType {
     type Raw = *mut BNBinaryViewType;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, BinaryViewType>;
 }
 
-unsafe impl CoreOwnedArrayProvider for BinaryViewType {
+unsafe impl CoreArrayProviderInner for BinaryViewType {
     unsafe fn free(raw: *mut Self::Raw, _count: usize, _context: &Self::Context) {
         BNFreeBinaryViewTypeList(raw);
     }
-}
-
-unsafe impl CoreArrayWrapper for BinaryViewType {
-    type Wrapped<'a> = Guard<'a, BinaryViewType>;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
         Guard::new(BinaryViewType(*raw), &())
     }

--- a/rust/src/debuginfo.rs
+++ b/rust/src/debuginfo.rs
@@ -273,11 +273,15 @@ impl ToOwned for DebugInfoParser {
 impl CoreArrayProvider for DebugInfoParser {
     type Raw = *mut BNDebugInfoParser;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, DebugInfoParser>;
 }
 
-unsafe impl CoreOwnedArrayProvider for DebugInfoParser {
+unsafe impl CoreArrayProviderInner for DebugInfoParser {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _: &Self::Context) {
         BNFreeDebugInfoParserList(raw, count);
+    }
+    unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, context: &'a Self::Context) -> Self::Wrapped<'a> {
+        Guard::new(Self { handle: *raw }, context)
     }
 }
 

--- a/rust/src/debuginfo.rs
+++ b/rust/src/debuginfo.rs
@@ -285,14 +285,6 @@ unsafe impl CoreArrayProviderInner for DebugInfoParser {
     }
 }
 
-unsafe impl CoreArrayWrapper for DebugInfoParser {
-    type Wrapped<'a> = Guard<'a, DebugInfoParser>;
-
-    unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
-        Guard::new(DebugInfoParser { handle: *raw }, &())
-    }
-}
-
 ///////////////////////
 // DebugFunctionInfo
 

--- a/rust/src/downloadprovider.rs
+++ b/rust/src/downloadprovider.rs
@@ -1,6 +1,4 @@
-use crate::rc::{
-    Array, CoreArrayProvider, CoreArrayWrapper, CoreOwnedArrayProvider, Guard, Ref, RefCountable,
-};
+use crate::rc::{Array, CoreArrayProvider, Guard, CoreArrayProviderInner, Ref, RefCountable};
 use crate::settings::Settings;
 use crate::string::{BnStrCompatible, BnString};
 use binaryninjacore_sys::*;
@@ -63,17 +61,13 @@ impl DownloadProvider {
 impl CoreArrayProvider for DownloadProvider {
     type Raw = *mut BNDownloadProvider;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, DownloadProvider>;
 }
 
-unsafe impl CoreOwnedArrayProvider for DownloadProvider {
+unsafe impl CoreArrayProviderInner for DownloadProvider {
     unsafe fn free(raw: *mut Self::Raw, _count: usize, _context: &Self::Context) {
         BNFreeDownloadProviderList(raw);
     }
-}
-
-unsafe impl CoreArrayWrapper for DownloadProvider {
-    type Wrapped<'a> = Guard<'a, DownloadProvider>;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
         Guard::new(DownloadProvider::from_raw(*raw), &())
     }

--- a/rust/src/function.rs
+++ b/rust/src/function.rs
@@ -414,17 +414,13 @@ unsafe impl RefCountable for Function {
 impl CoreArrayProvider for Function {
     type Raw = *mut BNFunction;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, Function>;
 }
 
-unsafe impl CoreOwnedArrayProvider for Function {
+unsafe impl CoreArrayProviderInner for Function {
     unsafe fn free(raw: *mut *mut BNFunction, count: usize, _context: &()) {
         BNFreeFunctionList(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for Function {
-    type Wrapped<'a> = Guard<'a, Function>;
-
     unsafe fn wrap_raw<'a>(raw: &'a *mut BNFunction, context: &'a ()) -> Self::Wrapped<'a> {
         Guard::new(Function { handle: *raw }, context)
     }
@@ -469,16 +465,12 @@ impl AddressRange {
 impl CoreArrayProvider for AddressRange {
     type Raw = BNAddressRange;
     type Context = ();
+    type Wrapped<'a> = &'a AddressRange;
 }
-unsafe impl CoreOwnedArrayProvider for AddressRange {
+unsafe impl CoreArrayProviderInner for AddressRange {
     unsafe fn free(raw: *mut Self::Raw, _count: usize, _context: &Self::Context) {
         BNFreeAddressRanges(raw);
     }
-}
-
-unsafe impl CoreArrayWrapper for AddressRange {
-    type Wrapped<'a> = &'a AddressRange;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
         mem::transmute(raw)
     }

--- a/rust/src/linearview.rs
+++ b/rust/src/linearview.rs
@@ -415,17 +415,13 @@ impl std::fmt::Display for LinearDisassemblyLine {
 impl CoreArrayProvider for LinearDisassemblyLine {
     type Raw = BNLinearDisassemblyLine;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, LinearDisassemblyLine>;
 }
 
-unsafe impl CoreOwnedArrayProvider for LinearDisassemblyLine {
+unsafe impl CoreArrayProviderInner for LinearDisassemblyLine {
     unsafe fn free(raw: *mut BNLinearDisassemblyLine, count: usize, _context: &()) {
         BNFreeLinearDisassemblyLines(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for LinearDisassemblyLine {
-    type Wrapped<'a> = Guard<'a, LinearDisassemblyLine>;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
         Guard::new(LinearDisassemblyLine::from_raw(raw), _context)
     }

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -1,6 +1,4 @@
-use crate::rc::{
-    Array, CoreArrayProvider, CoreArrayWrapper, CoreOwnedArrayProvider, Guard, Ref, RefCountable,
-};
+use crate::rc::{Array, CoreArrayProvider, Guard, CoreArrayProviderInner, Ref, RefCountable};
 use crate::string::{BnStrCompatible, BnString};
 use binaryninjacore_sys::*;
 use std::collections::HashMap;
@@ -335,17 +333,13 @@ unsafe impl RefCountable for Metadata {
 impl CoreArrayProvider for Metadata {
     type Raw = *mut BNMetadata;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, Metadata>;
 }
 
-unsafe impl CoreOwnedArrayProvider for Metadata {
+unsafe impl CoreArrayProviderInner for Metadata {
     unsafe fn free(raw: *mut *mut BNMetadata, _count: usize, _context: &()) {
         BNFreeMetadataArray(raw);
     }
-}
-
-unsafe impl CoreArrayWrapper for Metadata {
-    type Wrapped<'a> = Guard<'a, Metadata>;
-
     unsafe fn wrap_raw<'a>(raw: &'a *mut BNMetadata, context: &'a ()) -> Self::Wrapped<'a> {
         Guard::new(Metadata::from_raw(*raw), context)
     }

--- a/rust/src/platform.rs
+++ b/rust/src/platform.rs
@@ -365,17 +365,13 @@ unsafe impl RefCountable for Platform {
 impl CoreArrayProvider for Platform {
     type Raw = *mut BNPlatform;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, Platform>;
 }
 
-unsafe impl CoreOwnedArrayProvider for Platform {
+unsafe impl CoreArrayProviderInner for Platform {
     unsafe fn free(raw: *mut *mut BNPlatform, count: usize, _context: &()) {
         BNFreePlatformList(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for Platform {
-    type Wrapped<'a> = Guard<'a, Platform>;
-
     unsafe fn wrap_raw<'a>(raw: &'a *mut BNPlatform, context: &'a ()) -> Self::Wrapped<'a> {
         debug_assert!(!raw.is_null());
         Guard::new(Platform { handle: *raw }, context)

--- a/rust/src/relocation.rs
+++ b/rust/src/relocation.rs
@@ -4,7 +4,7 @@ use crate::{
     architecture::{Architecture, CoreArchitecture},
     binaryview::BinaryView,
     llil,
-    rc::{CoreArrayProvider, CoreArrayWrapper, CoreOwnedArrayProvider, Ref, RefCountable},
+    rc::{CoreArrayProvider, CoreArrayProviderInner, Ref, RefCountable},
     symbol::Symbol,
 };
 use binaryninjacore_sys::*;
@@ -221,16 +221,13 @@ impl Relocation {
 impl CoreArrayProvider for Relocation {
     type Raw = *mut BNRelocation;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, Relocation>;
 }
 
-unsafe impl CoreOwnedArrayProvider for Relocation {
+unsafe impl CoreArrayProviderInner for Relocation {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         BNFreeRelocationList(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for Relocation {
-    type Wrapped<'a> = Guard<'a, Relocation>;
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
         Guard::new(Relocation(*raw), &())
     }

--- a/rust/src/section.rs
+++ b/rust/src/section.rs
@@ -174,17 +174,13 @@ unsafe impl RefCountable for Section {
 impl CoreArrayProvider for Section {
     type Raw = *mut BNSection;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, Section>;
 }
 
-unsafe impl CoreOwnedArrayProvider for Section {
+unsafe impl CoreArrayProviderInner for Section {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         BNFreeSectionList(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for Section {
-    type Wrapped<'a> = Guard<'a, Section>;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, context: &'a Self::Context) -> Self::Wrapped<'a> {
         Guard::new(Section::from_raw(*raw), context)
     }

--- a/rust/src/segment.rs
+++ b/rust/src/segment.rs
@@ -204,17 +204,13 @@ unsafe impl RefCountable for Segment {
 impl CoreArrayProvider for Segment {
     type Raw = *mut BNSegment;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, Segment>;
 }
 
-unsafe impl CoreOwnedArrayProvider for Segment {
+unsafe impl CoreArrayProviderInner for Segment {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         BNFreeSegmentList(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for Segment {
-    type Wrapped<'a> = Guard<'a, Segment>;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, context: &'a Self::Context) -> Self::Wrapped<'a> {
         Guard::new(Segment::from_raw(*raw), context)
     }

--- a/rust/src/string.rs
+++ b/rust/src/string.rs
@@ -164,18 +164,14 @@ impl fmt::Debug for BnString {
 impl CoreArrayProvider for BnString {
     type Raw = *mut raw::c_char;
     type Context = ();
+    type Wrapped<'a> = &'a str;
 }
 
-unsafe impl CoreOwnedArrayProvider for BnString {
+unsafe impl CoreArrayProviderInner for BnString {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         use binaryninjacore_sys::BNFreeStringList;
         BNFreeStringList(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for BnString {
-    type Wrapped<'a> = &'a str;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
         CStr::from_ptr(*raw).to_str().unwrap()
     }

--- a/rust/src/symbol.rs
+++ b/rust/src/symbol.rs
@@ -329,17 +329,13 @@ unsafe impl RefCountable for Symbol {
 impl CoreArrayProvider for Symbol {
     type Raw = *mut BNSymbol;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, Symbol>;
 }
 
-unsafe impl CoreOwnedArrayProvider for Symbol {
+unsafe impl CoreArrayProviderInner for Symbol {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         BNFreeSymbolList(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for Symbol {
-    type Wrapped<'a> = Guard<'a, Symbol>;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, context: &'a Self::Context) -> Self::Wrapped<'a> {
         Guard::new(Symbol::from_raw(*raw), context)
     }

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -1439,17 +1439,13 @@ impl NamedTypedVariable {
 impl CoreArrayProvider for NamedTypedVariable {
     type Raw = BNVariableNameAndType;
     type Context = ();
+    type Wrapped<'a> = ManuallyDrop<NamedTypedVariable>;
 }
 
-unsafe impl CoreOwnedArrayProvider for NamedTypedVariable {
+unsafe impl CoreArrayProviderInner for NamedTypedVariable {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         BNFreeVariableNameAndTypeList(raw, count)
     }
-}
-
-unsafe impl CoreArrayWrapper for NamedTypedVariable {
-    type Wrapped<'a> = ManuallyDrop<NamedTypedVariable>;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
         ManuallyDrop::new(NamedTypedVariable {
             var: raw.var,
@@ -2406,16 +2402,12 @@ impl Drop for QualifiedName {
 impl CoreArrayProvider for QualifiedName {
     type Raw = BNQualifiedName;
     type Context = ();
+    type Wrapped<'a> = &'a QualifiedName;
 }
-unsafe impl CoreOwnedArrayProvider for QualifiedName {
+unsafe impl CoreArrayProviderInner for QualifiedName {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         BNFreeTypeNameList(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for QualifiedName {
-    type Wrapped<'a> = &'a QualifiedName;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
         mem::transmute(raw)
     }
@@ -2448,16 +2440,12 @@ impl Drop for QualifiedNameAndType {
 impl CoreArrayProvider for QualifiedNameAndType {
     type Raw = BNQualifiedNameAndType;
     type Context = ();
+    type Wrapped<'a> = &'a QualifiedNameAndType;
 }
-unsafe impl CoreOwnedArrayProvider for QualifiedNameAndType {
+unsafe impl CoreArrayProviderInner for QualifiedNameAndType {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         BNFreeTypeAndNameList(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for QualifiedNameAndType {
-    type Wrapped<'a> = &'a QualifiedNameAndType;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
         mem::transmute(raw)
     }
@@ -2494,16 +2482,12 @@ impl Drop for QualifiedNameTypeAndId {
 impl CoreArrayProvider for QualifiedNameTypeAndId {
     type Raw = BNQualifiedNameTypeAndId;
     type Context = ();
+    type Wrapped<'a> = &'a QualifiedNameTypeAndId;
 }
-unsafe impl CoreOwnedArrayProvider for QualifiedNameTypeAndId {
+unsafe impl CoreArrayProviderInner for QualifiedNameTypeAndId {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         BNFreeTypeIdList(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for QualifiedNameTypeAndId {
-    type Wrapped<'a> = &'a QualifiedNameTypeAndId;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
         mem::transmute(raw)
     }
@@ -2573,17 +2557,13 @@ unsafe impl RefCountable for NameAndType {
 impl CoreArrayProvider for NameAndType {
     type Raw = BNNameAndType;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, NameAndType>;
 }
 
-unsafe impl CoreOwnedArrayProvider for NameAndType {
+unsafe impl CoreArrayProviderInner for NameAndType {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         BNFreeNameAndTypeList(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for NameAndType {
-    type Wrapped<'a> = Guard<'a, NameAndType>;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
         unsafe { Guard::new(NameAndType::from_raw(raw), raw) }
     }
@@ -2653,16 +2633,12 @@ unsafe impl RefCountable for DataVariable {
 impl CoreArrayProvider for DataVariable {
     type Raw = BNDataVariable;
     type Context = ();
+    type Wrapped<'a> = &'a DataVariable;
 }
-unsafe impl CoreOwnedArrayProvider for DataVariable {
+unsafe impl CoreArrayProviderInner for DataVariable {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         BNFreeDataVariables(raw, count);
     }
-}
-
-unsafe impl CoreArrayWrapper for DataVariable {
-    type Wrapped<'a> = &'a DataVariable;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
         mem::transmute(raw)
     }

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -2094,17 +2094,13 @@ impl StructureMember {
 impl CoreArrayProvider for StructureMember {
     type Raw = BNStructureMember;
     type Context = ();
+    type Wrapped<'a> = Guard<'a, StructureMember>;
 }
 
-unsafe impl CoreOwnedArrayProvider for StructureMember {
+unsafe impl CoreArrayProviderInner for StructureMember {
     unsafe fn free(raw: *mut Self::Raw, count: usize, _context: &Self::Context) {
         BNFreeStructureMemberList(raw, count)
     }
-}
-
-unsafe impl CoreArrayWrapper for StructureMember {
-    type Wrapped<'a> = Guard<'a, StructureMember>;
-
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
         Guard::new(StructureMember::from_raw(*raw), &())
     }


### PR DESCRIPTION
This merge and re-split the ArrayProvider traits into `CoreArrayProvider` and `CoreArrayProviderInner`, with only the first being public.