### PR TITLE
python/architecture: return instance from `Architecture.register()`

### DIFF
--- a/python/architecture.py
+++ b/python/architecture.py
@@ -523,13 +523,14 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 		return self.name
 
 	@classmethod
-	def register(cls) -> None:
+	def register(cls) -> 'Architecture':
 		binaryninja._init_plugins()
 		if cls.name is None:
 			raise ValueError("architecture 'name' is not defined")
 		arch = cls()
 		cls._registered_cb = arch._cb
 		arch.handle = core.BNRegisterArchitecture(cls.name, arch._cb)
+		return arch
 
 	@property
 	def full_width_regs(self) -> List[RegisterName]:


### PR DESCRIPTION
Turns this:

```python
Avnera.register()
arch = Architecture['avnera']
arch.register_calling_convention(AvneraCCallingConvention(arch, 'default'))
```

Into this:

```python
arch = Avnera.register()
arch.register_calling_convention(AvneraCCallingConvention(arch, 'default'))
```