### PR TITLE
Rust: remove direct dependency on the `libc` crate

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -102,7 +102,6 @@ version = "0.1.0"
 dependencies = [
  "binaryninjacore-sys",
  "lazy_static",
- "libc",
  "log",
  "rayon",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -10,7 +10,6 @@ noexports = []
 [dependencies]
 lazy_static = "1.4.0"
 log = "0.4"
-libc = "0.2"
 rayon = { version = "1.8", optional = true }
 binaryninjacore-sys = { path = "binaryninjacore-sys" }
 

--- a/rust/src/binaryview.rs
+++ b/rust/src/binaryview.rs
@@ -268,15 +268,11 @@ pub trait BinaryViewExt: BinaryViewBase {
     }
 
     fn original_base(&self) -> u64 {
-        unsafe {
-            BNGetOriginalBase(self.as_ref().handle)
-        }
+        unsafe { BNGetOriginalBase(self.as_ref().handle) }
     }
 
     fn set_original_base(&self, base: u64) {
-        unsafe {
-            BNSetOriginalBase(self.as_ref().handle, base)
-        }
+        unsafe { BNSetOriginalBase(self.as_ref().handle, base) }
     }
 
     fn end(&self) -> u64 {
@@ -1411,10 +1407,7 @@ pub trait BinaryViewExt: BinaryViewBase {
         unsafe { BNRemoveComponentByGuid(self.as_ref().handle, path.as_ptr()) }
     }
 
-    fn data_variable_parent_components(
-        &self,
-        data_variable: &DataVariable,
-    ) -> Array<Component> {
+    fn data_variable_parent_components(&self, data_variable: &DataVariable) -> Array<Component> {
         let mut count = 0;
         let result = unsafe {
             BNGetDataVariableParentComponents(
@@ -1835,7 +1828,7 @@ where
     Handler: BinaryViewEventHandler,
 {
     unsafe extern "C" fn on_event<Handler: BinaryViewEventHandler>(
-        ctx: *mut ::std::os::raw::c_void,
+        ctx: *mut c_void,
         view: *mut BNBinaryView,
     ) {
         ffi_wrap!("EventHandler::on_event", {
@@ -1848,10 +1841,6 @@ where
     let raw = Box::into_raw(boxed);
 
     unsafe {
-        BNRegisterBinaryViewEvent(
-            event_type,
-            Some(on_event::<Handler>),
-            raw as *mut ::std::os::raw::c_void,
-        );
+        BNRegisterBinaryViewEvent(event_type, Some(on_event::<Handler>), raw as *mut c_void);
     }
 }

--- a/rust/src/callingconvention.rs
+++ b/rust/src/callingconvention.rs
@@ -15,19 +15,17 @@
 //! Contains and provides information about different systems' calling conventions to analysis.
 
 use std::borrow::Borrow;
+use std::ffi::c_void;
 use std::fmt::{Debug, Formatter};
 use std::marker::PhantomData;
 use std::mem;
-use std::os::raw::c_void;
 use std::ptr;
 use std::slice;
 
 use binaryninjacore_sys::*;
 
 use crate::architecture::{Architecture, ArchitectureExt, CoreArchitecture, Register};
-use crate::rc::{
-    CoreArrayProvider, CoreArrayProviderInner, Guard, Ref, RefCountable,
-};
+use crate::rc::{CoreArrayProvider, CoreArrayProviderInner, Guard, Ref, RefCountable};
 use crate::string::*;
 
 // TODO

--- a/rust/src/command.rs
+++ b/rust/src/command.rs
@@ -37,8 +37,8 @@ use binaryninjacore_sys::{
     BNRegisterPluginCommandForFunction, BNRegisterPluginCommandForRange,
 };
 
+use std::ffi::c_void;
 use std::ops::Range;
-use std::os::raw::c_void;
 
 use crate::binaryview::BinaryView;
 use crate::function::Function;

--- a/rust/src/custombinaryview.rs
+++ b/rust/src/custombinaryview.rs
@@ -18,10 +18,10 @@ use binaryninjacore_sys::*;
 
 pub use binaryninjacore_sys::BNModificationStatus as ModificationStatus;
 
+use std::ffi::c_void;
 use std::marker::PhantomData;
 use std::mem;
 use std::mem::MaybeUninit;
-use std::os::raw::c_void;
 use std::ptr;
 use std::slice;
 

--- a/rust/src/demangle.rs
+++ b/rust/src/demangle.rs
@@ -15,8 +15,7 @@
 //! Interfaces for demangling and simplifying mangled names in binaries.
 
 use binaryninjacore_sys::*;
-use std::os::raw::c_char;
-use std::{ffi::CStr, result};
+use std::ffi::{c_char, CStr};
 
 use crate::architecture::CoreArchitecture;
 use crate::string::{BnStrCompatible, BnString};
@@ -24,15 +23,12 @@ use crate::types::Type;
 
 use crate::rc::*;
 
-pub type Result<R> = result::Result<R, ()>;
+pub type Result<R> = std::result::Result<R, ()>;
 
-pub fn demangle_llvm<S: BnStrCompatible>(
-    mangled_name: S,
-    simplify: bool,
-) -> Result<Vec<String>> {
+pub fn demangle_llvm<S: BnStrCompatible>(mangled_name: S, simplify: bool) -> Result<Vec<String>> {
     let mangled_name_bwn = mangled_name.into_bytes_with_nul();
     let mangled_name_ptr = mangled_name_bwn.as_ref();
-    let mut out_name: *mut *mut std::os::raw::c_char = unsafe { std::mem::zeroed() };
+    let mut out_name: *mut *mut c_char = unsafe { std::mem::zeroed() };
     let mut out_size: usize = 0;
     let res = unsafe {
         BNDemangleLLVM(
@@ -77,7 +73,7 @@ pub fn demangle_gnu3<S: BnStrCompatible>(
     let mangled_name_bwn = mangled_name.into_bytes_with_nul();
     let mangled_name_ptr = mangled_name_bwn.as_ref();
     let mut out_type: *mut BNType = std::ptr::null_mut();
-    let mut out_name: *mut *mut std::os::raw::c_char = std::ptr::null_mut();
+    let mut out_name: *mut *mut c_char = std::ptr::null_mut();
     let mut out_size: usize = 0;
     let res = unsafe {
         BNDemangleGNU3(
@@ -133,7 +129,7 @@ pub fn demangle_ms<S: BnStrCompatible>(
     let mangled_name_ptr = mangled_name_bwn.as_ref();
 
     let mut out_type: *mut BNType = std::ptr::null_mut();
-    let mut out_name: *mut *mut std::os::raw::c_char = std::ptr::null_mut();
+    let mut out_name: *mut *mut c_char = std::ptr::null_mut();
     let mut out_size: usize = 0;
     let res = unsafe {
         BNDemangleMS(

--- a/rust/src/downloadprovider.rs
+++ b/rust/src/downloadprovider.rs
@@ -1,10 +1,9 @@
-use crate::rc::{Array, CoreArrayProvider, Guard, CoreArrayProviderInner, Ref, RefCountable};
+use crate::rc::{Array, CoreArrayProvider, CoreArrayProviderInner, Guard, Ref, RefCountable};
 use crate::settings::Settings;
 use crate::string::{BnStrCompatible, BnString};
 use binaryninjacore_sys::*;
 use std::collections::HashMap;
-use std::ffi::{c_void, CStr};
-use std::os::raw::c_char;
+use std::ffi::{c_char, c_void, CStr};
 use std::ptr::null_mut;
 use std::slice;
 

--- a/rust/src/fileaccessor.rs
+++ b/rust/src/fileaccessor.rs
@@ -27,7 +27,7 @@ impl<'a> FileAccessor<'a> {
     where
         F: 'a + Read + Write + Seek + Sized,
     {
-        use std::os::raw::c_void;
+        use std::ffi::c_void;
 
         extern "C" fn cb_get_length<F>(ctxt: *mut c_void) -> u64
         where

--- a/rust/src/filemetadata.rs
+++ b/rust/src/filemetadata.rs
@@ -49,6 +49,7 @@ use crate::database::Database;
 use crate::rc::*;
 use crate::string::*;
 
+use std::ffi::c_void;
 use std::ptr;
 
 #[derive(PartialEq, Eq, Hash)]
@@ -224,7 +225,7 @@ impl FileMetadata {
                 BNCreateDatabaseWithProgress(
                     handle,
                     filename_ptr,
-                    func as *mut libc::c_void,
+                    func as *mut c_void,
                     Some(cb_progress_func),
                     ptr::null_mut(),
                 )
@@ -273,7 +274,7 @@ impl FileMetadata {
                 BNOpenExistingDatabaseWithProgress(
                     self.handle,
                     filename_ptr,
-                    func as *mut libc::c_void,
+                    func as *mut c_void,
                     Some(cb_progress_func),
                 )
             },
@@ -313,11 +314,7 @@ unsafe impl RefCountable for FileMetadata {
     }
 }
 
-unsafe extern "C" fn cb_progress_func(
-    ctxt: *mut ::std::os::raw::c_void,
-    progress: usize,
-    total: usize,
-) -> bool {
+unsafe extern "C" fn cb_progress_func(ctxt: *mut c_void, progress: usize, total: usize) -> bool {
     let func: fn(usize, usize) -> bool = core::mem::transmute(ctxt);
     func(progress, total)
 }

--- a/rust/src/functionrecognizer.rs
+++ b/rust/src/functionrecognizer.rs
@@ -3,7 +3,7 @@ use crate::{
     architecture::CoreArchitecture, binaryview::BinaryView, function::Function, llil, mlil,
 };
 use binaryninjacore_sys::*;
-use std::os::raw::c_void;
+use std::ffi::c_void;
 
 pub trait FunctionRecognizer {
     fn recognize_low_level_il(

--- a/rust/src/headless.rs
+++ b/rust/src/headless.rs
@@ -13,8 +13,7 @@
 // limitations under the License.
 
 use crate::{
-    binaryview,
-    rc,
+    binaryview, rc,
     string::{BnStrCompatible, IntoJson},
 };
 
@@ -23,17 +22,16 @@ use std::path::PathBuf;
 
 #[cfg(not(target_os = "windows"))]
 fn binja_path() -> PathBuf {
-    use std::ffi::{CStr, OsStr};
+    use std::ffi::{c_char, c_void, CStr, OsStr};
     use std::mem;
-    use std::os::raw;
     use std::os::unix::ffi::OsStrExt;
 
     #[repr(C)]
     struct DlInfo {
-        dli_fname: *const raw::c_char,
-        dli_fbase: *mut raw::c_void,
-        dli_sname: *const raw::c_char,
-        dli_saddr: *mut raw::c_void,
+        dli_fname: *const c_char,
+        dli_fbase: *mut c_void,
+        dli_sname: *const c_char,
+        dli_saddr: *mut c_void,
     }
 
     if let Ok(p) = env::var("BINJA_DIR") {
@@ -41,7 +39,7 @@ fn binja_path() -> PathBuf {
     }
 
     extern "C" {
-        fn dladdr(addr: *mut raw::c_void, info: *mut DlInfo) -> raw::c_int;
+        fn dladdr(addr: *mut c_void, info: *mut DlInfo) -> i32;
     }
 
     unsafe {

--- a/rust/src/interaction.rs
+++ b/rust/src/interaction.rs
@@ -16,8 +16,7 @@
 
 use binaryninjacore_sys::*;
 
-use std::ffi::CStr;
-use std::os::raw::{c_char, c_void};
+use std::ffi::{c_char, c_void, CStr};
 use std::path::PathBuf;
 
 use crate::binaryview::BinaryView;
@@ -25,7 +24,7 @@ use crate::rc::Ref;
 use crate::string::{BnStrCompatible, BnString};
 
 pub fn get_text_line_input(prompt: &str, title: &str) -> Option<String> {
-    let mut value: *mut libc::c_char = std::ptr::null_mut();
+    let mut value: *mut c_char = std::ptr::null_mut();
 
     let result = unsafe {
         BNGetTextLineInput(
@@ -80,7 +79,7 @@ pub fn get_address_input(prompt: &str, title: &str) -> Option<u64> {
 }
 
 pub fn get_open_filename_input(prompt: &str, extension: &str) -> Option<PathBuf> {
-    let mut value: *mut libc::c_char = std::ptr::null_mut();
+    let mut value: *mut c_char = std::ptr::null_mut();
 
     let result = unsafe {
         BNGetOpenFileNameInput(
@@ -98,7 +97,7 @@ pub fn get_open_filename_input(prompt: &str, extension: &str) -> Option<PathBuf>
 }
 
 pub fn get_save_filename_input(prompt: &str, title: &str, default_name: &str) -> Option<PathBuf> {
-    let mut value: *mut libc::c_char = std::ptr::null_mut();
+    let mut value: *mut c_char = std::ptr::null_mut();
 
     let result = unsafe {
         BNGetSaveFileNameInput(
@@ -117,7 +116,7 @@ pub fn get_save_filename_input(prompt: &str, title: &str, default_name: &str) ->
 }
 
 pub fn get_directory_name_input(prompt: &str, default_name: &str) -> Option<PathBuf> {
-    let mut value: *mut libc::c_char = std::ptr::null_mut();
+    let mut value: *mut c_char = std::ptr::null_mut();
 
     let result = unsafe {
         BNGetDirectoryNameInput(

--- a/rust/src/logger.rs
+++ b/rust/src/logger.rs
@@ -33,8 +33,7 @@ pub use binaryninjacore_sys::BNLogLevel as Level;
 use binaryninjacore_sys::{BNLogListener, BNUpdateLogListeners};
 
 use log;
-use std::ffi::CStr;
-use std::os::raw::{c_char, c_void};
+use std::ffi::{c_char, c_void, CStr};
 
 struct Logger;
 static LOGGER: Logger = Logger;

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -2,7 +2,7 @@ use crate::rc::{Array, CoreArrayProvider, CoreArrayProviderInner, Guard, Ref, Re
 use crate::string::{BnStrCompatible, BnString, IntoJson};
 use binaryninjacore_sys::*;
 use std::collections::HashMap;
-use std::os::raw::c_char;
+use std::ffi::c_char;
 use std::slice;
 
 pub type MetadataType = BNMetadataType;

--- a/rust/src/platform.rs
+++ b/rust/src/platform.rs
@@ -14,7 +14,7 @@
 
 //! Contains all information related to the execution environment of the binary, mainly the calling conventions used
 
-use std::{borrow::Borrow, collections::HashMap, os::raw, path::Path, ptr, slice};
+use std::{borrow::Borrow, collections::HashMap, path::Path, ptr, slice};
 
 use binaryninjacore_sys::*;
 
@@ -291,7 +291,7 @@ impl TypeParser for Platform {
 
         let mut type_parser_result = TypeParserResult::default();
 
-        let mut error_string: *mut raw::c_char = ptr::null_mut();
+        let mut error_string = ptr::null_mut();
 
         let src = source.into_bytes_with_nul();
         let filename = filename.into_bytes_with_nul();

--- a/rust/src/relocation.rs
+++ b/rust/src/relocation.rs
@@ -9,8 +9,8 @@ use crate::{
 };
 use binaryninjacore_sys::*;
 use std::borrow::Borrow;
+use std::ffi::c_void;
 use std::mem::MaybeUninit;
-use std::os::raw::c_void;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum RelocationType {
@@ -500,7 +500,9 @@ where
 
     let name = name.into_bytes_with_nul();
 
-    let raw = Box::leak(Box::new(MaybeUninit::<RelocationHandlerBuilder<_>>::zeroed()));
+    let raw = Box::leak(Box::new(
+        MaybeUninit::<RelocationHandlerBuilder<_>>::zeroed(),
+    ));
     let mut custom_handler = BNCustomRelocationHandler {
         context: raw.as_mut_ptr() as *mut _,
         freeObject: Some(cb_free::<R>),

--- a/rust/src/settings.rs
+++ b/rust/src/settings.rs
@@ -16,8 +16,8 @@
 
 pub use binaryninjacore_sys::BNSettingsScope as SettingsScope;
 use binaryninjacore_sys::*;
+use std::ffi::c_char;
 use std::iter::FromIterator;
-use std::os::raw::c_char;
 
 use crate::binaryview::BinaryView;
 use crate::rc::*;

--- a/rust/src/string.rs
+++ b/rust/src/string.rs
@@ -15,17 +15,16 @@
 //! String wrappers for core-owned strings and strings being passed to the core
 
 use std::borrow::Cow;
-use std::ffi::{CStr, CString};
+use std::ffi::{c_char, CStr, CString};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::mem;
 use std::ops::Deref;
-use std::os::raw;
 
 use crate::rc::*;
 use crate::types::QualifiedName;
 
-pub(crate) fn raw_to_string(ptr: *const raw::c_char) -> Option<String> {
+pub(crate) fn raw_to_string(ptr: *const c_char) -> Option<String> {
     if ptr.is_null() {
         None
     } else {
@@ -37,7 +36,7 @@ pub(crate) fn raw_to_string(ptr: *const raw::c_char) -> Option<String> {
 /// functions provided by binaryninja_sys.
 #[repr(transparent)]
 pub struct BnString {
-    raw: *mut raw::c_char,
+    raw: *mut c_char,
 }
 
 /// A nul-terminated C string allocated by the core.
@@ -65,11 +64,11 @@ impl BnString {
     }
 
     /// Construct a BnString from an owned const char* allocated by BNAllocString
-    pub(crate) unsafe fn from_raw(raw: *mut raw::c_char) -> Self {
+    pub(crate) unsafe fn from_raw(raw: *mut c_char) -> Self {
         Self { raw }
     }
 
-    pub(crate) fn into_raw(self) -> *mut raw::c_char {
+    pub(crate) fn into_raw(self) -> *mut c_char {
         let res = self.raw;
 
         // we're surrendering ownership over the *mut c_char to
@@ -162,7 +161,7 @@ impl fmt::Debug for BnString {
 }
 
 impl CoreArrayProvider for BnString {
-    type Raw = *mut raw::c_char;
+    type Raw = *mut c_char;
     type Context = ();
     type Wrapped<'a> = &'a str;
 }

--- a/rust/src/typearchive.rs
+++ b/rust/src/typearchive.rs
@@ -884,9 +884,9 @@ where
 }
 
 unsafe extern "C" fn cb_type_added<T: TypeArchiveNotificationCallback>(
-    ctxt: *mut ::std::os::raw::c_void,
+    ctxt: *mut ffi::c_void,
     archive: *mut BNTypeArchive,
-    id: *const ::std::os::raw::c_char,
+    id: *const ffi::c_char,
     definition: *mut BNType,
 ) {
     let ctxt: &mut T = &mut *(ctxt as *mut T);
@@ -897,9 +897,9 @@ unsafe extern "C" fn cb_type_added<T: TypeArchiveNotificationCallback>(
     )
 }
 unsafe extern "C" fn cb_type_updated<T: TypeArchiveNotificationCallback>(
-    ctxt: *mut ::std::os::raw::c_void,
+    ctxt: *mut ffi::c_void,
     archive: *mut BNTypeArchive,
-    id: *const ::std::os::raw::c_char,
+    id: *const ffi::c_char,
     old_definition: *mut BNType,
     new_definition: *mut BNType,
 ) {
@@ -916,9 +916,9 @@ unsafe extern "C" fn cb_type_updated<T: TypeArchiveNotificationCallback>(
     )
 }
 unsafe extern "C" fn cb_type_renamed<T: TypeArchiveNotificationCallback>(
-    ctxt: *mut ::std::os::raw::c_void,
+    ctxt: *mut ffi::c_void,
     archive: *mut BNTypeArchive,
-    id: *const ::std::os::raw::c_char,
+    id: *const ffi::c_char,
     old_name: *const BNQualifiedName,
     new_name: *const BNQualifiedName,
 ) {
@@ -933,9 +933,9 @@ unsafe extern "C" fn cb_type_renamed<T: TypeArchiveNotificationCallback>(
     )
 }
 unsafe extern "C" fn cb_type_deleted<T: TypeArchiveNotificationCallback>(
-    ctxt: *mut ::std::os::raw::c_void,
+    ctxt: *mut ffi::c_void,
     archive: *mut BNTypeArchive,
-    id: *const ::std::os::raw::c_char,
+    id: *const ffi::c_char,
     definition: *mut BNType,
 ) {
     let ctxt: &mut T = &mut *(ctxt as *mut T);

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -31,17 +31,15 @@ use crate::{
 };
 
 use lazy_static::lazy_static;
-use std::ptr::null_mut;
 use std::{
     borrow::{Borrow, Cow},
     collections::{HashMap, HashSet},
-    ffi::CStr,
+    ffi::{c_char, CStr},
     fmt::{self, Debug, Display, Formatter},
     hash::{Hash, Hasher},
     iter::{zip, IntoIterator},
     mem::{self, ManuallyDrop},
     ops::Range,
-    os::raw::c_char,
     ptr, result, slice,
     sync::Mutex,
 };
@@ -1252,7 +1250,7 @@ impl fmt::Debug for Type {
 
                 let mut name = QualifiedName::from("");
 
-                let mut lines: *mut BNTypeDefinitionLine = null_mut();
+                let mut lines: *mut BNTypeDefinitionLine = ptr::null_mut();
                 let mut count: usize = 0;
 
                 unsafe {

--- a/rust/src/update.rs
+++ b/rust/src/update.rs
@@ -254,16 +254,12 @@ pub fn updates_checked() {
     unsafe { BNUpdatesChecked() }
 }
 
-unsafe extern "C" fn cb_progress_nop(
-    _ctxt: *mut ::std::os::raw::c_void,
-    _progress: u64,
-    _total: u64,
-) -> bool {
+unsafe extern "C" fn cb_progress_nop(_ctxt: *mut ffi::c_void, _progress: u64, _total: u64) -> bool {
     true
 }
 
 unsafe extern "C" fn cb_progress<F: FnMut(u64, u64) -> bool>(
-    ctxt: *mut ::std::os::raw::c_void,
+    ctxt: *mut ffi::c_void,
     progress: u64,
     total: u64,
 ) -> bool {


### PR DESCRIPTION
Almost all uses of the `libc` crate were to import types that the standard library already provides, e.g. `c_void`, `c_char`, etc. We can import those from `std::ffi`. In some places they were being imported from `std::os::raw`, so I changed those imports as well, as they are just type aliases for the definitions in `std::ffi` anyways.

One nontrivial case where `libc` was being used was inside `cb_{free_}flag_conditions_for_semantic_flag_group`, which used `libc::{malloc, free}`. This was changed to use `std::alloc::{alloc, dealloc}` and required some hacky layout calculations in order to smuggle the length of the allocated array across the FFI boundary. 

Getting rid of this hack would require for the Core API to change such that a `count: usize` parameter is passed to `cb_free_flag_conditions_for_semantic_flag_group` (and ideally also to `cb_free_register_list`) so that no smuggling would be required and we could just call `Box::from_raw(ptr::slice_from_raw_parts_mut(conds, count))` and be done. I'll open a separate issue for that.