### PR TITLE
Include CoreAPI documentation into the generate rust bindings

### DIFF
--- a/rust/binaryninjacore-sys/build.rs
+++ b/rust/binaryninjacore-sys/build.rs
@@ -97,6 +97,8 @@ fn main() {
         .size_t_is_usize(true)
         .generate_comments(false)
         .derive_default(true)
+        .generate_comments(true)
+        .clang_arg("-fparse-all-comments")
         .allowlist_function("BN.*")
         .allowlist_var("BN_CURRENT_CORE_ABI_VERSION")
         .allowlist_var("BN_MINIMUM_CORE_ABI_VERSION")


### PR DESCRIPTION
This will add documentation from the core API into the documentation generated by running `cargo doc`