### PR TITLE
Rust: Allow running doctests and unit tests

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,10 @@ jobs:
         working-directory: ./rust
         run: cargo test --doc -- --show-output
 
+      - name: cargo unit test
+        working-directory: ./rust
+        run: cargo test --no-run
+
       - name: cargo clippy
         working-directory: ./rust
         run: cargo clippy -- -D warnings

--- a/rust/binaryninjacore-sys/build.rs
+++ b/rust/binaryninjacore-sys/build.rs
@@ -44,7 +44,7 @@ fn link_path() -> PathBuf {
 }
 
 fn main() {
-    println!("cargo:rerun-if-changed=../../binaryninjacore.h");
+    println!("cargo::rerun-if-changed=../../binaryninjacore.h");
 
     //Cargo's output directory
     let out_dir = env::var("OUT_DIR").unwrap();
@@ -69,11 +69,11 @@ fn main() {
             )
             .expect("failed to create required symlink");
         }
-        println!("cargo:rustc-link-search={}", out_dir);
+        println!("cargo::rustc-link-search={}", out_dir);
     }
 
-    println!("cargo:rustc-link-lib=binaryninjacore");
-    println!("cargo:rustc-link-search={}", link_path.to_str().unwrap());
+    println!("cargo::rustc-link-lib=binaryninjacore");
+    println!("cargo::rustc-link-search={}", link_path.to_str().unwrap());
 
     let current_line = "#define BN_CURRENT_UI_ABI_VERSION ";
     let minimum_line = "#define BN_MINIMUM_UI_ABI_VERSION ";

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -1,3 +1,45 @@
+use std::env;
+use std::fs::File;
+use std::io::BufReader;
+use std::path::PathBuf;
+
+#[cfg(target_os = "macos")]
+static LASTRUN_PATH: (&str, &str) = ("HOME", "Library/Application Support/Binary Ninja/lastrun");
+
+#[cfg(target_os = "linux")]
+static LASTRUN_PATH: (&str, &str) = ("HOME", ".binaryninja/lastrun");
+
+#[cfg(windows)]
+static LASTRUN_PATH: (&str, &str) = ("APPDATA", "Binary Ninja\\lastrun");
+
+// Check last run location for path to BinaryNinja; Otherwise check the default install locations
+fn link_path() -> PathBuf {
+    use std::io::prelude::*;
+
+    let home = PathBuf::from(env::var(LASTRUN_PATH.0).unwrap());
+    let lastrun = PathBuf::from(&home).join(LASTRUN_PATH.1);
+
+    File::open(lastrun)
+        .and_then(|f| {
+            let mut binja_path = String::new();
+            let mut reader = BufReader::new(f);
+
+            reader.read_line(&mut binja_path)?;
+            Ok(PathBuf::from(binja_path.trim()))
+        })
+        .unwrap_or_else(|_| {
+            #[cfg(target_os = "macos")]
+            return PathBuf::from("/Applications/Binary Ninja.app/Contents/MacOS");
+
+            #[cfg(target_os = "linux")]
+            return home.join("binaryninja");
+
+            #[cfg(windows)]
+            return PathBuf::from(env::var("PROGRAMFILES").unwrap())
+                .join("Vector35\\BinaryNinja\\");
+        })
+}
+
 fn main() {
     // TODO : Enable the following when https://github.com/rust-lang/rust/issues/43781 stabilizes
     // #[cfg(doc)]
@@ -9,4 +51,31 @@ fn main() {
         "target/doc/under_construction.png",
     );
     let _ = std::fs::copy("../docs/img/logo.png", "target/doc/logo.png");
+
+    let install_path = env::var("BINARYNINJADIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| link_path());
+
+    #[cfg(target_os = "linux")]
+    println!(
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
+        install_path.to_str().unwrap(),
+        install_path.to_str().unwrap(),
+    );
+
+    #[cfg(target_os = "macos")]
+    println!(
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
+        install_path.to_str().unwrap(),
+        install_path.to_str().unwrap(),
+    );
+
+    #[cfg(target_os = "windows")]
+    {
+        println!("cargo::rustc-link-lib=binaryninjacore");
+        println!(
+            "cargo::rustc-link-search={}",
+            install_path.to_str().unwrap()
+        );
+    }
 }

--- a/rust/examples/basic_script/build.rs
+++ b/rust/examples/basic_script/build.rs
@@ -48,21 +48,24 @@ fn main() {
 
     #[cfg(target_os = "linux")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "macos")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "windows")]
     {
-        println!("cargo:rustc-link-lib=binaryninjacore");
-        println!("cargo:rustc-link-search={}", install_path.to_str().unwrap());
+        println!("cargo::rustc-link-lib=binaryninjacore");
+        println!(
+            "cargo::rustc-link-search={}",
+            install_path.to_str().unwrap()
+        );
     }
 }

--- a/rust/examples/decompile/build.rs
+++ b/rust/examples/decompile/build.rs
@@ -48,21 +48,24 @@ fn main() {
 
     #[cfg(target_os = "linux")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "macos")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "windows")]
     {
-        println!("cargo:rustc-link-lib=binaryninjacore");
-        println!("cargo:rustc-link-search={}", install_path.to_str().unwrap());
+        println!("cargo::rustc-link-lib=binaryninjacore");
+        println!(
+            "cargo::rustc-link-search={}",
+            install_path.to_str().unwrap()
+        );
     }
 }

--- a/rust/examples/dwarf/dwarf_export/build.rs
+++ b/rust/examples/dwarf/dwarf_export/build.rs
@@ -48,21 +48,24 @@ fn main() {
 
     #[cfg(target_os = "linux")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "macos")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "windows")]
     {
-        println!("cargo:rustc-link-lib=binaryninjacore");
-        println!("cargo:rustc-link-search={}", install_path.to_str().unwrap());
+        println!("cargo::rustc-link-lib=binaryninjacore");
+        println!(
+            "cargo::rustc-link-search={}",
+            install_path.to_str().unwrap()
+        );
     }
 }

--- a/rust/examples/hlil_lifter/build.rs
+++ b/rust/examples/hlil_lifter/build.rs
@@ -48,21 +48,24 @@ fn main() {
 
     #[cfg(target_os = "linux")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "macos")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "windows")]
     {
-        println!("cargo:rustc-link-lib=binaryninjacore");
-        println!("cargo:rustc-link-search={}", install_path.to_str().unwrap());
+        println!("cargo::rustc-link-lib=binaryninjacore");
+        println!(
+            "cargo::rustc-link-search={}",
+            install_path.to_str().unwrap()
+        );
     }
 }

--- a/rust/examples/hlil_visitor/build.rs
+++ b/rust/examples/hlil_visitor/build.rs
@@ -48,21 +48,24 @@ fn main() {
 
     #[cfg(target_os = "linux")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "macos")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "windows")]
     {
-        println!("cargo:rustc-link-lib=binaryninjacore");
-        println!("cargo:rustc-link-search={}", install_path.to_str().unwrap());
+        println!("cargo::rustc-link-lib=binaryninjacore");
+        println!(
+            "cargo::rustc-link-search={}",
+            install_path.to_str().unwrap()
+        );
     }
 }

--- a/rust/examples/minidump/build.rs
+++ b/rust/examples/minidump/build.rs
@@ -48,21 +48,24 @@ fn main() {
 
     #[cfg(target_os = "linux")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "macos")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "windows")]
     {
-        println!("cargo:rustc-link-lib=binaryninjacore");
-        println!("cargo:rustc-link-search={}", install_path.to_str().unwrap());
+        println!("cargo::rustc-link-lib=binaryninjacore");
+        println!(
+            "cargo::rustc-link-search={}",
+            install_path.to_str().unwrap()
+        );
     }
 }

--- a/rust/examples/mlil_lifter/build.rs
+++ b/rust/examples/mlil_lifter/build.rs
@@ -48,21 +48,24 @@ fn main() {
 
     #[cfg(target_os = "linux")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "macos")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "windows")]
     {
-        println!("cargo:rustc-link-lib=binaryninjacore");
-        println!("cargo:rustc-link-search={}", install_path.to_str().unwrap());
+        println!("cargo::rustc-link-lib=binaryninjacore");
+        println!(
+            "cargo::rustc-link-search={}",
+            install_path.to_str().unwrap()
+        );
     }
 }

--- a/rust/examples/mlil_visitor/build.rs
+++ b/rust/examples/mlil_visitor/build.rs
@@ -48,21 +48,24 @@ fn main() {
 
     #[cfg(target_os = "linux")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "macos")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "windows")]
     {
-        println!("cargo:rustc-link-lib=binaryninjacore");
-        println!("cargo:rustc-link-search={}", install_path.to_str().unwrap());
+        println!("cargo::rustc-link-lib=binaryninjacore");
+        println!(
+            "cargo::rustc-link-search={}",
+            install_path.to_str().unwrap()
+        );
     }
 }

--- a/rust/examples/template/build.rs
+++ b/rust/examples/template/build.rs
@@ -48,21 +48,24 @@ fn main() {
 
     #[cfg(target_os = "linux")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-l:libbinaryninjacore.so.1",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "macos")]
     println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
+        "cargo::rustc-link-arg=-Wl,-rpath,{},-L{},-lbinaryninjacore",
         install_path.to_str().unwrap(),
         install_path.to_str().unwrap(),
     );
 
     #[cfg(target_os = "windows")]
     {
-        println!("cargo:rustc-link-lib=binaryninjacore");
-        println!("cargo:rustc-link-search={}", install_path.to_str().unwrap());
+        println!("cargo::rustc-link-lib=binaryninjacore");
+        println!(
+            "cargo::rustc-link-search={}",
+            install_path.to_str().unwrap()
+        );
     }
 }


### PR DESCRIPTION
Adding the `cargo::rustc-link-arg` option to the build.rs file of the `binaryninja` crate allows doctests and unit tests to be linked against `binaryninjacore.so.1` and ran when invoking `cargo test`.

Also, the single-colon `cargo:` syntax is deprecated as of Rust 1.77, and future features will all use the `cargo::` syntax. Since the MSRV is already Rust 1.77, it's fine to switch for consistency's sake going forward.