### PR TITLE
Fixed type propagation issue in AARCH64 and MIPS

### DIFF
--- a/arch/arm64/arch_arm64.cpp
+++ b/arch/arm64/arch_arm64.cpp
@@ -2448,10 +2448,22 @@ class Arm64ImportedFunctionRecognizer : public FunctionRecognizer
 		if (jumpOperand.GetSourceRegister<LLIL_REG>() != targetReg)
 			return false;
 
-		Ref<Symbol> funcSym = Symbol::ImportedFunctionFromImportAddressSymbol(sym, func->GetStart());
+		Ref<Symbol> funcSym = Symbol::ImportedFunctionFromImportAddressSymbol(sym, func->GetStart()); // func is plt function
 		data->DefineAutoSymbol(funcSym);
-		func->ApplyImportedTypes(funcSym);
-		return true;
+		for (auto& extSym : data->GetSymbolsByName(funcSym->GetRawName()))
+		{
+			if (extSym->GetType() == ExternalSymbol)
+			{
+				DataVariable var;
+				if (data->GetDataVariableAtAddress(extSym->GetAddress(), var))
+				{
+					func->ApplyImportedTypes(funcSym, var.type);
+				}
+
+				return true;
+			}
+		}
+		return false;
 	}
 
 

--- a/arch/arm64/arch_arm64.cpp
+++ b/arch/arm64/arch_arm64.cpp
@@ -2448,20 +2448,17 @@ class Arm64ImportedFunctionRecognizer : public FunctionRecognizer
 		if (jumpOperand.GetSourceRegister<LLIL_REG>() != targetReg)
 			return false;
 
-		Ref<Symbol> funcSym = Symbol::ImportedFunctionFromImportAddressSymbol(sym, func->GetStart()); // func is plt function
+		Ref<Symbol> funcSym = Symbol::ImportedFunctionFromImportAddressSymbol(sym, func->GetStart());
 		data->DefineAutoSymbol(funcSym);
-		for (auto& extSym : data->GetSymbolsByName(funcSym->GetRawName()))
-		{
-			if (extSym->GetType() == ExternalSymbol)
-			{
-				DataVariable var;
-				if (data->GetDataVariableAtAddress(extSym->GetAddress(), var))
-				{
-					func->ApplyImportedTypes(funcSym, var.type);
-				}
 
-				return true;
+		auto extSym = data->GetSymbolsByName(funcSym->GetRawName(), data->GetExternalNameSpace());
+		if (!extSym.empty()) {
+			DataVariable var;
+			if (data->GetDataVariableAtAddress(extSym.front()->GetAddress(), var))
+			{
+				func->ApplyImportedTypes(funcSym, var.type);
 			}
+			return true;
 		}
 		return false;
 	}

--- a/arch/mips/arch_mips.cpp
+++ b/arch/mips/arch_mips.cpp
@@ -1747,8 +1747,20 @@ private:
 
 		Ref<Symbol> funcSym = Symbol::ImportedFunctionFromImportAddressSymbol(sym, func->GetStart());
 		data->DefineAutoSymbol(funcSym);
-		func->ApplyImportedTypes(funcSym);
-		return true;
+		for (auto& extSym : data->GetSymbolsByName(funcSym->GetRawName()))
+		{
+			if (extSym->GetType() == ExternalSymbol)
+			{
+				DataVariable var;
+				if (data->GetDataVariableAtAddress(extSym->GetAddress(), var))
+				{
+					func->ApplyImportedTypes(funcSym, var.type);
+				}
+
+				return true;
+			}
+		}
+		return false;
 	}
 
 
@@ -1939,7 +1951,19 @@ private:
 
 		Ref<Symbol> funcSym = Symbol::ImportedFunctionFromImportAddressSymbol(sym, func->GetStart());
 		data->DefineAutoSymbol(funcSym);
-		func->ApplyImportedTypes(funcSym);
+		for (auto& extSym : data->GetSymbolsByName(funcSym->GetRawName()))
+		{
+			if (extSym->GetType() == ExternalSymbol)
+			{
+				DataVariable var;
+				if (data->GetDataVariableAtAddress(extSym->GetAddress(), var))
+				{
+					func->ApplyImportedTypes(funcSym, var.type);
+				}
+
+				return true;
+			}
+		}
 		return true;
 	}
 

--- a/arch/mips/arch_mips.cpp
+++ b/arch/mips/arch_mips.cpp
@@ -1747,18 +1747,15 @@ private:
 
 		Ref<Symbol> funcSym = Symbol::ImportedFunctionFromImportAddressSymbol(sym, func->GetStart());
 		data->DefineAutoSymbol(funcSym);
-		for (auto& extSym : data->GetSymbolsByName(funcSym->GetRawName()))
-		{
-			if (extSym->GetType() == ExternalSymbol)
-			{
-				DataVariable var;
-				if (data->GetDataVariableAtAddress(extSym->GetAddress(), var))
-				{
-					func->ApplyImportedTypes(funcSym, var.type);
-				}
 
-				return true;
+		auto extSym = data->GetSymbolsByName(funcSym->GetRawName(), data->GetExternalNameSpace());
+		if (!extSym.empty()) {
+			DataVariable var;
+			if (data->GetDataVariableAtAddress(extSym.front()->GetAddress(), var))
+			{
+				func->ApplyImportedTypes(funcSym, var.type);
 			}
+			return true;
 		}
 		return false;
 	}
@@ -1823,18 +1820,14 @@ private:
 
 		if (pltSym)
 		{
-			for (auto& extSym : data->GetSymbolsByName(pltSym->GetRawName()))
-			{
-				if (extSym->GetType() == ExternalSymbol)
+			auto extSym = data->GetSymbolsByName(pltSym->GetRawName(), data->GetExternalNameSpace());
+			if (!extSym.empty()) {
+				DataVariable var;
+				if (data->GetDataVariableAtAddress(extSym.front()->GetAddress(), var))
 				{
-					DataVariable var;
-					if (data->GetDataVariableAtAddress(extSym->GetAddress(), var))
-					{
-						func->ApplyImportedTypes(pltSym, var.type);
-					}
-
-					return true;
+					func->ApplyImportedTypes(pltSym, var.type);
 				}
+				return true;
 			}
 		}
 
@@ -1951,20 +1944,17 @@ private:
 
 		Ref<Symbol> funcSym = Symbol::ImportedFunctionFromImportAddressSymbol(sym, func->GetStart());
 		data->DefineAutoSymbol(funcSym);
-		for (auto& extSym : data->GetSymbolsByName(funcSym->GetRawName()))
-		{
-			if (extSym->GetType() == ExternalSymbol)
-			{
-				DataVariable var;
-				if (data->GetDataVariableAtAddress(extSym->GetAddress(), var))
-				{
-					func->ApplyImportedTypes(funcSym, var.type);
-				}
 
-				return true;
+		auto extSym = data->GetSymbolsByName(funcSym->GetRawName(), data->GetExternalNameSpace());
+		if (!extSym.empty()) {
+			DataVariable var;
+			if (data->GetDataVariableAtAddress(extSym.front()->GetAddress(), var))
+			{
+				func->ApplyImportedTypes(funcSym, var.type);
 			}
+			return true;
 		}
-		return true;
+		return false;
 	}
 
 


### PR DESCRIPTION
Previously, prtinf type library is not being appropriately applied.

The original issue can be found here: #3092

Before
![image](https://github.com/Vector35/binaryninja-api/assets/34680029/b0cf4f30-831e-4222-a9e1-7be1624deee2)

After
![image](https://github.com/Vector35/binaryninja-api/assets/34680029/8085a19b-d723-4cc0-94d4-3a809aa91504)
