### PR TITLE
Create ExpressionBuilder from Expression

### DIFF
--- a/rust/src/llil/lifting.rs
+++ b/rust/src/llil/lifting.rs
@@ -607,6 +607,26 @@ where
     A: 'a + Architecture,
     R: ExpressionResultType,
 {
+    pub fn from_expr(expr: Expression<'a, A, Mutable, NonSSA<LiftedNonSSA>, R>) -> Self {
+        use binaryninjacore_sys::BNGetLowLevelILByIndex;
+
+        let instr = unsafe {
+            BNGetLowLevelILByIndex(expr.function.handle, expr.expr_idx)
+        };
+
+        ExpressionBuilder {
+            function: expr.function,
+            op: instr.operation,
+            size: instr.size,
+            flags: instr.flags,
+            op1: instr.operands[0],
+            op2: instr.operands[1],
+            op3: instr.operands[2],
+            op4: instr.operands[3],
+            _ty: PhantomData
+        }
+    }
+
     pub fn with_flag_write(mut self, flag_write: A::FlagWrite) -> Self {
         // TODO verify valid id
         self.flags = flag_write.id();


### PR DESCRIPTION
This is the rust equivalent to python's [LowLevelILFunction.copy_expr](https://dev-api.binary.ninja/binaryninja.lowlevelil-module.html#binaryninja.lowlevelil.LowLevelILFunction.copy_expr). This is very useful when replacing expressions with the original expression being a child expression, as replacing the expression without recreating the original expression will lead to the child expression sharing the same expression index, causing any visitor to infinitely loop.

Unlike [the previous PR](https://github.com/Vector35/binaryninja-api/pull/5634) this is implemented instead on the ExpressionBuilder, this allows greater flexibility and a more explicit API, instead of just implementing `Clone` and having it be implicitly write back to the IL, having an `ExpressionBuilder` be created allows you to discard the expression with no side-effects.