### PR TITLE
New standard proposal

### DIFF
--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -29,7 +29,6 @@ use binaryninja::{
         ExprInfo, InstrInfo, Label, Liftable, LiftableWithSize, LiftedNonSSA, Lifter, Mutable,
         NonSSA,
     },
-    rc::Ref,
     relocation::{
         CoreRelocationHandler, CustomRelocationHandlerHandle, RelocationHandler, RelocationInfo,
         RelocationType,
@@ -508,7 +507,7 @@ impl<D: RiscVDisassembler> architecture::Intrinsic for RiscVIntrinsic<D> {
         }
     }
 
-    fn inputs(&self) -> Vec<Ref<NameAndType>> {
+    fn inputs(&self) -> Vec<NameAndType> {
         match self.id {
             Intrinsic::Uret | Intrinsic::Sret | Intrinsic::Mret | Intrinsic::Wfi => {
                 vec![]
@@ -516,16 +515,16 @@ impl<D: RiscVDisassembler> architecture::Intrinsic for RiscVIntrinsic<D> {
             Intrinsic::Csrrd => {
                 vec![NameAndType::new(
                     "csr",
-                    &Type::int(4, false),
+                    Type::int(4, false),
                     max_confidence(),
                 )]
             }
             Intrinsic::Csrrw | Intrinsic::Csrwr | Intrinsic::Csrrs | Intrinsic::Csrrc => {
                 vec![
-                    NameAndType::new("csr", &Type::int(4, false), max_confidence()),
+                    NameAndType::new("csr", Type::int(4, false), max_confidence()),
                     NameAndType::new(
                         "value",
-                        &Type::int(<D::RegFile as RegFile>::Int::width(), false),
+                        Type::int(<D::RegFile as RegFile>::Int::width(), false),
                         min_confidence(),
                     ),
                 ]
@@ -540,8 +539,8 @@ impl<D: RiscVDisassembler> architecture::Intrinsic for RiscVIntrinsic<D> {
             | Intrinsic::Fmin(size)
             | Intrinsic::Fmax(size) => {
                 vec![
-                    NameAndType::new("", &Type::float(size as usize), max_confidence()),
-                    NameAndType::new("", &Type::float(size as usize), max_confidence()),
+                    NameAndType::new("", Type::float(size as usize), max_confidence()),
+                    NameAndType::new("", Type::float(size as usize), max_confidence()),
                 ]
             }
             Intrinsic::Fsqrt(size, _)
@@ -551,35 +550,35 @@ impl<D: RiscVDisassembler> architecture::Intrinsic for RiscVIntrinsic<D> {
             | Intrinsic::FcvtFToU(size, _, _) => {
                 vec![NameAndType::new(
                     "",
-                    &Type::float(size as usize),
+                    Type::float(size as usize),
                     max_confidence(),
                 )]
             }
             Intrinsic::FcvtIToF(size, _, _) => {
                 vec![NameAndType::new(
                     "",
-                    &Type::int(size as usize, true),
+                    Type::int(size as usize, true),
                     max_confidence(),
                 )]
             }
             Intrinsic::FcvtUToF(size, _, _) => {
                 vec![NameAndType::new(
                     "",
-                    &Type::int(size as usize, false),
+                    Type::int(size as usize, false),
                     max_confidence(),
                 )]
             }
             Intrinsic::Fence => {
                 vec![NameAndType::new(
                     "",
-                    &Type::int(4, false),
+                    Type::int(4, false),
                     min_confidence(),
                 )]
             }
         }
     }
 
-    fn outputs(&self) -> Vec<Conf<Ref<Type>>> {
+    fn outputs(&self) -> Vec<Conf<Type>> {
         match self.id {
             Intrinsic::Uret
             | Intrinsic::Sret

--- a/rust/examples/dwarf/dwarf_import/src/dwarfdebuginfo.rs
+++ b/rust/examples/dwarf/dwarf_import/src/dwarfdebuginfo.rs
@@ -95,7 +95,7 @@ impl FunctionInfoBuilder {
 // TODO : Don't make this pub...fix the value thing
 pub(crate) struct DebugType {
     name: String,
-    t: Ref<Type>,
+    t: Type,
     commit: bool,
 }
 
@@ -226,7 +226,7 @@ impl DebugInfoBuilder {
         self.types.values()
     }
 
-    pub(crate) fn add_type(&mut self, type_uid: TypeUID, name: String, t: Ref<Type>, commit: bool) {
+    pub(crate) fn add_type(&mut self, type_uid: TypeUID, name: String, t: Type, commit: bool) {
         if let Some(DebugType {
             name: existing_name,
             t: existing_type,
@@ -255,7 +255,7 @@ impl DebugInfoBuilder {
     }
 
     // TODO : Non-copy?
-    pub(crate) fn get_type(&self, type_uid: TypeUID) -> Option<(String, Ref<Type>)> {
+    pub(crate) fn get_type(&self, type_uid: TypeUID) -> Option<(String, Type)> {
         self.types
             .get(&type_uid)
             .map(|type_ref_ref| (type_ref_ref.name.clone(), type_ref_ref.t.clone()))
@@ -290,7 +290,7 @@ impl DebugInfoBuilder {
     fn commit_types(&self, debug_info: &mut DebugInfo) {
         for debug_type in self.types() {
             if debug_type.commit {
-                debug_info.add_type(debug_type.name.clone(), debug_type.t.as_ref(), &[]);
+                debug_info.add_type(debug_type.name.clone(), &debug_type.t, &[]);
                 // TODO : Components
             }
         }
@@ -308,7 +308,7 @@ impl DebugInfoBuilder {
         }
     }
 
-    fn get_function_type(&self, function: &FunctionInfoBuilder) -> Ref<Type> {
+    fn get_function_type(&self, function: &FunctionInfoBuilder) -> Type {
         let return_type = match function.return_type {
             Some(return_type_id) => Conf::new(self.get_type(return_type_id).unwrap().1.clone(), 0),
             _ => Conf::new(binaryninja::types::Type::void(), 0),

--- a/rust/examples/dwarf/dwarf_import/src/types.rs
+++ b/rust/examples/dwarf/dwarf_import/src/types.rs
@@ -16,11 +16,8 @@ use crate::die_handlers::*;
 use crate::dwarfdebuginfo::{DebugInfoBuilder, DebugInfoBuilderContext, TypeUID};
 use crate::helpers::*;
 
-use binaryninja::{
-    rc::*,
-    types::{
-        MemberAccess, MemberScope, ReferenceType, StructureBuilder, StructureType, Type, TypeClass,
-    },
+use binaryninja::types::{
+    MemberAccess, MemberScope, ReferenceType, StructureBuilder, StructureType, Type, TypeClass,
 };
 
 use gimli::{constants, DebuggingInformationEntry, Reader, Unit};
@@ -164,7 +161,7 @@ fn do_structure_parse<R: Reader<Offset = usize>>(
                                 });
 
                             structure_builder.insert(
-                                child_type.as_ref(),
+                                &child_type,
                                 child_name,
                                 struct_offset,
                                 false,
@@ -173,7 +170,7 @@ fn do_structure_parse<R: Reader<Offset = usize>>(
                             );
                         } else {
                             structure_builder.append(
-                                child_type.as_ref(),
+                                &child_type,
                                 child_name,
                                 MemberAccess::NoAccess,
                                 MemberScope::NoScope,
@@ -270,7 +267,7 @@ pub(crate) fn get_type<R: Reader<Offset = usize>>(
 
     // Collect the required information to create a type and add it to the type map. Also, add the dependencies of this type to the type's typeinfo
     // Create the type, make a TypeInfo for it, and add it to the debug info
-    let (type_def, mut commit): (Option<Ref<Type>>, bool) = match entry.tag() {
+    let (type_def, mut commit): (Option<Type>, bool) = match entry.tag() {
         constants::DW_TAG_base_type => (
             handle_base_type(unit, entry, debug_info_builder_context),
             false,

--- a/rust/examples/pdb-ng/src/struct_grouper.rs
+++ b/rust/examples/pdb-ng/src/struct_grouper.rs
@@ -414,7 +414,7 @@ fn apply_groups(
                 let mut inner = StructureBuilder::new();
                 apply_groups(members, &mut inner, children, inner_offset);
                 structure.insert(
-                    &Conf::new(Type::structure(inner.finalize().as_ref()), max_confidence()),
+                    &Conf::new(Type::structure(&inner.finalize()), max_confidence()),
                     format!("__inner{}", i),
                     inner_offset - offset,
                     false,
@@ -427,7 +427,7 @@ fn apply_groups(
                 inner.set_structure_type(StructureType::UnionStructureType);
                 apply_groups(members, &mut inner, children, inner_offset);
                 structure.insert(
-                    &Conf::new(Type::structure(inner.finalize().as_ref()), max_confidence()),
+                    &Conf::new(Type::structure(&inner.finalize()), max_confidence()),
                     format!("__inner{}", i),
                     inner_offset - offset,
                     false,

--- a/rust/src/architecture.rs
+++ b/rust/src/architecture.rs
@@ -316,7 +316,7 @@ pub trait Intrinsic: Sized + Clone + Copy {
     fn inputs(&self) -> Vec<Ref<NameAndType>>;
 
     /// Returns the list of the output types for this intrinsic.
-    fn outputs(&self) -> Vec<Conf<Ref<Type>>>;
+    fn outputs(&self) -> Vec<Conf<Type>>;
 }
 
 pub trait Architecture: 'static + Sized + AsRef<CoreArchitecture> {
@@ -653,7 +653,7 @@ impl Intrinsic for UnusedIntrinsic {
     fn inputs(&self) -> Vec<Ref<NameAndType>> {
         unreachable!()
     }
-    fn outputs(&self) -> Vec<Conf<Ref<Type>>> {
+    fn outputs(&self) -> Vec<Conf<Type>> {
         unreachable!()
     }
 }
@@ -1024,7 +1024,7 @@ impl Intrinsic for crate::architecture::CoreIntrinsic {
         }
     }
 
-    fn outputs(&self) -> Vec<Conf<Ref<Type>>> {
+    fn outputs(&self) -> Vec<Conf<Type>> {
         let mut count: usize = 0;
 
         unsafe {

--- a/rust/src/architecture.rs
+++ b/rust/src/architecture.rs
@@ -24,7 +24,9 @@ use std::{
     ffi::{c_char, c_int, CStr, CString},
     hash::Hash,
     mem::{zeroed, MaybeUninit},
-    ops, ptr, slice,
+    ops,
+    ptr,
+    slice,
 };
 
 use crate::{
@@ -1087,7 +1089,7 @@ impl CoreArchitecture {
     }
 
     pub fn name(&self) -> BnString {
-        unsafe { BnString::from_raw(BNGetArchitectureName(self.0)) }
+        unsafe { BnString::from_raw(ptr::NonNull::new(BNGetArchitectureName(self.0)).unwrap()) }
     }
 }
 

--- a/rust/src/architecture.rs
+++ b/rust/src/architecture.rs
@@ -1059,6 +1059,7 @@ impl Drop for CoreArchitectureList {
     }
 }
 
+#[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
 pub struct CoreArchitecture(pub(crate) *mut BNArchitecture);
 

--- a/rust/src/backgroundtask.rs
+++ b/rust/src/backgroundtask.rs
@@ -16,6 +16,7 @@
 
 use binaryninjacore_sys::*;
 
+use std::ptr::NonNull;
 use std::result;
 
 use crate::rc::*;
@@ -60,7 +61,9 @@ impl BackgroundTask {
     }
 
     pub fn get_progress_text(&self) -> BnString {
-        unsafe { BnString::from_raw(BNGetBackgroundTaskProgressText(self.handle)) }
+        unsafe {
+            BnString::from_raw(NonNull::new(BNGetBackgroundTaskProgressText(self.handle)).unwrap())
+        }
     }
 
     pub fn cancel(&self) {

--- a/rust/src/binaryview.rs
+++ b/rust/src/binaryview.rs
@@ -505,7 +505,7 @@ pub trait BinaryViewExt: BinaryViewBase {
         ty: Option<&Type>,
     ) -> Result<Ref<Symbol>> {
         let raw_type = ty
-            .map(|t| t.as_raw() as *mut BNType)
+            .map(|t| unsafe { t.as_raw() as *mut BNType })
             .unwrap_or(ptr::null_mut());
 
         unsafe {

--- a/rust/src/binaryview.rs
+++ b/rust/src/binaryview.rs
@@ -194,7 +194,7 @@ pub trait BinaryViewExt: BinaryViewBase {
 
     fn type_name(&self) -> BnString {
         let ptr: *mut c_char = unsafe { BNGetViewType(self.as_ref().handle) };
-        unsafe { BnString::from_raw(ptr) }
+        unsafe { BnString::from_raw(ptr::NonNull::new(ptr).unwrap()) }
     }
 
     fn parent_view(&self) -> Result<Ref<BinaryView>> {
@@ -222,7 +222,7 @@ pub trait BinaryViewExt: BinaryViewBase {
 
     fn view_type(&self) -> BnString {
         let ptr: *mut c_char = unsafe { BNGetViewType(self.as_ref().handle) };
-        unsafe { BnString::from_raw(ptr) }
+        unsafe { BnString::from_raw(ptr::NonNull::new(ptr).unwrap()) }
     }
 
     /// Reads up to `len` bytes from address `offset`
@@ -770,7 +770,7 @@ pub trait BinaryViewExt: BinaryViewBase {
         unsafe {
             let mut qualified_name = QualifiedName::from(name);
             let id_cstr = BNGetAnalysisTypeId(self.as_ref().handle, &mut qualified_name.0);
-            let id = BnString::from_raw(id_cstr);
+            let id = BnString::from_raw(ptr::NonNull::new(id_cstr).unwrap());
             if id.is_empty() {
                 return None;
             }

--- a/rust/src/binaryview.rs
+++ b/rust/src/binaryview.rs
@@ -733,7 +733,7 @@ pub trait BinaryViewExt: BinaryViewBase {
 
     fn get_type_by_ref(&self, ref_: &NamedTypeReference) -> Option<Type> {
         unsafe {
-            let type_handle = BNGetAnalysisTypeByRef(self.as_ref().handle, ref_.handle);
+            let type_handle = BNGetAnalysisTypeByRef(self.as_ref().handle, ref_.as_raw());
             if type_handle.is_null() {
                 return None;
             }

--- a/rust/src/binaryview.rs
+++ b/rust/src/binaryview.rs
@@ -583,19 +583,21 @@ pub trait BinaryViewExt: BinaryViewBase {
     ) -> QualifiedName {
         let mut qualified_name = QualifiedName::from(name);
         let source_str = source.into_bytes_with_nul();
-        let name_handle = unsafe {
-            let id_str = BNGenerateAutoTypeId(
+        let id_str = unsafe {
+            BNGenerateAutoTypeId(
                 source_str.as_ref().as_ptr() as *const _,
-                &mut qualified_name.0,
-            );
+                qualified_name.as_raw_mut(),
+            )
+        };
+        let name_handle = unsafe {
             BNDefineAnalysisType(
                 self.as_ref().handle,
                 id_str,
-                &mut qualified_name.0,
+                qualified_name.as_raw_mut(),
                 type_obj.as_raw(),
             )
         };
-        QualifiedName(name_handle)
+        unsafe { QualifiedName::from_raw(name_handle) }
     }
 
     fn define_user_type<S: BnStrCompatible>(&self, name: S, type_obj: &Type) {
@@ -603,7 +605,7 @@ pub trait BinaryViewExt: BinaryViewBase {
         unsafe {
             BNDefineUserAnalysisType(
                 self.as_ref().handle,
-                &mut qualified_name.0,
+                qualified_name.as_raw_mut(),
                 type_obj.as_raw(),
             )
         }

--- a/rust/src/callingconvention.rs
+++ b/rust/src/callingconvention.rs
@@ -455,7 +455,7 @@ impl<A: Architecture> CallingConvention<A> {
             };
             bn_params.push(BNFunctionParameter {
                 name: BnString::new(raw_name).into_raw(),
-                type_: parameter.t.contents.handle,
+                type_: parameter.t.contents.as_raw(),
                 typeConfidence: parameter.t.confidence,
                 defaultLocation: parameter.location.is_none(),
                 location,

--- a/rust/src/callingconvention.rs
+++ b/rust/src/callingconvention.rs
@@ -17,17 +17,13 @@
 use std::borrow::Borrow;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
-use std::mem;
 use std::os::raw::c_void;
-use std::ptr;
-use std::slice;
+use std::{mem, ptr, slice};
 
 use binaryninjacore_sys::*;
 
 use crate::architecture::{Architecture, ArchitectureExt, CoreArchitecture, Register};
-use crate::rc::{
-    CoreArrayProvider, CoreArrayProviderInner, Guard, Ref, RefCountable,
-};
+use crate::rc::{CoreArrayProvider, CoreArrayProviderInner, Guard, Ref, RefCountable};
 use crate::string::*;
 
 // TODO
@@ -437,7 +433,9 @@ impl<A: Architecture> CallingConvention<A> {
     }
 
     pub fn name(&self) -> BnString {
-        unsafe { BnString::from_raw(BNGetCallingConventionName(self.handle)) }
+        unsafe {
+            BnString::from_raw(NonNull::new(BNGetCallingConventionName(self.handle)).unwrap())
+        }
     }
 
     pub fn variables_for_parameters(

--- a/rust/src/custombinaryview.rs
+++ b/rust/src/custombinaryview.rs
@@ -19,11 +19,9 @@ use binaryninjacore_sys::*;
 pub use binaryninjacore_sys::BNModificationStatus as ModificationStatus;
 
 use std::marker::PhantomData;
-use std::mem;
 use std::mem::MaybeUninit;
 use std::os::raw::c_void;
-use std::ptr;
-use std::slice;
+use std::{mem, ptr, slice};
 
 use crate::architecture::Architecture;
 use crate::binaryview::{BinaryView, BinaryViewBase, BinaryViewExt, Result};
@@ -183,11 +181,17 @@ pub trait BinaryViewTypeBase: AsRef<BinaryViewType> {
 
 pub trait BinaryViewTypeExt: BinaryViewTypeBase {
     fn name(&self) -> BnString {
-        unsafe { BnString::from_raw(BNGetBinaryViewTypeName(self.as_ref().0)) }
+        unsafe {
+            BnString::from_raw(ptr::NonNull::new(BNGetBinaryViewTypeName(self.as_ref().0)).unwrap())
+        }
     }
 
     fn long_name(&self) -> BnString {
-        unsafe { BnString::from_raw(BNGetBinaryViewTypeLongName(self.as_ref().0)) }
+        unsafe {
+            BnString::from_raw(
+                ptr::NonNull::new(BNGetBinaryViewTypeLongName(self.as_ref().0)).unwrap(),
+            )
+        }
     }
 
     fn register_arch<A: Architecture>(&self, id: u32, endianness: Endianness, arch: &A) {

--- a/rust/src/debuginfo.rs
+++ b/rust/src/debuginfo.rs
@@ -78,7 +78,12 @@ use crate::{
     types::{DataVariableAndName, NameAndType, Type},
 };
 
-use std::{hash::Hash, os::raw::c_void, ptr, slice};
+use std::{
+    hash::Hash,
+    os::raw::c_void,
+    ptr::{self, NonNull},
+    slice,
+};
 
 struct ProgressContext(Option<Box<dyn Fn(usize, usize) -> Result<(), ()>>>);
 
@@ -127,7 +132,7 @@ impl DebugInfoParser {
 
     /// Returns the name of the current parser
     pub fn name(&self) -> BnString {
-        unsafe { BnString::from_raw(BNGetDebugInfoParserName(self.handle)) }
+        unsafe { BnString::from_raw(NonNull::new(BNGetDebugInfoParserName(self.handle)).unwrap()) }
     }
 
     /// Returns whether this debug-info parser is valid for the provided binary view

--- a/rust/src/debuginfo.rs
+++ b/rust/src/debuginfo.rs
@@ -389,7 +389,7 @@ impl DebugInfo {
     }
 
     /// Returns a generator of all types provided by a named DebugInfoParser
-    pub fn types_by_name<S: BnStrCompatible>(&self, parser_name: S) -> Vec<Ref<NameAndType>> {
+    pub fn types_by_name<S: BnStrCompatible>(&self, parser_name: S) -> Array<NameAndType> {
         let parser_name = parser_name.into_bytes_with_nul();
 
         let mut count: usize = 0;
@@ -400,30 +400,18 @@ impl DebugInfo {
                 &mut count,
             )
         };
-        let result: Vec<Ref<NameAndType>> = unsafe {
-            slice::from_raw_parts_mut(debug_types_ptr, count)
-                .iter()
-                .map(|x| NameAndType::from_raw(x).to_owned())
-                .collect()
-        };
-
-        unsafe { BNFreeDebugTypes(debug_types_ptr, count) };
-        result
+        // BNFreeDebugTypes is identical to BNFreeNameAndTypeList, so we can use
+        // Array<NameAndType> here with no consequences
+        unsafe{Array::new(debug_types_ptr, count, ())}
     }
 
     /// A generator of all types provided by DebugInfoParsers
-    pub fn types(&self) -> Vec<Ref<NameAndType>> {
+    pub fn types(&self) -> Array<NameAndType> {
         let mut count: usize = 0;
         let debug_types_ptr = unsafe { BNGetDebugTypes(self.handle, ptr::null_mut(), &mut count) };
-        let result: Vec<Ref<NameAndType>> = unsafe {
-            slice::from_raw_parts_mut(debug_types_ptr, count)
-                .iter()
-                .map(|x| NameAndType::from_raw(x).to_owned())
-                .collect()
-        };
-
-        unsafe { BNFreeDebugTypes(debug_types_ptr, count) };
-        result
+        // BNFreeDebugTypes is identical to BNFreeNameAndTypeList, so we can use
+        // Array<NameAndType> here with no consequences
+        unsafe{Array::new(debug_types_ptr, count, ())}
     }
 
     /// Returns a generator of all functions provided by a named DebugInfoParser

--- a/rust/src/debuginfo.rs
+++ b/rust/src/debuginfo.rs
@@ -778,7 +778,7 @@ impl DebugInfo {
         }
     }
 
-    pub fn add_data_variable_info(&self, var: DataVariableAndName) -> bool {
+    pub fn add_data_variable_info(&self, var: &DataVariableAndName) -> bool {
         unsafe { BNAddDebugDataVariableInfo(self.handle, var.as_raw()) }
     }
 }

--- a/rust/src/demangle.rs
+++ b/rust/src/demangle.rs
@@ -16,6 +16,7 @@
 
 use binaryninjacore_sys::*;
 use std::os::raw::c_char;
+use std::ptr::NonNull;
 use std::{ffi::CStr, result};
 
 use crate::architecture::CoreArchitecture;
@@ -73,7 +74,7 @@ pub fn demangle_gnu3<S: BnStrCompatible>(
     arch: &CoreArchitecture,
     mangled_name: S,
     simplify: bool,
-) -> Result<(Option<Ref<Type>>, Vec<String>)> {
+) -> Result<(Option<Type>, Vec<String>)> {
     let mangled_name_bwn = mangled_name.into_bytes_with_nul();
     let mangled_name_ptr = mangled_name_bwn.as_ref();
     let mut out_type: *mut BNType = std::ptr::null_mut();
@@ -106,7 +107,7 @@ pub fn demangle_gnu3<S: BnStrCompatible>(
             log::debug!("demangle_gnu3: out_type is NULL");
             None
         }
-        false => Some(unsafe { Type::ref_from_raw(out_type) }),
+        false => Some(unsafe { Type::from_raw(NonNull::new(out_type).unwrap()) }),
     };
 
     if out_name.is_null() {
@@ -128,7 +129,7 @@ pub fn demangle_ms<S: BnStrCompatible>(
     arch: &CoreArchitecture,
     mangled_name: S,
     simplify: bool,
-) -> Result<(Option<Ref<Type>>, Vec<String>)> {
+) -> Result<(Option<Type>, Vec<String>)> {
     let mangled_name_bwn = mangled_name.into_bytes_with_nul();
     let mangled_name_ptr = mangled_name_bwn.as_ref();
 
@@ -162,7 +163,7 @@ pub fn demangle_ms<S: BnStrCompatible>(
             log::debug!("demangle_ms: out_type is NULL");
             None
         }
-        false => Some(unsafe { Type::ref_from_raw(out_type) }),
+        false => Some(unsafe { Type::from_raw(NonNull::new(out_type).unwrap()) }),
     };
 
     if out_name.is_null() {

--- a/rust/src/disassembly.rs
+++ b/rust/src/disassembly.rs
@@ -23,8 +23,7 @@ use crate::rc::*;
 
 use std::convert::From;
 use std::ffi::CStr;
-use std::mem;
-use std::ptr;
+use std::{mem, ptr};
 
 pub type InstructionTextTokenType = BNInstructionTextTokenType;
 pub type InstructionTextTokenContext = BNInstructionTextTokenContext;
@@ -257,7 +256,7 @@ impl Clone for InstructionTextToken {
 impl Drop for InstructionTextToken {
     fn drop(&mut self) {
         if !self.0.text.is_null() {
-            let _owned = unsafe { BnString::from_raw(self.0.text) };
+            let _owned = unsafe { BnString::from_raw(ptr::NonNull::new(self.0.text).unwrap()) };
         }
         if !self.0.typeNames.is_null() && self.0.namesCount != 0 {
             unsafe { BNFreeStringList(self.0.typeNames, self.0.namesCount) }

--- a/rust/src/downloadprovider.rs
+++ b/rust/src/downloadprovider.rs
@@ -5,7 +5,7 @@ use binaryninjacore_sys::*;
 use std::collections::HashMap;
 use std::ffi::{c_void, CStr};
 use std::os::raw::c_char;
-use std::ptr::null_mut;
+use std::ptr::{null_mut, NonNull};
 use std::slice;
 
 pub struct DownloadProvider {
@@ -106,7 +106,7 @@ impl DownloadInstance {
 
     fn get_error(&self) -> BnString {
         let err: *mut c_char = unsafe { BNGetErrorForDownloadInstance(self.handle) };
-        unsafe { BnString::from_raw(err) }
+        unsafe { BnString::from_raw(NonNull::new(err).unwrap()) }
     }
 
     unsafe extern "C" fn o_write_callback(data: *mut u8, len: u64, ctxt: *mut c_void) -> u64 {

--- a/rust/src/filemetadata.rs
+++ b/rust/src/filemetadata.rs
@@ -85,7 +85,7 @@ impl FileMetadata {
     pub fn filename(&self) -> BnString {
         unsafe {
             let raw = BNGetFilename(self.handle);
-            BnString::from_raw(raw)
+            BnString::from_raw(ptr::NonNull::new(raw).unwrap())
         }
     }
 
@@ -142,7 +142,10 @@ impl FileMetadata {
     }
 
     pub fn begin_undo_actions(&self, anonymous_allowed: bool) -> BnString {
-        unsafe { BnString::from_raw(BNBeginUndoActions(self.handle, anonymous_allowed)) }
+        unsafe {
+            let result = BNBeginUndoActions(self.handle, anonymous_allowed);
+            BnString::from_raw(ptr::NonNull::new(result).unwrap())
+        }
     }
 
     pub fn commit_undo_actions<S: BnStrCompatible>(&self, id: S) {
@@ -172,7 +175,7 @@ impl FileMetadata {
     }
 
     pub fn current_view(&self) -> BnString {
-        unsafe { BnString::from_raw(BNGetCurrentView(self.handle)) }
+        unsafe { BnString::from_raw(ptr::NonNull::new(BNGetCurrentView(self.handle)).unwrap()) }
     }
 
     pub fn current_offset(&self) -> u64 {

--- a/rust/src/function.rs
+++ b/rust/src/function.rs
@@ -544,7 +544,7 @@ impl Function {
         let mut adjust_type = adjust_type.map(|adjust_type| {
             let adjust_type = adjust_type.into();
             BNTypeWithConfidence {
-                type_: adjust_type.contents.as_raw(),
+                type_: unsafe { adjust_type.contents.as_raw() },
                 confidence: adjust_type.confidence,
             }
         });
@@ -813,7 +813,7 @@ impl Function {
     ) -> RegisterValue {
         let arch = arch.unwrap_or_else(|| self.arch());
         let func_type = func_type
-            .map(|f| f.as_raw() as *mut BNType)
+            .map(|f| unsafe { f.as_raw() as *mut BNType })
             .unwrap_or(core::ptr::null_mut());
         let value =
             unsafe { BNGetParameterValueAtInstruction(self.handle, arch.0, addr, func_type, i) };
@@ -1104,7 +1104,7 @@ impl Function {
         arch: Option<CoreArchitecture>,
     ) {
         let arch = arch.unwrap_or_else(|| self.arch());
-        let name_ptr = name.as_raw() as *const BNQualifiedName as *mut BNQualifiedName;
+        let name_ptr = unsafe { name.as_raw() as *const BNQualifiedName as *mut BNQualifiedName };
         unsafe { BNAddUserTypeReference(self.handle, arch.0, from_addr, name_ptr) }
     }
 
@@ -1129,7 +1129,7 @@ impl Function {
         arch: Option<CoreArchitecture>,
     ) {
         let arch = arch.unwrap_or_else(|| self.arch());
-        let name_ptr = name.as_raw() as *const BNQualifiedName as *mut BNQualifiedName;
+        let name_ptr = unsafe { name.as_raw() as *const BNQualifiedName as *mut BNQualifiedName };
         unsafe { BNRemoveUserTypeReference(self.handle, arch.0, from_addr, name_ptr) }
     }
 
@@ -1160,7 +1160,7 @@ impl Function {
     ) {
         let size = size.unwrap_or(0);
         let arch = arch.unwrap_or_else(|| self.arch());
-        let name_ptr = name.as_raw() as *const BNQualifiedName as *mut BNQualifiedName;
+        let name_ptr = unsafe { name.as_raw() as *const BNQualifiedName as *mut BNQualifiedName };
         unsafe {
             BNAddUserTypeFieldReference(self.handle, arch.0, from_addr, name_ptr, offset, size)
         }
@@ -1192,7 +1192,7 @@ impl Function {
     ) {
         let size = size.unwrap_or(0);
         let arch = arch.unwrap_or_else(|| self.arch());
-        let name_ptr = name.as_raw() as *const BNQualifiedName as *mut BNQualifiedName;
+        let name_ptr = unsafe{ name.as_raw() as *const BNQualifiedName as *mut BNQualifiedName };
         unsafe {
             BNRemoveUserTypeFieldReference(self.handle, arch.0, from_addr, name_ptr, offset, size)
         }

--- a/rust/src/function.rs
+++ b/rust/src/function.rs
@@ -1205,8 +1205,7 @@ impl Function {
         size: Option<usize>,
     ) -> DataBuffer {
         let size = size.unwrap_or(0);
-        let state_raw = state.into_raw_value();
-        DataBuffer::from_raw(unsafe { BNGetConstantData(self.handle, state_raw, value, size) })
+        DataBuffer::from_raw(unsafe { BNGetConstantData(self.handle, state, value, size) })
     }
 
     pub fn constants_referenced_by(

--- a/rust/src/function.rs
+++ b/rust/src/function.rs
@@ -1104,7 +1104,7 @@ impl Function {
         arch: Option<CoreArchitecture>,
     ) {
         let arch = arch.unwrap_or_else(|| self.arch());
-        let name_ptr = &name.0 as *const BNQualifiedName as *mut _;
+        let name_ptr = name.as_raw() as *const BNQualifiedName as *mut BNQualifiedName;
         unsafe { BNAddUserTypeReference(self.handle, arch.0, from_addr, name_ptr) }
     }
 
@@ -1129,7 +1129,7 @@ impl Function {
         arch: Option<CoreArchitecture>,
     ) {
         let arch = arch.unwrap_or_else(|| self.arch());
-        let name_ptr = &name.0 as *const BNQualifiedName as *mut _;
+        let name_ptr = name.as_raw() as *const BNQualifiedName as *mut BNQualifiedName;
         unsafe { BNRemoveUserTypeReference(self.handle, arch.0, from_addr, name_ptr) }
     }
 
@@ -1160,7 +1160,7 @@ impl Function {
     ) {
         let size = size.unwrap_or(0);
         let arch = arch.unwrap_or_else(|| self.arch());
-        let name_ptr = &name.0 as *const _ as *mut _;
+        let name_ptr = name.as_raw() as *const BNQualifiedName as *mut BNQualifiedName;
         unsafe {
             BNAddUserTypeFieldReference(self.handle, arch.0, from_addr, name_ptr, offset, size)
         }
@@ -1192,7 +1192,7 @@ impl Function {
     ) {
         let size = size.unwrap_or(0);
         let arch = arch.unwrap_or_else(|| self.arch());
-        let name_ptr = &name.0 as *const _ as *mut _;
+        let name_ptr = name.as_raw() as *const BNQualifiedName as *mut BNQualifiedName;
         unsafe {
             BNRemoveUserTypeFieldReference(self.handle, arch.0, from_addr, name_ptr, offset, size)
         }

--- a/rust/src/function.rs
+++ b/rust/src/function.rs
@@ -184,7 +184,7 @@ impl Function {
     }
 
     pub fn comment(&self) -> BnString {
-        unsafe { BnString::from_raw(BNGetFunctionComment(self.handle)) }
+        unsafe { BnString::from_raw(NonNull::new(BNGetFunctionComment(self.handle)).unwrap()) }
     }
 
     pub fn set_comment<S: BnStrCompatible>(&self, comment: S) {
@@ -206,7 +206,9 @@ impl Function {
     }
 
     pub fn comment_at(&self, addr: u64) -> BnString {
-        unsafe { BnString::from_raw(BNGetCommentForAddress(self.handle, addr)) }
+        unsafe {
+            BnString::from_raw(NonNull::new(BNGetCommentForAddress(self.handle, addr)).unwrap())
+        }
     }
 
     pub fn set_comment_at<S: BnStrCompatible>(&self, addr: u64, comment: S) {
@@ -279,7 +281,7 @@ impl Function {
         unsafe {
             let raw_var = var.raw();
             let raw_name = BNGetVariableName(self.handle, &raw_var);
-            BnString::from_raw(raw_name)
+            BnString::from_raw(NonNull::new(raw_name).unwrap())
         }
     }
 
@@ -1536,15 +1538,16 @@ impl Function {
         arch: Option<CoreArchitecture>,
     ) -> BnString {
         let arch = arch.unwrap_or_else(|| self.arch());
-        unsafe {
-            BnString::from_raw(BNGetIntegerConstantDisplayTypeEnumerationType(
+        let result = unsafe {
+            BNGetIntegerConstantDisplayTypeEnumerationType(
                 self.handle,
                 arch.0,
                 instr_addr,
                 value,
                 operand,
-            ))
-        }
+            )
+        };
+        unsafe { BnString::from_raw(NonNull::new(result).unwrap()) }
     }
 
     /// Get the current text display type for an integer token in the disassembly or IL views
@@ -1721,7 +1724,7 @@ impl Function {
             return None;
         }
         let var = unsafe { Variable::from_raw(found_value.var) };
-        let name = unsafe { BnString::from_raw(found_value.name) };
+        let name = unsafe { BnString::from_raw(NonNull::new(found_value.name).unwrap()) };
         let var_type = Conf::new(
             unsafe { Type::from_raw(NonNull::new(found_value.type_).unwrap()) },
             found_value.typeConfidence,
@@ -2093,7 +2096,7 @@ impl Function {
     /// is under develoment. Currently the provenance information is
     /// undocumented, not persistent, and not saved to a database.
     pub fn provenance(&self) -> BnString {
-        unsafe { BnString::from_raw(BNGetProvenanceString(self.handle)) }
+        unsafe { BnString::from_raw(NonNull::new(BNGetProvenanceString(self.handle)).unwrap()) }
     }
 
     /// Get registers that are used for the return value

--- a/rust/src/hlil/instruction.rs
+++ b/rust/src/hlil/instruction.rs
@@ -4,7 +4,7 @@ use binaryninjacore_sys::BNHighLevelILOperation;
 use crate::architecture::CoreIntrinsic;
 use crate::operand_iter::OperandIter;
 use crate::rc::Ref;
-use crate::types::{ConstantData, RegisterValue, RegisterValueType, SSAVariable, Variable};
+use crate::types::{ConstantData, RegisterValue, SSAVariable, Variable};
 
 use super::operation::*;
 use super::{HighLevelILFunction, HighLevelILLiftedInstruction, HighLevelILLiftedInstructionKind};
@@ -749,12 +749,12 @@ impl HighLevelILInstruction {
             ConstData(op) => Lifted::ConstData(LiftedConstData {
                 constant_data: ConstantData::new(
                     self.function.get_function(),
-                    RegisterValue {
-                        state: RegisterValueType::from_raw_value(op.constant_data_kind).unwrap(),
-                        value: op.constant_data_value,
-                        offset: 0,
-                        size: op.size,
-                    },
+                    RegisterValue::new(
+                        RegisterValue::type_from_u32(op.constant_data_kind).unwrap(),
+                        op.constant_data_value,
+                        0,
+                        op.size,
+                    ),
                 ),
             }),
 

--- a/rust/src/hlil/operation.rs
+++ b/rust/src/hlil/operation.rs
@@ -1,3 +1,5 @@
+use std::ptr::NonNull;
+
 use binaryninjacore_sys::BNGetGotoLabelName;
 
 use crate::architecture::CoreIntrinsic;
@@ -16,7 +18,8 @@ pub struct GotoLabel {
 
 impl GotoLabel {
     pub fn name(&self) -> BnString {
-        unsafe { BnString::from_raw(BNGetGotoLabelName(self.function.handle, self.target)) }
+        let result = unsafe { BNGetGotoLabelName(self.function.handle, self.target) };
+        unsafe { BnString::from_raw(NonNull::new(result).unwrap()) }
     }
 }
 

--- a/rust/src/interaction.rs
+++ b/rust/src/interaction.rs
@@ -19,6 +19,7 @@ use binaryninjacore_sys::*;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_void};
 use std::path::PathBuf;
+use std::ptr::NonNull;
 
 use crate::binaryview::BinaryView;
 use crate::rc::Ref;
@@ -38,7 +39,7 @@ pub fn get_text_line_input(prompt: &str, title: &str) -> Option<String> {
         return None;
     }
 
-    Some(unsafe { BnString::from_raw(value).to_string() })
+    Some(unsafe { BnString::from_raw(NonNull::new(value).unwrap()).to_string() })
 }
 
 pub fn get_integer_input(prompt: &str, title: &str) -> Option<i64> {
@@ -93,7 +94,7 @@ pub fn get_open_filename_input(prompt: &str, extension: &str) -> Option<PathBuf>
         return None;
     }
 
-    let string = unsafe { BnString::from_raw(value) };
+    let string = unsafe { BnString::from_raw(NonNull::new(value).unwrap()) };
     Some(PathBuf::from(string.as_str()))
 }
 
@@ -112,7 +113,7 @@ pub fn get_save_filename_input(prompt: &str, title: &str, default_name: &str) ->
         return None;
     }
 
-    let string = unsafe { BnString::from_raw(value) };
+    let string = unsafe { BnString::from_raw(NonNull::new(value).unwrap()) };
     Some(PathBuf::from(string.as_str()))
 }
 
@@ -130,7 +131,7 @@ pub fn get_directory_name_input(prompt: &str, default_name: &str) -> Option<Path
         return None;
     }
 
-    let string = unsafe { BnString::from_raw(value) };
+    let string = unsafe { BnString::from_raw(NonNull::new(value).unwrap()) };
     Some(PathBuf::from(string.as_str()))
 }
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -165,6 +165,7 @@ pub mod templatesimplifier;
 pub mod types;
 
 use std::path::PathBuf;
+use std::ptr::NonNull;
 
 pub use binaryninjacore_sys::BNBranchType as BranchType;
 pub use binaryninjacore_sys::BNEndianness as Endianness;
@@ -271,9 +272,7 @@ pub fn load_with_options<S: BnStrCompatible, O: IntoJson>(
 
 pub fn install_directory() -> Result<PathBuf, ()> {
     let s: *mut std::os::raw::c_char = unsafe { binaryninjacore_sys::BNGetInstallDirectory() };
-    if s.is_null() {
-        return Err(());
-    }
+    let s = NonNull::new(s).ok_or(())?;
     Ok(PathBuf::from(
         unsafe { string::BnString::from_raw(s) }.to_string(),
     ))
@@ -282,9 +281,7 @@ pub fn install_directory() -> Result<PathBuf, ()> {
 pub fn bundled_plugin_directory() -> Result<PathBuf, ()> {
     let s: *mut std::os::raw::c_char =
         unsafe { binaryninjacore_sys::BNGetBundledPluginDirectory() };
-    if s.is_null() {
-        return Err(());
-    }
+    let s = NonNull::new(s).ok_or(())?;
     Ok(PathBuf::from(
         unsafe { string::BnString::from_raw(s) }.to_string(),
     ))
@@ -300,9 +297,7 @@ pub fn set_bundled_plugin_directory<S: string::BnStrCompatible>(new_dir: S) {
 
 pub fn user_directory() -> Result<PathBuf, ()> {
     let s: *mut std::os::raw::c_char = unsafe { binaryninjacore_sys::BNGetUserDirectory() };
-    if s.is_null() {
-        return Err(());
-    }
+    let s = NonNull::new(s).ok_or(())?;
     Ok(PathBuf::from(
         unsafe { string::BnString::from_raw(s) }.to_string(),
     ))
@@ -310,9 +305,7 @@ pub fn user_directory() -> Result<PathBuf, ()> {
 
 pub fn user_plugin_directory() -> Result<PathBuf, ()> {
     let s: *mut std::os::raw::c_char = unsafe { binaryninjacore_sys::BNGetUserPluginDirectory() };
-    if s.is_null() {
-        return Err(());
-    }
+    let s = NonNull::new(s).ok_or(())?;
     Ok(PathBuf::from(
         unsafe { string::BnString::from_raw(s) }.to_string(),
     ))
@@ -320,9 +313,7 @@ pub fn user_plugin_directory() -> Result<PathBuf, ()> {
 
 pub fn repositories_directory() -> Result<PathBuf, ()> {
     let s: *mut std::os::raw::c_char = unsafe { binaryninjacore_sys::BNGetRepositoriesDirectory() };
-    if s.is_null() {
-        return Err(());
-    }
+    let s = NonNull::new(s).ok_or(())?;
     Ok(PathBuf::from(
         unsafe { string::BnString::from_raw(s) }.to_string(),
     ))
@@ -330,9 +321,7 @@ pub fn repositories_directory() -> Result<PathBuf, ()> {
 
 pub fn settings_file_name() -> Result<PathBuf, ()> {
     let s: *mut std::os::raw::c_char = unsafe { binaryninjacore_sys::BNGetSettingsFileName() };
-    if s.is_null() {
-        return Err(());
-    }
+    let s = NonNull::new(s).ok_or(())?;
     Ok(PathBuf::from(
         unsafe { string::BnString::from_raw(s) }.to_string(),
     ))
@@ -350,9 +339,7 @@ pub fn path_relative_to_bundled_plugin_directory<S: string::BnStrCompatible>(
             path.into_bytes_with_nul().as_ref().as_ptr() as *const std::os::raw::c_char,
         )
     };
-    if s.is_null() {
-        return Err(());
-    }
+    let s = NonNull::new(s).ok_or(())?;
     Ok(PathBuf::from(
         unsafe { string::BnString::from_raw(s) }.to_string(),
     ))
@@ -366,9 +353,7 @@ pub fn path_relative_to_user_plugin_directory<S: string::BnStrCompatible>(
             path.into_bytes_with_nul().as_ref().as_ptr() as *const std::os::raw::c_char,
         )
     };
-    if s.is_null() {
-        return Err(());
-    }
+    let s = NonNull::new(s).ok_or(())?;
     Ok(PathBuf::from(
         unsafe { string::BnString::from_raw(s) }.to_string(),
     ))
@@ -380,16 +365,16 @@ pub fn path_relative_to_user_directory<S: string::BnStrCompatible>(path: S) -> R
             path.into_bytes_with_nul().as_ref().as_ptr() as *const std::os::raw::c_char,
         )
     };
-    if s.is_null() {
-        return Err(());
-    }
+    let s = NonNull::new(s).ok_or(())?;
     Ok(PathBuf::from(
         unsafe { string::BnString::from_raw(s) }.to_string(),
     ))
 }
 
 pub fn version() -> string::BnString {
-    unsafe { string::BnString::from_raw(binaryninjacore_sys::BNGetVersionString()) }
+    unsafe {
+        string::BnString::from_raw(NonNull::new(binaryninjacore_sys::BNGetVersionString()).unwrap())
+    }
 }
 
 pub fn plugin_abi_version() -> u32 {

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -3,6 +3,7 @@ use crate::string::{BnStrCompatible, BnString, IntoJson};
 use binaryninjacore_sys::*;
 use std::collections::HashMap;
 use std::os::raw::c_char;
+use std::ptr::NonNull;
 use std::slice;
 
 pub type MetadataType = BNMetadataType;
@@ -69,7 +70,7 @@ impl Metadata {
                 if ptr.is_null() {
                     return Err(());
                 }
-                Ok(unsafe { BnString::from_raw(ptr) })
+                Ok(unsafe { BnString::from_raw(NonNull::new(ptr).unwrap()) })
             }
             _ => Err(()),
         }
@@ -157,7 +158,7 @@ impl Metadata {
                 let list = unsafe { slice::from_raw_parts(ptr, size) };
                 let vec = list
                     .iter()
-                    .map(|ptr| unsafe { BnString::from_raw(*ptr) })
+                    .map(|ptr| unsafe { BnString::from_raw(NonNull::new(*ptr).unwrap()) })
                     .collect::<Vec<_>>();
                 unsafe { BNFreeMetadataStringList(ptr, size) };
                 Ok(vec)
@@ -173,7 +174,7 @@ impl Metadata {
                 if ptr.is_null() {
                     return Err(());
                 }
-                Ok(unsafe { BnString::from_raw(ptr) })
+                Ok(unsafe { BnString::from_raw(NonNull::new(ptr).unwrap()) })
             }
             _ => Err(()),
         }
@@ -230,7 +231,7 @@ impl Metadata {
 
                 let mut map = HashMap::new();
                 for i in 0..size {
-                    let key = unsafe { BnString::from_raw(keys[i]) };
+                    let key = unsafe { BnString::from_raw(NonNull::new(keys[i]).unwrap()) };
 
                     let value = unsafe {
                         Ref::<Metadata>::new(Self {

--- a/rust/src/mlil/instruction.rs
+++ b/rust/src/mlil/instruction.rs
@@ -1159,7 +1159,7 @@ impl MediumLevelILInstruction {
     pub fn set_expr_type<'a, T: Into<Conf<&'a Type>>>(&self, value: T) {
         let type_: Conf<&'a Type> = value.into();
         let mut type_raw: BNTypeWithConfidence = BNTypeWithConfidence {
-            type_: type_.contents.as_raw(),
+            type_: unsafe{ type_.contents.as_raw() },
             confidence: type_.confidence,
         };
         unsafe { BNSetMediumLevelILExprType(self.function.handle, self.index, &mut type_raw) }

--- a/rust/src/mlil/instruction.rs
+++ b/rust/src/mlil/instruction.rs
@@ -7,8 +7,8 @@ use crate::disassembly::InstructionTextToken;
 use crate::operand_iter::OperandIter;
 use crate::rc::{Array, CoreArrayProvider, CoreArrayProviderInner, Ref};
 use crate::types::{
-    Conf, ConstantData, DataFlowQueryOption, ILBranchDependence, PossibleValueSet,
-    RegisterValue, RegisterValueType, SSAVariable, Type, Variable,
+    Conf, ConstantData, DataFlowQueryOption, ILBranchDependence, PossibleValueSet, RegisterValue,
+    SSAVariable, Type, Variable,
 };
 
 use super::lift::*;
@@ -751,12 +751,12 @@ impl MediumLevelILInstruction {
             ConstData(op) => Lifted::ConstData(LiftedConstData {
                 constant_data: ConstantData::new(
                     self.function.get_function(),
-                    RegisterValue {
-                        state: RegisterValueType::from_raw_value(op.constant_data_kind).unwrap(),
-                        value: op.constant_data_value,
-                        offset: 0,
-                        size: op.size,
-                    },
+                    RegisterValue::new(
+                        RegisterValue::type_from_u32(op.constant_data_kind).unwrap(),
+                        op.constant_data_value,
+                        0,
+                        op.size,
+                    ),
                 ),
             }),
             Jump(op) => Lifted::Jump(LiftedJump {

--- a/rust/src/mlil/instruction.rs
+++ b/rust/src/mlil/instruction.rs
@@ -1,3 +1,5 @@
+use std::ptr::NonNull;
+
 use binaryninjacore_sys::*;
 
 use crate::architecture::CoreIntrinsic;
@@ -1138,11 +1140,11 @@ impl MediumLevelILInstruction {
     }
 
     /// Type of expression
-    pub fn expr_type(&self) -> Option<Conf<Ref<Type>>> {
+    pub fn expr_type(&self) -> Option<Conf<Type>> {
         let result = unsafe { BNGetMediumLevelILExprType(self.function.handle, self.index) };
         (!result.type_.is_null()).then(|| {
             Conf::new(
-                unsafe { Type::ref_from_raw(result.type_) },
+                unsafe { Type::from_raw(NonNull::new(result.type_).unwrap()) },
                 result.confidence,
             )
         })
@@ -1157,7 +1159,7 @@ impl MediumLevelILInstruction {
     pub fn set_expr_type<'a, T: Into<Conf<&'a Type>>>(&self, value: T) {
         let type_: Conf<&'a Type> = value.into();
         let mut type_raw: BNTypeWithConfidence = BNTypeWithConfidence {
-            type_: type_.contents.handle,
+            type_: type_.contents.as_raw(),
             confidence: type_.confidence,
         };
         unsafe { BNSetMediumLevelILExprType(self.function.handle, self.index, &mut type_raw) }

--- a/rust/src/platform.rs
+++ b/rust/src/platform.rs
@@ -18,6 +18,7 @@ use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::os::raw;
 use std::path::Path;
+use std::ptr::NonNull;
 use std::{ptr, slice};
 
 use binaryninjacore_sys::*;
@@ -157,7 +158,7 @@ impl Platform {
     pub fn name(&self) -> BnString {
         unsafe {
             let raw_name = BNGetPlatformName(self.handle);
-            BnString::from_raw(raw_name)
+            BnString::from_raw(NonNull::new(raw_name).unwrap())
         }
     }
 
@@ -312,7 +313,7 @@ impl TypeParser for Platform {
                 auto_type_source.as_ref().as_ptr() as _,
             );
 
-            let error_msg = BnString::from_raw(error_string);
+            let error_msg = BnString::from_raw(NonNull::new(error_string).unwrap());
 
             if !success {
                 return Err(error_msg.to_string());

--- a/rust/src/platform.rs
+++ b/rust/src/platform.rs
@@ -313,35 +313,33 @@ impl TypeParser for Platform {
                 auto_type_source.as_ref().as_ptr() as _,
             );
 
-            let error_msg = BnString::from_raw(NonNull::new(error_string).unwrap());
-
             if !success {
+                let error_msg = BnString::from_raw(NonNull::new(error_string).unwrap());
                 return Err(error_msg.to_string());
             }
 
             for i in slice::from_raw_parts(result.types, result.typeCount) {
-                let name = QualifiedName::from_raw(i.name);
-                type_parser_result.types.insert(
-                    name.string(),
-                    Type::from_raw(ptr::NonNull::new(i.type_).unwrap()),
-                );
+                let name = QualifiedName::ref_from_raw(&i.name);
+                type_parser_result
+                    .types
+                    .insert(name.string(), Type::ref_from_raw(&i.type_).clone());
             }
 
             for i in slice::from_raw_parts(result.functions, result.functionCount) {
-                let name = QualifiedName::from_raw(i.name);
-                type_parser_result.functions.insert(
-                    name.string(),
-                    Type::from_raw(ptr::NonNull::new(i.type_).unwrap()),
-                );
+                let name = QualifiedName::ref_from_raw(&i.name);
+                type_parser_result
+                    .functions
+                    .insert(name.string(), Type::ref_from_raw(&i.type_).clone());
             }
 
             for i in slice::from_raw_parts(result.variables, result.variableCount) {
-                let name = QualifiedName::from_raw(i.name);
-                type_parser_result.variables.insert(
-                    name.string(),
-                    Type::from_raw(ptr::NonNull::new(i.type_).unwrap()),
-                );
+                let name = QualifiedName::ref_from_raw(&i.name);
+                type_parser_result
+                    .variables
+                    .insert(name.string(), Type::ref_from_raw(&i.type_).clone());
             }
+
+            BNFreeTypeParserResult(&mut result);
         }
 
         Ok(type_parser_result)

--- a/rust/src/platform.rs
+++ b/rust/src/platform.rs
@@ -320,7 +320,7 @@ impl TypeParser for Platform {
             }
 
             for i in slice::from_raw_parts(result.types, result.typeCount) {
-                let name = QualifiedName(i.name);
+                let name = QualifiedName::from_raw(i.name);
                 type_parser_result.types.insert(
                     name.string(),
                     Type::from_raw(ptr::NonNull::new(i.type_).unwrap()),
@@ -328,7 +328,7 @@ impl TypeParser for Platform {
             }
 
             for i in slice::from_raw_parts(result.functions, result.functionCount) {
-                let name = QualifiedName(i.name);
+                let name = QualifiedName::from_raw(i.name);
                 type_parser_result.functions.insert(
                     name.string(),
                     Type::from_raw(ptr::NonNull::new(i.type_).unwrap()),
@@ -336,7 +336,7 @@ impl TypeParser for Platform {
             }
 
             for i in slice::from_raw_parts(result.variables, result.variableCount) {
-                let name = QualifiedName(i.name);
+                let name = QualifiedName::from_raw(i.name);
                 type_parser_result.variables.insert(
                     name.string(),
                     Type::from_raw(ptr::NonNull::new(i.type_).unwrap()),

--- a/rust/src/platform.rs
+++ b/rust/src/platform.rs
@@ -14,17 +14,19 @@
 
 //! Contains all information related to the execution environment of the binary, mainly the calling conventions used
 
-use std::{borrow::Borrow, collections::HashMap, os::raw, path::Path, ptr, slice};
+use std::borrow::Borrow;
+use std::collections::HashMap;
+use std::os::raw;
+use std::path::Path;
+use std::{ptr, slice};
 
 use binaryninjacore_sys::*;
 
-use crate::{
-    architecture::{Architecture, CoreArchitecture},
-    callingconvention::CallingConvention,
-    rc::*,
-    string::*,
-    types::{QualifiedName, QualifiedNameAndType, Type},
-};
+use crate::architecture::{Architecture, CoreArchitecture};
+use crate::callingconvention::CallingConvention;
+use crate::rc::*;
+use crate::string::*;
+use crate::types::{QualifiedName, QualifiedNameAndType, Type};
 
 #[derive(PartialEq, Eq, Hash)]
 pub struct Platform {
@@ -257,9 +259,9 @@ pub trait TypeParser {
 
 #[derive(Clone, Default)]
 pub struct TypeParserResult {
-    pub types: HashMap<String, Ref<Type>>,
-    pub variables: HashMap<String, Ref<Type>>,
-    pub functions: HashMap<String, Ref<Type>>,
+    pub types: HashMap<String, Type>,
+    pub variables: HashMap<String, Type>,
+    pub functions: HashMap<String, Type>,
 }
 
 impl TypeParser for Platform {
@@ -318,23 +320,26 @@ impl TypeParser for Platform {
 
             for i in slice::from_raw_parts(result.types, result.typeCount) {
                 let name = QualifiedName(i.name);
-                type_parser_result
-                    .types
-                    .insert(name.string(), Type::ref_from_raw(i.type_));
+                type_parser_result.types.insert(
+                    name.string(),
+                    Type::from_raw(ptr::NonNull::new(i.type_).unwrap()),
+                );
             }
 
             for i in slice::from_raw_parts(result.functions, result.functionCount) {
                 let name = QualifiedName(i.name);
-                type_parser_result
-                    .functions
-                    .insert(name.string(), Type::ref_from_raw(i.type_));
+                type_parser_result.functions.insert(
+                    name.string(),
+                    Type::from_raw(ptr::NonNull::new(i.type_).unwrap()),
+                );
             }
 
             for i in slice::from_raw_parts(result.variables, result.variableCount) {
                 let name = QualifiedName(i.name);
-                type_parser_result
-                    .variables
-                    .insert(name.string(), Type::ref_from_raw(i.type_));
+                type_parser_result.variables.insert(
+                    name.string(),
+                    Type::from_raw(ptr::NonNull::new(i.type_).unwrap()),
+                );
             }
         }
 

--- a/rust/src/rc.rs
+++ b/rust/src/rc.rs
@@ -233,18 +233,6 @@ impl<P: CoreArrayProviderInner> Array<P> {
         }
     }
 
-    pub(crate) unsafe fn into_raw(self) -> (*mut P::Raw, usize, P::Context) {
-        let contents = self.contents;
-        let count = self.count;
-
-        // extract the context, because we can't move it directly, we need
-        // to be carefull to take the value, not droping self
-        let slf = mem::ManuallyDrop::new(self);
-        let context = mem::transmute_copy(&slf.context);
-
-        (contents, count, context)
-    }
-
     #[inline]
     pub fn len(&self) -> usize {
         self.count

--- a/rust/src/rc.rs
+++ b/rust/src/rc.rs
@@ -233,6 +233,18 @@ impl<P: CoreArrayProviderInner> Array<P> {
         }
     }
 
+    pub(crate) unsafe fn into_raw(self) -> (*mut P::Raw, usize, P::Context) {
+        let contents = self.contents;
+        let count = self.count;
+
+        // extract the context, because we can't move it directly, we need
+        // to be carefull to take the value, not droping self
+        let slf = mem::ManuallyDrop::new(self);
+        let context = mem::transmute_copy(&slf.context);
+
+        (contents, count, context)
+    }
+
     #[inline]
     pub fn len(&self) -> usize {
         self.count

--- a/rust/src/section.rs
+++ b/rust/src/section.rs
@@ -16,6 +16,7 @@
 
 use std::fmt;
 use std::ops::Range;
+use std::ptr::NonNull;
 
 use binaryninjacore_sys::*;
 
@@ -83,11 +84,11 @@ impl Section {
     }
 
     pub fn name(&self) -> BnString {
-        unsafe { BnString::from_raw(BNSectionGetName(self.handle)) }
+        unsafe { BnString::from_raw(NonNull::new(BNSectionGetName(self.handle)).unwrap()) }
     }
 
     pub fn section_type(&self) -> BnString {
-        unsafe { BnString::from_raw(BNSectionGetType(self.handle)) }
+        unsafe { BnString::from_raw(NonNull::new(BNSectionGetType(self.handle)).unwrap()) }
     }
 
     pub fn start(&self) -> u64 {
@@ -115,11 +116,11 @@ impl Section {
     }
 
     pub fn linked_section(&self) -> BnString {
-        unsafe { BnString::from_raw(BNSectionGetLinkedSection(self.handle)) }
+        unsafe { BnString::from_raw(NonNull::new(BNSectionGetLinkedSection(self.handle)).unwrap()) }
     }
 
     pub fn info_section(&self) -> BnString {
-        unsafe { BnString::from_raw(BNSectionGetInfoSection(self.handle)) }
+        unsafe { BnString::from_raw(NonNull::new(BNSectionGetInfoSection(self.handle)).unwrap()) }
     }
 
     pub fn info_data(&self) -> u64 {

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -16,14 +16,14 @@
 
 pub use binaryninjacore_sys::BNSettingsScope as SettingsScope;
 use binaryninjacore_sys::*;
+
 use std::iter::FromIterator;
 use std::os::raw::c_char;
+use std::ptr;
 
 use crate::binaryview::BinaryView;
 use crate::rc::*;
 use crate::string::{BnStrCompatible, BnString};
-
-use std::ptr;
 
 #[derive(PartialEq, Eq, Hash)]
 pub struct Settings {
@@ -57,7 +57,7 @@ impl Settings {
     }
 
     pub fn serialize_schema(&self) -> BnString {
-        unsafe { BnString::from_raw(BNSettingsSerializeSchema(self.handle)) }
+        unsafe { BnString::from_raw(ptr::NonNull::new(BNSettingsSerializeSchema(self.handle)).unwrap()) }
     }
 
     pub fn deserialize_schema<S: BnStrCompatible>(&self, schema: S) -> bool {
@@ -168,14 +168,15 @@ impl Settings {
             Some(mut scope) => scope.as_mut(),
             _ => ptr::null_mut() as *mut _,
         };
-        unsafe {
-            BnString::from_raw(BNSettingsGetString(
+        let result = unsafe {
+            BNSettingsGetString(
                 self.handle,
                 key.as_ref().as_ptr() as *mut _,
                 view_handle,
                 scope_ptr,
-            ))
-        }
+            )
+        };
+        unsafe { BnString::from_raw(ptr::NonNull::new(result).unwrap()) }
     }
 
     pub fn get_string_list<S: BnStrCompatible>(
@@ -224,14 +225,15 @@ impl Settings {
             Some(mut scope) => scope.as_mut(),
             _ => ptr::null_mut() as *mut _,
         };
-        unsafe {
-            BnString::from_raw(BNSettingsGetJson(
+        let result = unsafe {
+            BNSettingsGetJson(
                 self.handle,
                 key.as_ref().as_ptr() as *mut _,
                 view_handle,
                 scope_ptr,
-            ))
-        }
+            )
+        };
+        unsafe { BnString::from_raw(ptr::NonNull::new(result).unwrap()) }
     }
 
     pub fn set_bool<S: BnStrCompatible>(

--- a/rust/src/symbol.rs
+++ b/rust/src/symbol.rs
@@ -14,9 +14,8 @@
 
 //! Interfaces for the various kinds of symbols in a binary.
 
-use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::ptr;
+use std::{fmt, ptr};
 
 use crate::rc::*;
 use crate::string::*;
@@ -248,15 +247,15 @@ impl Symbol {
     }
 
     pub fn full_name(&self) -> BnString {
-        unsafe { BnString::from_raw(BNGetSymbolFullName(self.handle)) }
+        unsafe { BnString::from_raw(ptr::NonNull::new(BNGetSymbolFullName(self.handle)).unwrap()) }
     }
 
     pub fn short_name(&self) -> BnString {
-        unsafe { BnString::from_raw(BNGetSymbolShortName(self.handle)) }
+        unsafe { BnString::from_raw(ptr::NonNull::new(BNGetSymbolShortName(self.handle)).unwrap()) }
     }
 
     pub fn raw_name(&self) -> BnString {
-        unsafe { BnString::from_raw(BNGetSymbolRawName(self.handle)) }
+        unsafe { BnString::from_raw(ptr::NonNull::new(BNGetSymbolRawName(self.handle)).unwrap()) }
     }
 
     pub fn address(&self) -> u64 {

--- a/rust/src/tags.rs
+++ b/rust/src/tags.rs
@@ -14,6 +14,8 @@
 
 //! Interfaces for creating and modifying tags in a BinaryView.
 
+use std::ptr::NonNull;
+
 use binaryninjacore_sys::*;
 
 use crate::architecture::CoreArchitecture;
@@ -40,11 +42,11 @@ impl Tag {
     }
 
     pub fn id(&self) -> BnString {
-        unsafe { BnString::from_raw(BNTagGetId(self.handle)) }
+        unsafe { BnString::from_raw(NonNull::new(BNTagGetId(self.handle)).unwrap()) }
     }
 
     pub fn data(&self) -> BnString {
-        unsafe { BnString::from_raw(BNTagGetData(self.handle)) }
+        unsafe { BnString::from_raw(NonNull::new(BNTagGetData(self.handle)).unwrap()) }
     }
 
     pub fn t(&self) -> Ref<TagType> {
@@ -122,11 +124,11 @@ impl TagType {
     }
 
     pub fn id(&self) -> BnString {
-        unsafe { BnString::from_raw(BNTagTypeGetId(self.handle)) }
+        unsafe { BnString::from_raw(NonNull::new(BNTagTypeGetId(self.handle)).unwrap()) }
     }
 
     pub fn icon(&self) -> BnString {
-        unsafe { BnString::from_raw(BNTagTypeGetIcon(self.handle)) }
+        unsafe { BnString::from_raw(NonNull::new(BNTagTypeGetIcon(self.handle)).unwrap()) }
     }
 
     pub fn set_icon<S: BnStrCompatible>(&self, icon: S) {
@@ -137,7 +139,7 @@ impl TagType {
     }
 
     pub fn name(&self) -> BnString {
-        unsafe { BnString::from_raw(BNTagTypeGetName(self.handle)) }
+        unsafe { BnString::from_raw(NonNull::new(BNTagTypeGetName(self.handle)).unwrap()) }
     }
 
     pub fn set_name<S: BnStrCompatible>(&self, name: S) {

--- a/rust/src/templatesimplifier.rs
+++ b/rust/src/templatesimplifier.rs
@@ -1,3 +1,5 @@
+use std::ptr::NonNull;
+
 use crate::{
     string::{BnStrCompatible, BnString},
     types::QualifiedName,
@@ -6,7 +8,8 @@ use binaryninjacore_sys::{BNRustSimplifyStrToFQN, BNRustSimplifyStrToStr};
 
 pub fn simplify_str_to_str<S: BnStrCompatible>(input: S) -> BnString {
     let name = input.into_bytes_with_nul();
-    unsafe { BnString::from_raw(BNRustSimplifyStrToStr(name.as_ref().as_ptr() as *mut _)) }
+    let result = unsafe { BNRustSimplifyStrToStr(name.as_ref().as_ptr() as *mut _) };
+    unsafe { BnString::from_raw(NonNull::new(result).unwrap()) }
 }
 
 pub fn simplify_str_to_fqn<S: BnStrCompatible>(input: S, simplify: bool) -> QualifiedName {

--- a/rust/src/templatesimplifier.rs
+++ b/rust/src/templatesimplifier.rs
@@ -15,7 +15,7 @@ pub fn simplify_str_to_str<S: BnStrCompatible>(input: S) -> BnString {
 pub fn simplify_str_to_fqn<S: BnStrCompatible>(input: S, simplify: bool) -> QualifiedName {
     let name = input.into_bytes_with_nul();
     unsafe {
-        QualifiedName(BNRustSimplifyStrToFQN(
+        QualifiedName::from_raw(BNRustSimplifyStrToFQN(
             name.as_ref().as_ptr() as *mut _,
             simplify,
         ))

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -3410,6 +3410,7 @@ impl Drop for UserVariableValues {
 /////////////////////////
 // ConstantReference
 
+#[repr(C)]
 #[derive(Copy, Clone, Eq, Hash, PartialEq)]
 pub struct ConstantReference {
     pub value: i64,

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -2359,6 +2359,10 @@ impl Debug for NamedTypeReference {
 pub struct QualifiedName(pub(crate) BNQualifiedName);
 
 impl QualifiedName {
+    pub(crate) unsafe fn ref_from_raw(handle: &BNQualifiedName) -> &Self {
+        mem::transmute(handle)
+    }
+
     // TODO : I think this is bad
     pub fn string(&self) -> String {
         unsafe {
@@ -2481,7 +2485,7 @@ unsafe impl CoreArrayProviderInner for QualifiedName {
         BNFreeTypeNameList(raw, count);
     }
     unsafe fn wrap_raw<'a>(raw: &'a Self::Raw, _context: &'a Self::Context) -> Self::Wrapped<'a> {
-        mem::transmute(raw)
+        QualifiedName::ref_from_raw(raw)
     }
 }
 

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -3860,9 +3860,6 @@ mod test {
         assert_eq!(name_type_ref.name().string().as_str(), "Test");
     }
 
-    // TODO <Plarform as TypeParser>::parse_types_from_source forgot to call
-    // BNFreeTypeParserResult, leaking the result
-
     // TODO BNGetDebugDataVariableByName returns a *mut BNDataVariableAndName
     // pointer, can we deref it? Or it need to be freed by proper drop.
     // Verify if

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -3455,6 +3455,8 @@ unsafe impl CoreArrayProviderInner for ConstantReference {
 /////////////////////////
 // IndirectBranchInfo
 
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
 pub struct IndirectBranchInfo {
     pub source_arch: CoreArchitecture,
     pub source_addr: u64,

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -3859,14 +3859,4 @@ mod test {
         let name_type_ref = NamedTypeReference::new(type_class, &name);
         assert_eq!(name_type_ref.name().string().as_str(), "Test");
     }
-
-    // TODO BNGetDebugDataVariableByName returns a *mut BNDataVariableAndName
-    // pointer, can we deref it? Or it need to be freed by proper drop.
-    // Verify if
-    // * DebugInfo::get_data_variable_by_name
-    // * DebugInfo::get_data_variable_by_address
-    // should call BNFreeDataVariableAndName
-    // Also verify if
-    // * DebugInfo::add_data_variable_info
-    // should receive a reference or some kind of owned pointer
 }


### PR DESCRIPTION
This is an proposal to standardize the inner-workings of the API, specially with the FFI types.

Mostly it consist of creating standard functions to create/manger FFI wrapper types, such as functions `into_raw`, `as_raw`, `from_raw`, `ref_from_raw`, the use of `NonNull<T>` instead of the naked pointer, hide inner representations, etc.

This don't necessarily has the objective of being merged, but act like a guide to new implementations.