### PR TITLE
fix github workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          submodules: true
 
       - name: Install Clang
         run: |


### PR DESCRIPTION
pdb-ng fails because it's unable to build without its sub-modules.