### PR TITLE
Add new setting to skip HEAD requests for localhost servers

### DIFF
--- a/python/settings.py
+++ b/python/settings.py
@@ -65,6 +65,7 @@ class Settings:
 		"title"               string                                   None                 No         Concise Setting Title
 		"type"                string                                   None                 No         {"array", "boolean", "number", "string"}
 		"elementType"         string                                   "type" is "array"    No         {"string"}
+		"sorted"              boolean                                  "type" is "array"    Yes        Automatically sort list items (default is true)
 		"enum"                array : {string}                         "type" is "string"   Yes        Enumeration definitions
 		"enumDescriptions"    array : {string}                         "type" is "string"   Yes        Enumeration descriptions that match "enum" array
 		"minValue"            number                                   "type" is "number"   Yes        Specify 0 to infer unsigned (default is signed)

--- a/rust/examples/pdb-ng/src/lib.rs
+++ b/rust/examples/pdb-ng/src/lib.rs
@@ -841,6 +841,18 @@ fn init_plugin() -> bool {
         }"#,
     );
 
+    settings.register_setting_json(
+        "pdb.features.parseSymbols",
+        r#"{
+            "title" : "Parse PDB Symbols",
+            "type" : "boolean",
+            "default" : true,
+            "aliases" : [],
+            "description" : "Parse Symbol names and types. If you turn this off, you will only load Types.",
+            "ignore" : []
+        }"#,
+    );
+
     true
 }
 

--- a/rust/examples/pdb-ng/src/lib.rs
+++ b/rust/examples/pdb-ng/src/lib.rs
@@ -252,6 +252,14 @@ fn sym_store_exists(path: &String) -> Result<bool> {
     if !Settings::new("").get_bool("network.pdbAutoDownload", None, None) {
         return Err(anyhow!("Auto download disabled"));
     }
+
+    // If the user doesn't want to check the network path
+    // (in the case of using a symbol server proxy that doesn't accept HEAD requests),
+    // just assume the path exists and return true.
+    if path.contains("localhost:") && Settings::new("").get_bool("network.pdbSkipNetworkPathCheck", None, None) {
+        return Ok(true);
+    }
+
     info!("HEAD: {}", path);
 
     // Download from remote
@@ -780,6 +788,18 @@ fn init_plugin() -> bool {
             "default" : true,
             "aliases" : ["pdb.autoDownload", "pdb.auto-download-pdb"],
             "description" : "Automatically search for and download pdb files from specified symbol servers.",
+            "ignore" : []
+        }"#,
+    );
+
+    settings.register_setting_json(
+        "network.pdbSkipNetworkPathCheck",
+        r#"{
+            "title" : "Skip Network Path Check",
+            "type" : "boolean",
+            "default" : false,
+            "aliases" : ["pdb.SkipNetworkPathCheck", "pdb.skip-network-path-check"],
+            "description" : "Skip the HEAD http request that verifies if a PDB network path exists (only for localhost servers).",
             "ignore" : []
         }"#,
     );

--- a/rust/examples/pdb-ng/src/lib.rs
+++ b/rust/examples/pdb-ng/src/lib.rs
@@ -790,6 +790,7 @@ fn init_plugin() -> bool {
             "title" : "Symbol Server List",
             "type" : "array",
             "elementType" : "string",
+            "sorted" : false,
             "default" : ["https://msdl.microsoft.com/download/symbols"],
             "aliases" : ["pdb.symbol-server-list", "pdb.symbolServerList"],
             "description" : "List of servers to query for pdb symbols.",

--- a/rust/examples/pdb-ng/src/parser.rs
+++ b/rust/examples/pdb-ng/src/parser.rs
@@ -166,7 +166,10 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
             self.debug_info.add_type(name, ty.as_ref(), &[]); // TODO : Components
         }
 
-        info!("PDB found {} types", self.named_types.len());
+        info!(
+            "PDB found {} types (before resolving NTRs)",
+            self.named_types.len()
+        );
 
         let (symbols, functions) =
             self.parse_symbols(Self::split_progress(&progress, 1, &[1.0, 3.0, 0.5, 0.5]))?;
@@ -185,6 +188,7 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
             )?;
         }
 
+        info!("PDB found {} types", self.named_types.len());
         info!("PDB found {} data variables", symbols.len());
         info!("PDB found {} functions", functions.len());
 

--- a/rust/examples/pdb-ng/src/parser.rs
+++ b/rust/examples/pdb-ng/src/parser.rs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::env;
 use std::fmt::Display;
 
@@ -63,36 +63,36 @@ pub struct PDBParserInstance<'a, S: Source<'a> + 'a> {
     /// type_parser.rs
 
     /// TypeIndex -> ParsedType enum used during parsing
-    pub(crate) indexed_types: HashMap<TypeIndex, ParsedType>,
+    pub(crate) indexed_types: BTreeMap<TypeIndex, ParsedType>,
     /// QName -> Binja Type for finished types
-    pub(crate) named_types: HashMap<String, Ref<Type>>,
+    pub(crate) named_types: BTreeMap<String, Ref<Type>>,
     /// Raw (mangled) name -> TypeIndex for resolving forward references
-    pub(crate) full_type_indices: HashMap<String, TypeIndex>,
+    pub(crate) full_type_indices: BTreeMap<String, TypeIndex>,
     /// Stack of types we're currently parsing
     pub(crate) type_stack: Vec<TypeIndex>,
     /// Stack of parent types we're parsing nested types inside of
     pub(crate) namespace_stack: Vec<String>,
     /// Type Index -> Does it return on the stack
-    pub(crate) type_default_returnable: HashMap<TypeIndex, bool>,
+    pub(crate) type_default_returnable: BTreeMap<TypeIndex, bool>,
 
     /// symbol_parser.rs
 
     /// List of fully parsed symbols from all modules
     pub(crate) parsed_symbols: Vec<ParsedSymbol>,
     /// Raw name -> index in parsed_symbols
-    pub(crate) parsed_symbols_by_name: HashMap<String, usize>,
+    pub(crate) parsed_symbols_by_name: BTreeMap<String, usize>,
     /// Raw name -> Symbol index for looking up symbols for the currently parsing module (mostly for thunks)
-    pub(crate) named_symbols: HashMap<String, SymbolIndex>,
+    pub(crate) named_symbols: BTreeMap<String, SymbolIndex>,
     /// Parent -> Children symbol index tree for the currently parsing module
-    pub(crate) symbol_tree: HashMap<SymbolIndex, Vec<SymbolIndex>>,
+    pub(crate) symbol_tree: BTreeMap<SymbolIndex, Vec<SymbolIndex>>,
     /// Child -> Parent symbol index mapping, inverse of symbol_tree
-    pub(crate) symbol_parents: HashMap<SymbolIndex, SymbolIndex>,
+    pub(crate) symbol_parents: BTreeMap<SymbolIndex, SymbolIndex>,
     /// Stack of (start, end) indices for the current symbols being parsed while constructing the tree
     pub(crate) symbol_stack: Vec<(SymbolIndex, SymbolIndex)>,
     /// Index -> parsed symbol for the currently parsing module
-    pub(crate) indexed_symbols: HashMap<SymbolIndex, ParsedSymbol>,
+    pub(crate) indexed_symbols: BTreeMap<SymbolIndex, ParsedSymbol>,
     /// Symbol address -> Symbol for looking up by address
-    pub(crate) addressed_symbols: HashMap<u64, Vec<ParsedSymbol>>,
+    pub(crate) addressed_symbols: BTreeMap<u64, Vec<ParsedSymbol>>,
     /// CPU type of the currently parsing module
     pub(crate) module_cpu_type: Option<CPUType>,
 }
@@ -273,7 +273,7 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
     fn collect_name(
         &self,
         name: &NamedTypeReference,
-        unknown_names: &mut HashMap<String, NamedTypeReferenceClass>,
+        unknown_names: &mut BTreeMap<String, NamedTypeReferenceClass>,
     ) {
         let used_name = name.name().to_string();
         if let Some(&found) =
@@ -306,7 +306,7 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
     fn collect_names(
         &self,
         ty: &Type,
-        unknown_names: &mut HashMap<String, NamedTypeReferenceClass>,
+        unknown_names: &mut BTreeMap<String, NamedTypeReferenceClass>,
     ) {
         match ty.type_class() {
             TypeClass::StructureTypeClass => {
@@ -357,13 +357,13 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
         symbols: &Vec<ParsedSymbol>,
         progress: Box<dyn Fn(usize, usize) -> Result<()> + '_>,
     ) -> Result<()> {
-        let mut unknown_names = HashMap::new();
+        let mut unknown_names = BTreeMap::new();
         let mut known_names = self
             .bv
             .types()
             .iter()
             .map(|qnat| qnat.name().string())
-            .collect::<HashSet<_>>();
+            .collect::<BTreeSet<_>>();
 
         for ty in &self.named_types {
             known_names.insert(ty.0.clone());

--- a/rust/examples/pdb-ng/src/symbol_parser.rs
+++ b/rust/examples/pdb-ng/src/symbol_parser.rs
@@ -1830,7 +1830,7 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
                             // Fallback in case we don't find a specific one
                             t = Some(Conf::new(
                                 Type::named_type_from_type(search_type, ty.as_ref()),
-                                max_confidence(),
+                                DEMANGLE_CONFIDENCE,
                             ));
 
                             if self.settings.get_bool(
@@ -1849,10 +1849,10 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
                                         // Wow!
                                         t = Some(Conf::new(
                                             Type::named_type_from_type(lengthy_name, ty.as_ref()),
-                                            max_confidence(),
+                                            DEMANGLE_CONFIDENCE,
                                         ));
                                     } else {
-                                        t = Some(Conf::new(lengthy_type, max_confidence()));
+                                        t = Some(Conf::new(lengthy_type, DEMANGLE_CONFIDENCE));
                                     }
                                 }
                             }
@@ -1884,7 +1884,7 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
                 if let Some(ty) = self.named_types.get(&vt_name) {
                     t = Some(Conf::new(
                         Type::named_type_from_type(&vt_name, ty.as_ref()),
-                        max_confidence(),
+                        DEMANGLE_CONFIDENCE,
                     ));
                 } else {
                     // Sometimes the demangler has trouble with `class Foo` in templates
@@ -1896,7 +1896,7 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
                     if let Some(ty) = self.named_types.get(&vt_name) {
                         t = Some(Conf::new(
                             Type::named_type_from_type(&vt_name, ty.as_ref()),
-                            max_confidence(),
+                            DEMANGLE_CONFIDENCE,
                         ));
                     } else {
                         t = Some(Conf::new(

--- a/rust/examples/pdb-ng/src/symbol_parser.rs
+++ b/rust/examples/pdb-ng/src/symbol_parser.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::mem;
 
 use anyhow::{anyhow, Result};
 use itertools::Itertools;
@@ -513,9 +514,8 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
             }
         }
 
-        let filtered_symbols = self
-            .indexed_symbols
-            .drain()
+        let filtered_symbols = mem::replace(&mut self.indexed_symbols, BTreeMap::new())
+            .into_iter()
             .filter_map(|(idx, sym)| {
                 if final_symbols.contains(&idx) {
                     Some(sym)

--- a/rust/examples/pdb-ng/src/symbol_parser.rs
+++ b/rust/examples/pdb-ng/src/symbol_parser.rs
@@ -330,12 +330,30 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
                 .into_iter()
                 .map(|(_, sym)| sym.clone())
                 .sorted_by_key(|sym| match sym {
-                    ParsedSymbol::Data(ParsedDataSymbol { type_, .. }) => {
-                        type_.as_ref().map(|ty| ty.confidence).unwrap_or(0)
-                    }
-                    ParsedSymbol::Procedure(ParsedProcedure { type_, .. }) => {
-                        type_.as_ref().map(|ty| ty.confidence).unwrap_or(0)
-                    }
+                    ParsedSymbol::Data(ParsedDataSymbol {
+                        type_, is_public, ..
+                    }) => type_
+                        .as_ref()
+                        .map(|ty| {
+                            if *is_public {
+                                ty.confidence / 2
+                            } else {
+                                ty.confidence
+                            }
+                        })
+                        .unwrap_or(0),
+                    ParsedSymbol::Procedure(ParsedProcedure {
+                        type_, is_public, ..
+                    }) => type_
+                        .as_ref()
+                        .map(|ty| {
+                            if *is_public {
+                                ty.confidence / 2
+                            } else {
+                                ty.confidence
+                            }
+                        })
+                        .unwrap_or(0),
                     _ => 0,
                 })
                 .collect::<Vec<_>>(),
@@ -343,12 +361,30 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
                 .into_iter()
                 .map(|(_, func)| func.clone())
                 .sorted_by_key(|sym| match sym {
-                    ParsedSymbol::Data(ParsedDataSymbol { type_, .. }) => {
-                        type_.as_ref().map(|ty| ty.confidence).unwrap_or(0)
-                    }
-                    ParsedSymbol::Procedure(ParsedProcedure { type_, .. }) => {
-                        type_.as_ref().map(|ty| ty.confidence).unwrap_or(0)
-                    }
+                    ParsedSymbol::Data(ParsedDataSymbol {
+                        type_, is_public, ..
+                    }) => type_
+                        .as_ref()
+                        .map(|ty| {
+                            if *is_public {
+                                ty.confidence / 2
+                            } else {
+                                ty.confidence
+                            }
+                        })
+                        .unwrap_or(0),
+                    ParsedSymbol::Procedure(ParsedProcedure {
+                        type_, is_public, ..
+                    }) => type_
+                        .as_ref()
+                        .map(|ty| {
+                            if *is_public {
+                                ty.confidence / 2
+                            } else {
+                                ty.confidence
+                            }
+                        })
+                        .unwrap_or(0),
                     _ => 0,
                 })
                 .collect::<Vec<_>>(),


### PR DESCRIPTION
Proxy servers such as [SymProxyCloud](https://github.com/microsoft/SymProxyCloud) don't respond to `HEAD` requests, so this PR adds a new setting that allows the user to skip file existence checks using a `HEAD` request.

Note that this setting only affects `localhost` servers, not other remote servers.