### PR TITLE
Implement Clone for Expression

### DIFF
--- a/rust/src/llil/expression.rs
+++ b/rust/src/llil/expression.rs
@@ -83,6 +83,36 @@ where
     }
 }
 
+impl<'func, A, V, R> Clone for Expression<'func, A, Mutable, NonSSA<V>, R>
+    where
+        A: 'func + Architecture,
+        V: NonSSAVariant,
+        R: ExpressionResultType,
+{
+    fn clone(&self) -> Self {
+        use binaryninjacore_sys::BNLowLevelILAddExpr;
+        
+        let expr = unsafe {
+            BNGetLowLevelILByIndex(self.function.handle, self.expr_idx)
+        };
+
+        let cloned_expr_idx = unsafe {
+            BNLowLevelILAddExpr(
+                self.function.handle,
+                expr.operation,
+                expr.size,
+                expr.flags,
+                expr.operands[0],
+                expr.operands[1],
+                expr.operands[2],
+                expr.operands[3],
+            )
+        };
+
+        Expression::new(self.function, cloned_expr_idx)
+    }
+}
+
 fn common_info<'func, A, M, F>(
     function: &'func Function<A, M, F>,
     op: BNLowLevelILInstruction,


### PR DESCRIPTION
This is the rust equivalent to python's [LowLevelILFunction.copy_expr](https://dev-api.binary.ninja/binaryninja.lowlevelil-module.html#binaryninja.lowlevelil.LowLevelILFunction.copy_expr). This is very useful when replacing expressions with the original expression being a child expression, as replacing the expression without recreating the original expression will lead to the child expression sharing the same expression index, causing any visitor to infinitely loop.

This allows you to `clone` the expression which effectively creates a new expression index for which you can slot into the replaced expression.