### PR TITLE
Remove loader.architecture override handling in views

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -417,7 +417,7 @@ def load(*args, **kwargs) -> BinaryView:
 		...
 		134
 
-		>>> with load(bytes.fromhex('5054ebfe'), options={'loader.architecture' : 'x86'}) as bv:
+		>>> with load(bytes.fromhex('5054ebfe'), options={'loader.platform' : 'x86'}) as bv:
 		...     print(len(list(bv.functions)))
 		...
 		1

--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -1458,7 +1458,7 @@ class Segment:
 		>>> rom_base = 0xffff0000
 		>>> segments = Segment.serialize(image_base=base, start=base, length=0x1000, data_offset=0, data_length=0x1000, flags=SegmentFlag.SegmentReadable|SegmentFlag.SegmentExecutable)
 		>>> segments = Segment.serialize(image_base=base, start=rom_base, length=0x1000, flags=SegmentFlag.SegmentReadable, segments=segments)
-		>>> view = load(bytes.fromhex('5054ebfe'), options={'loader.imageBase': base, 'loader.architecture': 'x86', 'loader.segments': segments})
+		>>> view = load(bytes.fromhex('5054ebfe'), options={'loader.imageBase': base, 'loader.platform': 'x86', 'loader.segments': segments})
 		```
 		"""
 		segments_list = json.loads(segments)

--- a/python/examples/mappedview.py
+++ b/python/examples/mappedview.py
@@ -26,6 +26,7 @@
 from binaryninja.log import log_error
 from binaryninja import _binaryninjacore as core
 from binaryninja.architecture import Architecture
+from binaryninja.platform import Platform
 from binaryninja.binaryview import BinaryView
 from binaryninja.binaryview import BinaryViewType
 from binaryninja.enums import SegmentFlag
@@ -53,7 +54,7 @@ class MappedView(BinaryView):
 	def get_load_settings_for_data(cls, data):
 		# This method is optional. If provided this is where the Load Settings for a BinaryViewType are specified. Binary Ninja provides
 		# some default read-only load settings which are:
-		#		["loader.architecture", "loader.platform", "loader.entryPointOffset", "loader.imageBase", "loader.segments", "loader.sections"]
+		#		["loader.platform", "loader.entryPointOffset", "loader.imageBase", "loader.segments", "loader.sections"]
 		# The default load settings are provided for consistency and convenience.
 		# The default load settings are always generated with a read-only indication which is respected by the UI.
 		# The read-only indication is a property that consists of a JSON name/value pair ("readOnly" : true).
@@ -75,7 +76,7 @@ class MappedView(BinaryView):
 			load_settings = registered_view.get_default_load_settings_for_data(view)
 
 			# Specify default load settings that can be overridden (from the UI).
-			overrides = ["loader.architecture", "loader.platform", "loader.entryPointOffset", "loader.imageBase", "loader.segments", "loader.sections"]
+			overrides = ["loader.platform", "loader.entryPointOffset", "loader.imageBase", "loader.segments", "loader.sections"]
 			for override in overrides:
 				if load_settings.contains(override):
 					load_settings.update_property(override, json.dumps({'readOnly': False}))
@@ -127,9 +128,9 @@ class MappedView(BinaryView):
 					# This allows us to generate default load options for the BinaryView. This step is not required but can be useful.
 					load_settings = self.__class__.get_load_settings_for_data(self.parent_view)
 
-			arch = load_settings.get_string("loader.architecture", self)
-			self.arch = Architecture[arch]  # type: ignore
-			self.platform = Architecture[arch].standalone_platform  # type: ignore
+			platform = load_settings.get_string("loader.platform", self)
+			self.platform = Platform[platform]
+			self.arch = self.platform.arch  # type: ignore
 			self.load_address = load_settings.get_integer("loader.imageBase", self)
 			self.add_auto_segment(
 			  self.load_address, len(self.parent_view), 0, len(self.parent_view),

--- a/view/pe/teview.cpp
+++ b/view/pe/teview.cpp
@@ -214,6 +214,9 @@ bool TEView::Init()
 		ReadTEImageHeader(reader, header);
 		ReadTEImageSectionHeaders(reader, header.numberOfSections);
 		m_headersOffset = header.strippedSize - EFI_TE_IMAGE_HEADER_SIZE;
+
+		// m_imageBase represents the base of the original PE image (before headers were stripped), not the base of the
+		// TE image (bv.start)
 		m_imageBase = header.imageBase;
 
 		// Set architecture and platform
@@ -223,8 +226,7 @@ bool TEView::Init()
 			if (settings->Contains("loader.imageBase"))
 			{
 				uint64_t baseOverride = settings->Get<uint64_t>("loader.imageBase", this);
-				// TE image bases represent the base of the original PE (before headers are stripped) - make this
-				// adjustment for the user
+				// Apply the headers offset adjustment to compute the base of the original PE image
 				m_imageBase = baseOverride - m_headersOffset;
 			}
 

--- a/view/pe/teview.cpp
+++ b/view/pe/teview.cpp
@@ -202,19 +202,6 @@ TEView::TEView(BinaryView* bv, bool parseOnly) : BinaryView("TE", bv->GetFile(),
 	m_backedByDatabase = bv->GetFile()->IsBackedByDatabase("TE");
 }
 
-void TEView::HandleUserOverrides()
-{
-	auto settings = GetLoadSettings(GetTypeName());
-	if (!settings)
-		return;
-
-	if (settings->Contains("loader.imageBase"))
-		m_imageBase = settings->Get<uint64_t>("loader.imageBase", this);
-
-	if (settings->Contains("loader.architecture"))
-		m_arch = Architecture::GetByName(settings->Get<string>("loader.architecture", this));
-}
-
 bool TEView::Init()
 {
 	BinaryReader reader(GetParentView(), LittleEndian);
@@ -227,27 +214,26 @@ bool TEView::Init()
 		ReadTEImageHeader(reader, header);
 		ReadTEImageSectionHeaders(reader, header.numberOfSections);
 		m_headersOffset = header.strippedSize - EFI_TE_IMAGE_HEADER_SIZE;
+		m_imageBase = header.imageBase;
 
 		// Set architecture and platform
-		HandleUserOverrides();
-		if (m_arch)
+		auto settings = GetLoadSettings(GetTypeName());
+		if (settings)
 		{
-			auto archName = m_arch->GetName();
-			if (archName == "x86")
-				platform = Platform::GetByName("efi-x86");
-			if (archName == "x86_64")
-				platform = Platform::GetByName("efi-x86_64");
-			if (archName == "aarch64")
-				platform = Platform::GetByName("efi-aarch64");
-			if (!platform)
+			if (settings->Contains("loader.imageBase"))
 			{
-				m_logger->LogError("TE architecture '%s' is not supported", archName.c_str());
-				return false;
+				uint64_t baseOverride = settings->Get<uint64_t>("loader.imageBase", this);
+				// TE image bases represent the base of the original PE (before headers are stripped) - make this
+				// adjustment for the user
+				m_imageBase = baseOverride - m_headersOffset;
 			}
+
+			if (settings->Contains("loader.platform"))
+				platform = Platform::GetByName(settings->Get<string>("loader.platform", this));
 		}
-		else
+
+		if (!platform)
 		{
-			m_imageBase = header.imageBase;
 			switch (header.machine)
 			{
 			case IMAGE_FILE_MACHINE_I386:
@@ -259,21 +245,19 @@ bool TEView::Init()
 			case IMAGE_FILE_MACHINE_ARM64:
 				platform = Platform::GetByName("efi-aarch64");
 				break;
+			case IMAGE_FILE_MACHINE_ARM:
+				platform = Platform::GetByName("efi-armv7");
+				break;
+			case IMAGE_FILE_MACHINE_THUMB:
+				platform = Platform::GetByName("efi-thumb2");
+				break;
 			default:
-				LogError("TE architecture '0x%x' is not supported", header.machine);
+				LogError("TE platform '0x%x' is not supported", header.machine);
 				return false;
 			}
-
-			if (!platform)
-			{
-				// Should never occur as long as the platforms exist
-				m_logger->LogError("Failed to set platform for TE file");
-				return false;
-			}
-
-			m_arch = platform->GetArchitecture();
 		}
 
+		m_arch = platform->GetArchitecture();
 		SetDefaultPlatform(platform);
 		SetDefaultArchitecture(m_arch);
 
@@ -382,7 +366,7 @@ Ref<Settings> TEViewType::GetLoadSettingsForData(BinaryView *bv)
 
 	// specify default load settings that can be overridden
 	Ref<Settings> settings = GetDefaultLoadSettingsForData(viewRef);
-	vector<string> overrides = {"loader.architecture", "loader.imageBase"};
+	vector<string> overrides = {"loader.platform", "loader.imageBase"};
 	for (const auto& override : overrides)
 	{
 		if (settings->Contains(override))

--- a/view/pe/teview.h
+++ b/view/pe/teview.h
@@ -77,7 +77,6 @@ namespace BinaryNinja
 	private:
 		void ReadTEImageHeader(BinaryReader& reader, struct TEImageHeader& imageHeader);
 		void ReadTEImageSectionHeaders(BinaryReader& reader, uint32_t numSections);
-		void HandleUserOverrides();
 		void CreateSections();
 		void AssignHeaderTypes();
 	};


### PR DESCRIPTION
Fix for https://github.com/Vector35/binaryninja-api/issues/5362#event-12730665835

It's important to understand that this PR still allows for backwards compatibility and doesn't prevent the use of `loader.architecture` for overriding the architecture. `loader.architecture` has been deprecated for `loader.platform`, so if they use `loader.architecture`, it gets reset to `loader.platform` (which is an override that's handled by all the views). 

Example of the new behavior (if they use the deprecated `loader.architecture` setting):

```
>>> bv = load("test.exe", options={"loader.architecture" : "armv7"})
[0:6451428262981885673 Settings warn] Setting 'loader.architecture' deprecated by 'loader.platform'.
>>> bv.arch
<arch: armv7>
>>> bv.platform
<platform: armv7>
```

How we want users to do it from now on:

```
>>> bv = load("test.exe", options={"loader.platform" : "efi-x86"})
>>> bv.arch
<arch: x86>
>>> bv.platform
<platform: efi-x86>
```