### PR TITLE
arm64: lift sxtl, sxtl2, sshll, sshll2

### DIFF
--- a/arch/arm64/arm64test.py
+++ b/arch/arm64/arm64test.py
@@ -15,6 +15,21 @@ path_il_h = os.path.join(path_here, 'il.h')
 
 ATTR_PTR_AUTH = ILInstructionAttribute(8) # enum BNILInstructionAttribute.SrcInstructionUsesPointerAuth from api/binaryninjacore.h
 
+tests_sshll = [
+    # sshll v0.2d, v0.2s, #0xf
+    (b'\x00\xa4\x2f\x0f', 'LLIL_SET_REG.q(v0.d[0],LLIL_SX.q(LLIL_LSL.q(LLIL_LSR.d(LLIL_REG.d(v0.s[0]),LLIL_CONST.b(0x0)),LLIL_CONST.b(0xF))));' + \
+     ' LLIL_SET_REG.q(v0.d[1],LLIL_SX.q(LLIL_LSL.q(LLIL_LSR.d(LLIL_REG.d(v0.s[1]),LLIL_CONST.b(0x0)),LLIL_CONST.b(0xF))))'),
+    # sxtl v0.2d, v0.2s
+    (b'\x00\xa4\x20\x0f', 'LLIL_SET_REG.q(v0.d[0],LLIL_SX.q(LLIL_LSL.q(LLIL_LSR.d(LLIL_REG.d(v0.s[0]),LLIL_CONST.b(0x0)),LLIL_CONST.b(0x0))));' + \
+     ' LLIL_SET_REG.q(v0.d[1],LLIL_SX.q(LLIL_LSL.q(LLIL_LSR.d(LLIL_REG.d(v0.s[1]),LLIL_CONST.b(0x0)),LLIL_CONST.b(0x0))))'),
+    # sshll2 v0.2d, v0.4s, #0xf
+    (b'\x00\xa4\x2f\x4f', 'LLIL_SET_REG.q(v0.d[0],LLIL_SX.q(LLIL_LSL.q(LLIL_LSR.d(LLIL_REG.d(v0.s[0]),LLIL_CONST.b(0x40)),LLIL_CONST.b(0xF))));' + \
+     ' LLIL_SET_REG.q(v0.d[1],LLIL_SX.q(LLIL_LSL.q(LLIL_LSR.d(LLIL_REG.d(v0.s[1]),LLIL_CONST.b(0x40)),LLIL_CONST.b(0xF))))'),
+    # sxtl2 v0.2d, v0.2s
+    (b'\x00\xa4\x20\x4f', 'LLIL_SET_REG.q(v0.d[0],LLIL_SX.q(LLIL_LSL.q(LLIL_LSR.d(LLIL_REG.d(v0.s[0]),LLIL_CONST.b(0x40)),LLIL_CONST.b(0x0))));' + \
+     ' LLIL_SET_REG.q(v0.d[1],LLIL_SX.q(LLIL_LSL.q(LLIL_LSR.d(LLIL_REG.d(v0.s[1]),LLIL_CONST.b(0x40)),LLIL_CONST.b(0x0))))'),
+]
+
 tests_udf = [
     # udf #0
     (b'\x00\x00\x00\x00', 'LLIL_TRAP(0)'),
@@ -2232,44 +2247,7 @@ tests_st1 = [
                          ' LLIL_SET_REG.q(x29,LLIL_ADD.q(LLIL_REG.q(x29),LLIL_REG.q(x21)))'),
 ]
 
-test_cases = \
-    tests_udf + \
-    tests_pac + \
-    tests_load_acquire_store_release + \
-    tests_movk + \
-    tests_mvni + \
-    tests_2791 + \
-    tests_ucvtf + \
-    tests_ucvtf2 + \
-    tests_scvtf + \
-    tests_ret + \
-    tests_svc_hvc_smc + \
-    tests_clrex + \
-    tests_xtn_xtn2 + \
-    tests_dc + \
-    tests_uxtl_uxtl2 + \
-    tests_ldadd + \
-    tests_swp + \
-    tests_dup + \
-    tests_stlr + \
-    tests_ldnp + \
-    tests_stnp + \
-    tests_mov + \
-    tests_movi + \
-    tests_fsub + \
-    tests_fadd + \
-    tests_fmul + \
-    tests_fcvt + \
-    tests_fccmp_fccmpe + \
-    tests_fcmp_fcmpe + \
-    tests_fcsel + \
-    tests_fmov + \
-    tests_sha + \
-    tests_rev + \
-    tests_ld1 + \
-    tests_ld2 + \
-    tests_st1 + \
-    [
+tests_grab_bag = [
     # some vectors loads/stores that do not fill the entire register
     # TODO: ld1/st1 with different addressing modes
     # ld1 {v0.8b, v1.8b}, [x0]
@@ -2849,6 +2827,46 @@ test_cases = \
                          ' LLIL_GOTO(8)'), # ccmp w8, #30, #8, mi
     (b'\x1F\x20\x03\xD5', 'LLIL_NOP()'), # nop, gets optimized from function
 ]
+
+test_cases = \
+    tests_sshll + \
+    tests_udf + \
+    tests_pac + \
+    tests_load_acquire_store_release + \
+    tests_movk + \
+    tests_mvni + \
+    tests_2791 + \
+    tests_ucvtf + \
+    tests_ucvtf2 + \
+    tests_scvtf + \
+    tests_ret + \
+    tests_svc_hvc_smc + \
+    tests_clrex + \
+    tests_xtn_xtn2 + \
+    tests_dc + \
+    tests_uxtl_uxtl2 + \
+    tests_ldadd + \
+    tests_swp + \
+    tests_dup + \
+    tests_stlr + \
+    tests_ldnp + \
+    tests_stnp + \
+    tests_mov + \
+    tests_movi + \
+    tests_fsub + \
+    tests_fadd + \
+    tests_fmul + \
+    tests_fcvt + \
+    tests_fccmp_fccmpe + \
+    tests_fcmp_fcmpe + \
+    tests_fcsel + \
+    tests_fmov + \
+    tests_sha + \
+    tests_rev + \
+    tests_ld1 + \
+    tests_ld2 + \
+    tests_st1 + \
+    tests_grab_bag
 
 def il2str(il):
     sz_lookup = {1:'.b', 2:'.w', 4:'.d', 8:'.q', 16:'.o'}

--- a/arch/arm64/il.cpp
+++ b/arch/arm64/il.cpp
@@ -2217,6 +2217,41 @@ bool GetLowLevelILForInstruction(
 
 		break;
 	}
+	case ARM64_SXTL:
+	case ARM64_SXTL2:
+	case ARM64_SSHLL:
+	case ARM64_SSHLL2:
+	{
+		Register srcs[16], dsts[16];
+		int dst_n = unpack_vector(operand1, dsts);
+		int src_n = unpack_vector(operand2, srcs);
+
+		// We cannot check that the src and dst counts are the same here
+		// because the 2 variants use different count arrange specs, e.g.
+		// sxtl2 v0.2d, v1.4s
+
+		int left_shift = 0;
+		if (instr.operation == ARM64_SSHLL || instr.operation == ARM64_SSHLL2)
+			left_shift = IMM_O(operand3);
+
+		int two_variant_shift = 0;
+		if (instr.operation == ARM64_SXTL2 || instr.operation == ARM64_SSHLL2)
+			two_variant_shift = 64;
+
+		int dst_size = get_register_size(dsts[0]);
+		int src_size = get_register_size(srcs[0]);
+
+		for (int i = 0; i < dst_n; ++i)
+			il.AddInstruction(il.SetRegister(dst_size, dsts[i],
+				il.SignExtend(dst_size,
+					il.ShiftLeft(dst_size,
+						il.LogicalShiftRight(src_size,
+							il.Register(src_size, srcs[i]),
+							il.Const(1, two_variant_shift)),
+						il.Const(1, left_shift)))));
+
+		break;
+	}
 	case ARM64_ST1:
 		LoadStoreVector(il, false, instr.operands[0], instr.operands[1]);
 		break;


### PR DESCRIPTION
Partially fixes #5417

Also superficial re-ordering of the tests to make it easier to add new tests.

With both PRs targeting #5417 we get this LLIL:
```
  41 @ 100003ea0  s1 = [x29 - 8 {var_18}].d
  42 @ 100003ea4  s0 = s1
  43 @ 100003ea8  v0.d[0] = sx.q(v0.s[0] u>> 0 << 0)
  44 @ 100003ea8  v0.d[1] = sx.q(v0.s[1] u>> 0 << 0)
  45 @ 100003eac  d1 = int.q(d0)
  46 @ 100003eb0  d0 = 10.0
  47 @ 100003eb4  d0 = d0 f+ d1
  48 @ 100003eb8  s0 = fconvert.s(d0)
  49 @ 100003ebc  x8 = sx.q([x29 - 8 {var_18}].d)
  50 @ 100003ec0  x9 = 0x2c
  51 @ 100003ec4  x9 = x8 * x9
  52 @ 100003ec8  x8 = &main::x
  53 @ 100003ecc  x8 = x8
  54 @ 100003ed0  x8 = x8 + x9
  55 @ 100003ed4  [x8 + 0x28].d = s0
  56 @ 100003ed8  [x29 - 0xc {var_1c_1}].d = 0
  57 @ 100003edc  goto 58 @ 0x100003ee0
```

and this HLIL:
```
  10 @ 100003ea0  int64_t v1
  11 @ 100003ea0  v1.d = var_18
  12 @ 100003ea4  v0.d = v1.d
  13 @ 100003eb8  v0.d = fconvert.s(10.0 f+ int.q((v0.d u>> 0 << 0):4.d u>> 0 << 0))
  14 @ 100003ed4  *(sx.q(var_18) * 0x2c + 0x100008028) = v0.d
  15 @ 100003ed8  int32_t var_1c_1 = 0
```

Finally, it looks like there are some other unlifted SHL variants that would probably follow the same template. Let me know if you've come across any of these and I can take a look.