### PR TITLE
Add `VariableSourceType` type alias

### DIFF
--- a/rust/examples/dwarf/dwarf_import/src/dwarfdebuginfo.rs
+++ b/rust/examples/dwarf/dwarf_import/src/dwarfdebuginfo.rs
@@ -21,8 +21,7 @@ use binaryninja::{
     rc::*,
     symbol::SymbolType,
     templatesimplifier::simplify_str_to_fqn,
-    types::{Conf, FunctionParameter, NamedTypedVariable, Type, Variable},
-    binaryninjacore_sys::BNVariableSourceType,
+    types::{Conf, FunctionParameter, NamedTypedVariable, Type, Variable, VariableSourceType},
 };
 
 use gimli::{DebuggingInformationEntry, Dwarf, Unit};
@@ -415,7 +414,7 @@ impl DebugInfoBuilder {
             return;
         }
 
-        let var = Variable::new(BNVariableSourceType::StackVariableSourceType, 0, adjusted_offset);
+        let var = Variable::new(VariableSourceType::StackVariableSourceType, 0, adjusted_offset);
         function.stack_variables.push(NamedTypedVariable::new(var, name, t, false));
 
     }

--- a/rust/examples/pdb-ng/src/symbol_parser.rs
+++ b/rust/examples/pdb-ng/src/symbol_parser.rs
@@ -35,13 +35,12 @@ use pdb::{
 };
 
 use binaryninja::architecture::{Architecture, ArchitectureExt, Register};
-use binaryninja::binaryninjacore_sys::BNVariableSourceType;
 use binaryninja::binaryview::BinaryViewBase;
 use binaryninja::demangle::demangle_ms;
 use binaryninja::rc::Ref;
 use binaryninja::types::{
     max_confidence, min_confidence, Conf, ConfMergable, FunctionParameter, QualifiedName,
-    StructureBuilder, Type, TypeClass, Variable,
+    StructureBuilder, Type, TypeClass, Variable, VariableSourceType,
 };
 
 use crate::PDBParserInstance;
@@ -736,7 +735,7 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
         let storage = if let Some(reg) = self.convert_register(data.register) {
             vec![ParsedLocation {
                 location: Variable {
-                    t: BNVariableSourceType::RegisterVariableSourceType,
+                    t: VariableSourceType::RegisterVariableSourceType,
                     index: 0,
                     storage: reg,
                 },
@@ -1425,7 +1424,7 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
                     type_: self.lookup_type_conf(&data.type_index, false)?,
                     storage: vec![ParsedLocation {
                         location: Variable {
-                            t: BNVariableSourceType::StackVariableSourceType,
+                            t: VariableSourceType::StackVariableSourceType,
                             index: 0,
                             storage: data.offset as i64,
                         },
@@ -1443,7 +1442,7 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
                     type_: self.lookup_type_conf(&data.type_index, false)?,
                     storage: vec![ParsedLocation {
                         location: Variable {
-                            t: BNVariableSourceType::StackVariableSourceType,
+                            t: VariableSourceType::StackVariableSourceType,
                             index: 0,
                             storage: data.offset as i64,
                         },
@@ -1587,7 +1586,7 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
         if let Some(reg) = self.convert_register(data.register) {
             Ok(Some(ParsedSymbol::Location(ParsedLocation {
                 location: Variable {
-                    t: BNVariableSourceType::RegisterVariableSourceType,
+                    t: VariableSourceType::RegisterVariableSourceType,
                     index: 0,
                     storage: reg,
                 },
@@ -1654,7 +1653,7 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
             type_: self.lookup_type_conf(&data.type_index, false)?,
             storage: vec![ParsedLocation {
                 location: Variable {
-                    t: BNVariableSourceType::StackVariableSourceType,
+                    t: VariableSourceType::StackVariableSourceType,
                     index: 0,
                     storage: data.offset as i64,
                 },
@@ -1696,14 +1695,14 @@ impl<'a, S: Source<'a> + 'a> PDBParserInstance<'a, S> {
                     for loc in &new_storage {
                         match loc {
                             Variable {
-                                t: BNVariableSourceType::RegisterVariableSourceType,
+                                t: VariableSourceType::RegisterVariableSourceType,
                                 ..
                             } => {
                                 // Assume register vars are always parameters
                                 really_is_param = true;
                             }
                             Variable {
-                                t: BNVariableSourceType::StackVariableSourceType,
+                                t: VariableSourceType::StackVariableSourceType,
                                 storage,
                                 ..
                             } if *storage >= 0 => {

--- a/rust/src/types.rs
+++ b/rust/src/types.rs
@@ -55,6 +55,7 @@ pub type MemberAccess = BNMemberAccess;
 pub type MemberScope = BNMemberScope;
 pub type ILBranchDependence = BNILBranchDependence;
 pub type DataFlowQueryOption = BNDataFlowQueryOption;
+pub type VariableSourceType = BNVariableSourceType;
 
 ////////////////
 // Confidence
@@ -1378,9 +1379,9 @@ impl FunctionParameter {
 
     pub(crate) fn from_raw(member: BNFunctionParameter) -> Self {
         let name = if member.name.is_null() {
-            if member.location.type_ == BNVariableSourceType::RegisterVariableSourceType {
+            if member.location.type_ == VariableSourceType::RegisterVariableSourceType {
                 format!("reg_{}", member.location.storage)
-            } else if member.location.type_ == BNVariableSourceType::StackVariableSourceType {
+            } else if member.location.type_ == VariableSourceType::StackVariableSourceType {
                 format!("arg_{}", member.location.storage)
             } else {
                 String::new()
@@ -1412,13 +1413,13 @@ impl FunctionParameter {
 
 #[derive(Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub struct Variable {
-    pub t: BNVariableSourceType,
+    pub t: VariableSourceType,
     pub index: u32,
     pub storage: i64,
 }
 
 impl Variable {
-    pub fn new(t: BNVariableSourceType, index: u32, storage: i64) -> Self {
+    pub fn new(t: VariableSourceType, index: u32, storage: i64) -> Self {
         Self { t, index, storage }
     }
 


### PR DESCRIPTION
To avoid having to import `BNVariableSourceType` from `binaryninja::binaryninjacore_sys` when constructing a `Variable`.