### PR TITLE
Fix TagType::set_icon so that it actually sets a tag type's icon

### DIFF
--- a/rust/src/tags.rs
+++ b/rust/src/tags.rs
@@ -132,7 +132,7 @@ impl TagType {
     pub fn set_icon<S: BnStrCompatible>(&self, icon: S) {
         let icon = icon.into_bytes_with_nul();
         unsafe {
-            BNTagTypeSetName(self.handle, icon.as_ref().as_ptr() as *mut _);
+            BNTagTypeSetIcon(self.handle, icon.as_ref().as_ptr() as *mut _);
         }
     }
 


### PR DESCRIPTION
Hi!

It's not currently possible to set a tag type's icon using the Rust API because of a small typo.  
This MR addresses the issue.

Best regards,
Erwan