### PR TITLE
Update bindgen to fix building with llvm 18

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -116,17 +116,17 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.68.1"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "726e4313eb6ec35d2730258ad4e15b547ee75d6afaa1361a922e78e59b7d8078"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
+ "itertools",
  "lazy_static",
  "lazycell",
  "log",
- "peeking_take_while",
  "prettyplease",
  "proc-macro2",
  "quote",
@@ -724,12 +724,6 @@ dependencies = [
  "pdb",
  "regex",
 ]
-
-[[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pin-project-lite"

--- a/rust/binaryninjacore-sys/Cargo.toml
+++ b/rust/binaryninjacore-sys/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Ryan Snyder <ryan@vector35.com>", "Kyle Martin <kyle@vector35.com>"]
 build = "build.rs"
 
 [build-dependencies]
-bindgen = "^0.68"
+bindgen = "^0.69.2"


### PR DESCRIPTION
LLVM 18 broke compatibility with bindgen 0.68 by fixing a longstanding bug (see [slack](https://binaryninja.slack.com/archives/C0CVALTLN/p1720413586596999?thread_ts=1720409858.417409&cid=C0CVALTLN) discussion), and this issue was fixed in 0.69.2.