### PR TITLE
Rust: change signatures of `define_{auto,user}_data_var`

### DIFF
--- a/rust/src/binaryview.rs
+++ b/rust/src/binaryview.rs
@@ -49,7 +49,9 @@ use crate::segment::{Segment, SegmentBuilder};
 use crate::settings::Settings;
 use crate::symbol::{Symbol, SymbolType};
 use crate::tags::{Tag, TagType};
-use crate::types::{DataVariable, NamedTypeReference, QualifiedName, QualifiedNameAndType, Type};
+use crate::types::{
+    Conf, DataVariable, NamedTypeReference, QualifiedName, QualifiedNameAndType, Type,
+};
 use crate::Endianness;
 
 use crate::rc::*;
@@ -574,24 +576,16 @@ pub trait BinaryViewExt: BinaryViewBase {
         }
     }
 
-    fn define_auto_data_var(&self, dv: &DataVariable) {
+    fn define_auto_data_var<'a, T: Into<Conf<&'a Type>>>(&self, addr: u64, ty: T) {
         unsafe {
-            BNDefineDataVariable(
-                self.as_ref().handle,
-                dv.address(),
-                &mut dv.type_with_confidence().into(),
-            );
+            BNDefineDataVariable(self.as_ref().handle, addr, &mut ty.into().into());
         }
     }
 
     /// You likely would also like to call [`Self::define_user_symbol`] to bind this data variable with a name
-    fn define_user_data_var(&self, dv: &DataVariable) {
+    fn define_user_data_var<'a, T: Into<Conf<&'a Type>>>(&self, addr: u64, ty: T) {
         unsafe {
-            BNDefineUserDataVariable(
-                self.as_ref().handle,
-                dv.address(),
-                &mut dv.type_with_confidence().into(),
-            );
+            BNDefineUserDataVariable(self.as_ref().handle, addr, &mut ty.into().into());
         }
     }
 


### PR DESCRIPTION
Since `DataVariable` had its fields made private, it is no longer constructible. Therefore, these methods should change signature such that it is actually possible to use them. I feel like the new API is also more intuitive to use as well.