### PR TITLE
Allow Rust CoreAPI FFI to implement Default

### DIFF
--- a/rust/binaryninjacore-sys/build.rs
+++ b/rust/binaryninjacore-sys/build.rs
@@ -96,6 +96,7 @@ fn main() {
         .clang_arg("c++")
         .size_t_is_usize(true)
         .generate_comments(false)
+        .derive_default(true)
         .allowlist_function("BN.*")
         .allowlist_var("BN_CURRENT_CORE_ABI_VERSION")
         .allowlist_var("BN_MINIMUM_CORE_ABI_VERSION")


### PR DESCRIPTION
This allow writing simpler and cleaner code when initializing FFI types, avoiding the need of `core::mem::zeroed()`.

It's specially useful to partially initialize structs:
```rust
BNHighlightColor {
  style: BNHighlightColorStyle::StandardHighlightColor,
  color: BNHighlightStandardColor::NoHighlightColor,
  alpha,
  ..Default::default()
}
```