### PR TITLE
Remove sysv calling convention

### DIFF
--- a/platform/efi/platform_efi.cpp
+++ b/platform/efi/platform_efi.cpp
@@ -112,10 +112,6 @@ public:
 			RegisterFastcallCallingConvention(cc);
 			RegisterStdcallCallingConvention(cc);
 		}
-
-		// Linux-style calling convention is sometimes used internally by EFI applications
-		cc = arch->GetCallingConventionByName("sysv");
-		RegisterCallingConvention(cc);
 	}
 
 	static Ref<Platform> Recognize(BinaryView* view, Metadata* metadata)
@@ -145,10 +141,6 @@ public:
 			RegisterFastcallCallingConvention(cc);
 			RegisterStdcallCallingConvention(cc);
 		}
-
-		// Linux-style calling convention is sometimes used internally by EFI applications
-		cc = arch->GetCallingConventionByName("sysv");
-		RegisterCallingConvention(cc);
 	}
 
 	static Ref<Platform> Recognize(BinaryView* view, Metadata* metadata)


### PR DESCRIPTION
Adding `sysv` calling convention introduces a lot of false positives during analysis. Defined in the UEFI Specification, X64 follows the same calling convention as `win64` calling convention.

https://uefi.org/specs/UEFI/2.9_A/02_Overview.html#detailed-calling-conventions

If still possible for users to set the calling convention to `sysv` in function properties widget.