### PR TITLE
BinaryView and platforms for VxWorks

### DIFF
--- a/platform/vxworks/CMakeLists.txt
+++ b/platform/vxworks/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+
+project(platform_vxworks)
+
+if(NOT BN_INTERNAL_BUILD)
+	add_subdirectory(${PROJECT_SOURCE_DIR}/../.. ${PROJECT_BINARY_DIR}/api)
+endif()
+
+file(GLOB SOURCES
+	*.cpp
+	*.h)
+
+if(DEMO)
+	add_library(platform_vxworks STATIC ${SOURCES})
+else()
+	add_library(platform_vxworks SHARED ${SOURCES})
+endif()
+
+target_link_libraries(platform_vxworks binaryninjaapi)
+
+set_target_properties(platform_vxworks PROPERTIES
+    CXX_STANDARD 17
+	CXX_VISIBILITY_PRESET hidden
+	CXX_STANDARD_REQUIRED ON
+    VISIBILITY_INLINES_HIDDEN ON
+	POSITION_INDEPENDENT_CODE ON)
+
+if(BN_INTERNAL_BUILD)
+	plugin_rpath(platform_vxworks)
+	set_target_properties(platform_vxworks PROPERTIES
+		LIBRARY_OUTPUT_DIRECTORY ${BN_CORE_PLUGIN_DIR}
+		RUNTIME_OUTPUT_DIRECTORY ${BN_CORE_PLUGIN_DIR})
+endif()

--- a/platform/vxworks/platform_vxworks.cpp
+++ b/platform/vxworks/platform_vxworks.cpp
@@ -1,0 +1,183 @@
+#include "binaryninjaapi.h"
+
+using namespace BinaryNinja;
+using namespace std;
+
+Ref<Platform> g_vxWorksX86, g_vxWorksX64, g_vxWorksArm, g_vxWorksArm64, g_vxWorksThumb;
+Ref<Platform> g_vxWorksMips32, g_vxWorksMips64, g_vxWorksPpc32, g_vxWorksPpc64;
+Ref<Platform> g_vxWorksRiscV32, g_vxWorksRiscv64;
+
+
+class VxWorksIntelPlatform : public Platform
+{
+public:
+    VxWorksIntelPlatform(Architecture* arch, const std::string& name) : Platform(arch, name)
+    {
+        Ref<CallingConvention> cc;
+        cc = arch->GetCallingConventionByName("cdecl");
+        if (cc)
+        {
+            RegisterDefaultCallingConvention(cc);
+            RegisterCdeclCallingConvention(cc);
+			RegisterFastcallCallingConvention(cc);
+            RegisterStdcallCallingConvention(cc);
+        }
+    }
+};
+
+class VxWorksArmPlatform : public Platform
+{
+public:
+    VxWorksArmPlatform(Architecture* arch, const std::string& name) : Platform(arch, name)
+    {
+        Ref<CallingConvention> cc;
+        cc = arch->GetCallingConventionByName("cdecl");
+        if (cc)
+        {
+            RegisterDefaultCallingConvention(cc);
+            RegisterCdeclCallingConvention(cc);
+			RegisterFastcallCallingConvention(cc);
+			RegisterStdcallCallingConvention(cc);
+        }
+    }
+};
+
+class VxWorksMipsPlatform : public Platform
+{
+public:
+    VxWorksMipsPlatform(Architecture* arch, const std::string& name) : Platform(arch, name)
+    {
+        Ref<CallingConvention> cc;
+		cc = arch->GetCallingConventionByName("o32");
+		if (cc)
+		{
+			RegisterDefaultCallingConvention(cc);
+			RegisterCdeclCallingConvention(cc);
+			RegisterFastcallCallingConvention(cc);
+			RegisterStdcallCallingConvention(cc);
+		}
+    }
+};
+
+class VxWorksPpcPlatform : public Platform
+{
+public:
+	VxWorksPpcPlatform(Architecture* arch, const std::string& name): Platform(arch, name)
+	{
+		Ref<CallingConvention> cc;
+		cc = arch->GetCallingConventionByName("svr4");
+		if (cc)
+			RegisterDefaultCallingConvention(cc);
+	}
+};
+
+class VxWorksRiscVPlatform : public Platform
+{
+public:
+    VxWorksRiscVPlatform(Architecture* arch, const std::string& name): Platform(arch, name)
+    {
+        Ref<CallingConvention> cc;
+        cc = arch->GetCallingConventionByName("default");
+        if (cc)
+        {
+			RegisterDefaultCallingConvention(cc);
+			RegisterCdeclCallingConvention(cc);
+			RegisterFastcallCallingConvention(cc);
+			RegisterStdcallCallingConvention(cc);
+        }
+    }
+};
+
+extern "C"
+{
+	BN_DECLARE_CORE_ABI_VERSION
+
+#ifndef DEMO_VERSION
+	BINARYNINJAPLUGIN void CorePluginDependencies()
+	{
+		AddOptionalPluginDependency("arch_x86");
+		AddOptionalPluginDependency("arch_armv7");
+		AddOptionalPluginDependency("arch_arm64");
+		AddOptionalPluginDependency("arch_mips");
+		AddOptionalPluginDependency("arch_ppc");
+		AddOptionalPluginDependency("arch_riscv");
+	}
+#endif
+
+#ifdef DEMO_VERSION
+    bool VxWorksPluginInit()
+#else
+    BINARYNINJAPLUGIN bool CorePluginInit()
+#endif
+    {
+        Ref<BinaryViewType> vx = BinaryViewType::GetByName("VxWorks");
+        if (!vx)
+            return true;
+
+        Ref<Architecture> x86 = Architecture::GetByName("x86");
+        Ref<Architecture> x64 = Architecture::GetByName("x86_64");
+        if (x86 && x64)
+        {
+            g_vxWorksX86 = new VxWorksIntelPlatform(x86, "vxworks-x86");
+            Platform::Register("vxworks", g_vxWorksX86);
+			BinaryViewType::RegisterDefaultPlatform("VxWorks", x86, g_vxWorksX86);
+            g_vxWorksX64 = new VxWorksIntelPlatform(x64, "vxworks-x86_64");
+            Platform::Register("vxworks", g_vxWorksX64);
+			BinaryViewType::RegisterDefaultPlatform("VxWorks", x64, g_vxWorksX64);
+        }
+
+        Ref<Architecture> armv7 = Architecture::GetByName("armv7");
+        Ref<Architecture> thumb2 = Architecture::GetByName("thumb2");
+        Ref<Architecture> arm64 = Architecture::GetByName("aarch64");
+        if (armv7 && thumb2)
+        {
+            g_vxWorksArm = new VxWorksArmPlatform(armv7, "vxworks-armv7");
+            Platform::Register("vxworks", g_vxWorksArm);
+			BinaryViewType::RegisterDefaultPlatform("VxWorks", armv7, g_vxWorksArm);
+            g_vxWorksThumb = new VxWorksArmPlatform(thumb2, "vxworks-thumb2");
+            Platform::Register("vxworks", g_vxWorksThumb);
+			BinaryViewType::RegisterDefaultPlatform("VxWorks", thumb2, g_vxWorksThumb);
+            g_vxWorksArm64 = new VxWorksArmPlatform(arm64, "vxworks-aarch64");
+            Platform::Register("vxworks", g_vxWorksArm64);
+            BinaryViewType::RegisterDefaultPlatform("VxWorks", arm64, g_vxWorksArm64);
+        }
+
+		Ref<Architecture> mips32 = Architecture::GetByName("mips32");
+        Ref<Architecture> mips64 = Architecture::GetByName("mips64");
+		if (mips64 && mips32)
+		{
+            g_vxWorksMips32 = new VxWorksMipsPlatform(mips32, "vxworks-mips32");
+            Platform::Register("vxworks", g_vxWorksMips32);
+			BinaryViewType::RegisterDefaultPlatform("VxWorks", mips32, g_vxWorksMips32);
+            g_vxWorksMips64 = new VxWorksMipsPlatform(mips64, "vxworks-mips64");
+            Platform::Register("vxworks", g_vxWorksMips64);
+			BinaryViewType::RegisterDefaultPlatform("VxWorks", mips64, g_vxWorksMips64);
+        }
+
+        Ref<Architecture> ppc32 = Architecture::GetByName("ppc");
+        Ref<Architecture> ppc64 = Architecture::GetByName("ppc64");
+        if (ppc32 && ppc64)
+        {
+            g_vxWorksPpc32 = new VxWorksPpcPlatform(ppc32, "vxworks-ppc32");
+            Platform::Register("vxworks", g_vxWorksPpc32);
+			BinaryViewType::RegisterDefaultPlatform("VxWorks", ppc32, g_vxWorksPpc32);
+            g_vxWorksPpc64 = new VxWorksPpcPlatform(ppc64, "vxworks-ppc64");
+            Platform::Register("vxworks", g_vxWorksPpc64);
+			BinaryViewType::RegisterDefaultPlatform("VxWorks", ppc64, g_vxWorksPpc64);
+        }
+
+        Ref<Architecture> riscv32 = Architecture::GetByName("rv32gc");
+        Ref<Architecture> riscv64 = Architecture::GetByName("rv64gc");
+        if (riscv32 && riscv64)
+        {
+            g_vxWorksRiscV32 = new VxWorksRiscVPlatform(riscv32, "vxworks-rv32gc");
+            Platform::Register("vxworks", g_vxWorksRiscV32);
+			BinaryViewType::RegisterDefaultPlatform("VxWorks", riscv32, g_vxWorksRiscV32);
+            g_vxWorksRiscv64 = new VxWorksRiscVPlatform(riscv64, "vxworks-rv64gc");
+            Platform::Register("vxworks", g_vxWorksRiscv64);
+			BinaryViewType::RegisterDefaultPlatform("VxWorks", riscv64, g_vxWorksRiscv64);
+        }
+
+        return true;
+    }
+}

--- a/view/vxworks/CMakeLists.txt
+++ b/view/vxworks/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+
+project(view_vxworks)
+
+if(NOT BN_INTERNAL_BUILD)
+    add_subdirectory(${PROJECT_SOURCE_DIR}/../.. ${PROJECT_BINARY_DIR}/api)
+endif()
+
+file(GLOB SOURCES
+        *.cpp
+        *.h)
+
+if(DEMO)
+    add_library(view_vxworks STATIC ${SOURCES})
+else()
+    add_library(view_vxworks SHARED ${SOURCES})
+endif()
+
+target_link_libraries(view_vxworks binaryninjaapi)
+
+set_target_properties(view_vxworks PROPERTIES
+        CXX_STANDARD 17
+        CXX_VISIBILITY_PRESET hidden
+        CXX_STANDARD_REQUIRED ON
+        VISIBILITY_INLINES_HIDDEN ON
+        POSITION_INDEPENDENT_CODE ON)
+
+if(BN_INTERNAL_BUILD)
+    plugin_rpath(view_vxworks)
+    set_target_properties(view_vxworks PROPERTIES
+            LIBRARY_OUTPUT_DIRECTORY ${BN_CORE_PLUGIN_DIR}
+            RUNTIME_OUTPUT_DIRECTORY ${BN_CORE_PLUGIN_DIR})
+endif()

--- a/view/vxworks/LICENSE
+++ b/view/vxworks/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2021-2024 Vector 35 Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/view/vxworks/vxworksview.cpp
+++ b/view/vxworks/vxworksview.cpp
@@ -1,0 +1,465 @@
+// BinaryView for VxWorks Real-Time Operating System (RTOS) images
+
+#include "vxworksview.h"
+
+using namespace BinaryNinja;
+using namespace std;
+
+static VxWorksViewType* g_vxWorksViewType = nullptr;
+
+#define NEW_CDM_SIGNATURE_OFFSET 0x0
+#define NEW_CDM_SIGNATURE_SIZE 0xb
+#define PACKAGED_CDM_SIGNATURE_SIZE 0x3
+#define PACKAGED_CDM_SIGNATURE_OFFSET 0x50
+static VxWorksImageType IdentifyVxWorksImageType(BinaryReader* reader)
+{
+    reader->Seek(0);
+    uint32_t magic;
+    if (!reader->TryRead32(magic))
+        return VxWorksUnsupportedImageType;
+
+    if (magic == 0x7c6000a6 || magic == 0x7c631a78)
+        return VxWorksStandardImageType;
+
+    uint8_t newCDMSignature[NEW_CDM_SIGNATURE_SIZE];
+    reader->Seek(NEW_CDM_SIGNATURE_OFFSET);
+    if (!reader->TryRead(newCDMSignature, NEW_CDM_SIGNATURE_SIZE))
+        return VxWorksUnsupportedImageType;
+    if (memcmp(newCDMSignature, "vxWorks.pkg", NEW_CDM_SIGNATURE_SIZE) == 0)
+        return VxWorksCDMNewImageType;
+
+    uint8_t oldCMSSignature[PACKAGED_CDM_SIGNATURE_SIZE];
+    reader->Seek(PACKAGED_CDM_SIGNATURE_OFFSET);
+    if (!reader->TryRead(oldCMSSignature, PACKAGED_CDM_SIGNATURE_SIZE))
+        return VxWorksUnsupportedImageType;
+    if (memcmp(oldCMSSignature, "CDM", PACKAGED_CDM_SIGNATURE_SIZE) == 0)
+        return VxWorksCDMPackagedImageType;
+
+    return VxWorksUnsupportedImageType;
+}
+
+
+void BinaryNinja::InitVxWorksViewType()
+{
+    static VxWorksViewType type;
+    BinaryViewType::Register(&type);
+    g_vxWorksViewType = &type;
+}
+
+
+VxWorksView::VxWorksView(BinaryView* data, bool parseOnly): BinaryView("VxWorks", data->GetFile(), data),
+    m_parseOnly(parseOnly)
+{
+    CreateLogger("BinaryView");
+    m_logger = CreateLogger("BinaryView.VxWorksView");
+}
+
+
+bool VxWorksView::DetermineImageBase(BinaryReader *reader)
+{
+    VxWorksImageType imageType = IdentifyVxWorksImageType(reader);
+    switch (imageType)
+    {
+    case VxWorksStandardImageType:
+    {
+        uint32_t magic;
+        reader->Seek(0);
+        if (!reader->TryRead32(magic))
+            return 0;
+
+        // TODO: dynamically determine the image base
+        switch (magic)
+        {
+        case 0x7c6000a6: // vx5_ppc_big_endian_0x10000.bin
+            m_imageBase = 0x10000;
+            return true;
+        case 0x7810a0e3: // vx5_arm_little_endian_0x1000.bin
+            m_imageBase = 0x1000;
+        case 0x7c631a78:
+            m_imageBase = 0x400000;
+            return true;
+        default:
+            m_logger->LogError("Unsupported standard VxWorks image magic");
+            return false;
+        }
+    }
+    case VxWorksCDMPackagedImageType:
+        return false; // TODO - not implemented yet
+    case VxWorksCDMNewImageType:
+        return false; // TODO - not implemented yet
+    default:
+        m_logger->LogError("Unsupported VxWorks image type!?");
+        return 0;
+    }
+}
+
+
+bool VxWorksView::ScanForVxWorks5SymbolTable(BinaryView* parentView, BinaryReader *reader)
+{
+    uint64_t endDataAddress = m_imageBase + parentView->GetLength();
+    VxWorks5SymbolTableEntry entry;
+    uint64_t startOffset = parentView->GetLength() - sizeof(entry);
+    uint64_t endOffset = 0;
+    if (parentView->GetLength() > MAX_SYMBOL_TABLE_REGION_SIZE)
+        endOffset = parentView->GetLength() - MAX_SYMBOL_TABLE_REGION_SIZE;
+    uint64_t searchPos = startOffset;
+
+    m_logger->LogDebug("Scanning backwards for VxWorks 5 symbol table (0x%016x-0x%016x)...",
+        m_imageBase + startOffset, m_imageBase + endOffset);
+    while (searchPos > endOffset)
+    {
+        reader->Seek(searchPos + 4); // Skip the unknown field
+        if (!reader->TryRead32(entry.name) || !reader->TryRead32(entry.address) || !reader->TryRead32(entry.flags))
+            break;
+
+        if ((entry.name >= m_imageBase && entry.name < endDataAddress) &&
+            (entry.address >= m_imageBase && entry.address < endDataAddress))
+        {
+            // Name and symbol address pointers are within file
+            m_symbolTable5.push_back(entry);
+            searchPos -= sizeof(entry);
+            continue;
+        }
+
+        if (m_symbolTable5.size() > MIN_VALID_SYMBOL_ENTRIES)
+            break;
+
+        searchPos -= 4;
+        m_symbolTable5.clear();
+    }
+
+    if (m_symbolTable5.size() < MIN_VALID_SYMBOL_ENTRIES)
+    {
+        m_symbolTable5.clear();
+        return false;
+    }
+
+    m_version = VxWorksVersion5;
+    m_logger->LogDebug("Found %d VxWorks 5 symbol table entries", m_symbolTable5.size());
+    return true;
+}
+
+
+bool VxWorksView::ScanForVxWorksSymbolTable(BinaryView* parentView, BinaryReader *reader)
+{
+    // TODO scan for VxWorks 6 symbol table
+    return ScanForVxWorks5SymbolTable(parentView, reader);
+}
+
+
+#define MAX_SYMBOL_NAME_LENGTH 128
+void VxWorksView::ProcessSymbolTable(BinaryReader *reader)
+{
+    std::set<uint64_t> textSymbolAddresses;
+    std::set<uint64_t> dataSymbolAddresses;
+    std::set<uint64_t> roDataSymbolAddresses;
+    std::set<uint64_t> externSymbolAddresses;
+
+    switch (m_version)
+    {
+    case VxWorksVersion5:
+    {
+        for (const auto& entry : m_symbolTable5)
+        {
+            reader->Seek(entry.name - m_imageBase);
+            string symbolName = reader->ReadCString(MAX_SYMBOL_NAME_LENGTH);
+            uint8_t type = VXWORKS_SYMBOL_ENTRY_TYPE(entry.flags);
+            auto it = VxWorks5SymbolTypeMap.find((VxWorks5SymbolType)type);
+            if (it == VxWorks5SymbolTypeMap.end())
+            {
+                m_logger->LogError("Unknown VxWorks 5 symbol type: 0x%02x (%s)", type, symbolName.c_str());
+                continue;
+            }
+
+            auto symbolType = it->second;
+            switch (symbolType)
+            {
+            case FunctionSymbol:
+                textSymbolAddresses.insert(entry.address);
+                break;
+            case DataSymbol:
+                if (type == VxWorks5GlobalAbsoluteSymbolType)
+                    roDataSymbolAddresses.insert(entry.address);
+                else
+                    dataSymbolAddresses.insert(entry.address);
+                break;
+            case ExternalSymbol:
+                externSymbolAddresses.insert(entry.address);
+                break;
+            default:
+                break;
+            }
+
+            DefineAutoSymbol(new Symbol(symbolType, symbolName, entry.address));
+            if (symbolName == "usrRoot")
+                m_usrRoot = entry.address;
+        }
+
+        break;
+    }
+    case VxWorksVersion6:
+    {
+        m_logger->LogError("VxWorks 6 symbol table not implemented yet");
+        break;
+    }
+    case VxWorksUnknownVersion:
+    default:
+        // Shouldn't get here - we set the VxWorks version when we find the symbol table
+        m_logger->LogError(
+            "VxWorks version is unknown, cannot apply symbols."
+            "Please report this issue."
+        );
+        return;
+    }
+
+    if (textSymbolAddresses.size() > 1)
+    {
+        m_sections.push_back({
+            { *textSymbolAddresses.begin(), *textSymbolAddresses.rbegin() },
+            ".text",
+            ReadOnlyCodeSectionSemantics
+        });
+    }
+
+    if (dataSymbolAddresses.size() > 1)
+    {
+        m_sections.push_back({
+            { *dataSymbolAddresses.begin(), *dataSymbolAddresses.rbegin() },
+            ".data",
+            ReadWriteDataSectionSemantics
+        });
+    }
+
+    if (externSymbolAddresses.size() > 1)
+    {
+        m_sections.push_back({
+            { *externSymbolAddresses.begin(), *externSymbolAddresses.rbegin() },
+            ".extern",
+            ExternalSectionSemantics
+        });
+    }
+
+    if (roDataSymbolAddresses.size() > 1)
+    {
+        m_sections.push_back({
+            { *roDataSymbolAddresses.begin(), *roDataSymbolAddresses.rbegin() },
+            ".rodata",
+            ReadOnlyDataSectionSemantics
+        });
+    }
+}
+
+
+void VxWorksView::AddSections(BinaryView *parentView)
+{
+    if (m_sections.empty())
+    {
+        m_logger->LogDebug("No sections found, creating default section");
+        AddAutoSection(".text", m_imageBase, parentView->GetLength(), ReadOnlyCodeSectionSemantics);
+        return;
+    }
+
+    // Sort section information by start address (last first)
+    std::sort(m_sections.begin(), m_sections.end(), [](const VxWorksSectionInfo& a, const VxWorksSectionInfo& b)
+    {
+        return a.AddressRange.first > b.AddressRange.first;
+    });
+
+    uint64_t lastStart = 0;
+    bool lastSection = true;
+    for (const auto& section : m_sections)
+    {
+        uint64_t end = lastStart ? lastStart : section.AddressRange.second;
+        if (lastSection)
+        {
+            end = m_imageBase + parentView->GetLength();
+            lastSection = false;
+        }
+
+        m_logger->LogDebug("Creating section %s at 0x%016x-0x%016x", section.Name.c_str(),
+            section.AddressRange.first, end);
+        AddAutoSection(section.Name, section.AddressRange.first, end-section.AddressRange.first, section.Semantics);
+        lastStart = section.AddressRange.first;
+    }
+}
+
+
+void VxWorksView::DetermineEntryPoint()
+{
+    m_entryPoint = m_imageBase;
+    if (m_usrRoot)
+    {
+        // If we found the usrRoot function in the symbol table, use it
+        m_entryPoint = m_usrRoot;
+        return;
+    }
+
+    for (const auto& section : m_sections)
+    {
+        // No symbol table, set the entry point to the start of .text, likely the _sysInit function
+        if (section.Name == ".text")
+            m_entryPoint = section.AddressRange.first;
+    }
+}
+
+
+bool VxWorksView::Init()
+{
+    try
+    {
+        auto parentView = GetParentView();
+        if (!parentView)
+        {
+            m_logger->LogError("Failed to get parent view");
+            return false;
+        }
+
+        // TODO: identify the platform dynamically
+        auto platform = Platform::GetByName("ppc");
+        if (!platform)
+        {
+            m_logger->LogError("Failed to get platform");
+            return false;
+        }
+
+        m_arch = platform->GetArchitecture();
+        SetDefaultPlatform(platform);
+        SetDefaultArchitecture(m_arch);
+
+        BinaryReader reader(parentView, m_endianness);
+        if (!DetermineImageBase(&reader))
+            return false;
+
+        AddAutoSegment(m_imageBase, parentView->GetLength(), 0, parentView->GetLength(),
+            SegmentReadable | SegmentWritable | SegmentExecutable);
+
+        if (m_parseOnly)
+            return true;
+
+        if (ScanForVxWorksSymbolTable(parentView, &reader))
+            ProcessSymbolTable(&reader);
+        else
+            m_logger->LogWarn("Could not find VxWorks symbol table");
+
+        AddSections(parentView);
+        DetermineEntryPoint();
+		AddEntryPointForAnalysis(platform, m_entryPoint);
+        return true;
+    }
+    catch (std::exception& e)
+    {
+        m_logger->LogError("Failed to load VxWorks image: %s", e.what());
+        return false;
+    }
+
+    return true;
+}
+
+
+uint64_t VxWorksView::PerformGetEntryPoint() const
+{
+    return m_entryPoint;
+}
+
+
+size_t VxWorksView::PerformGetAddressSize() const
+{
+    return m_arch->GetAddressSize();
+}
+
+
+VxWorksViewType::VxWorksViewType(): BinaryViewType("VxWorks", "VxWorks")
+{
+	m_logger = LogRegistry::CreateLogger("BinaryView");
+}
+
+
+Ref<BinaryView> VxWorksViewType::Create(BinaryView* data)
+{
+	try
+	{
+		return new VxWorksView(data);
+	}
+	catch (std::exception& e)
+	{
+		m_logger->LogError("%s<BinaryViewType> failed to create view! '%s'", GetName().c_str(), e.what());
+		return nullptr;
+	}
+}
+
+
+Ref<BinaryView> VxWorksViewType::Parse(BinaryView* data)
+{
+    try
+    {
+        return new VxWorksView(data, true);
+    }
+    catch (std::exception& e)
+    {
+        m_logger->LogError("%s<BinaryViewType> failed to parse view! '%s'", GetName().c_str(), e.what());
+        return nullptr;
+    }
+}
+
+
+bool VxWorksViewType::IsTypeValidForData(BinaryView* data)
+{
+	BinaryReader reader(data, BigEndian);
+    VxWorksImageType imageType = IdentifyVxWorksImageType(&reader);
+    switch (imageType)
+    {
+    case VxWorksStandardImageType:
+        m_logger->LogDebug("VxWorks standard image type detected");
+        break;
+    case VxWorksCDMPackagedImageType:
+        m_logger->LogDebug("VxWorks packaged CDM image type detected");
+        break;
+    case VxWorksCDMNewImageType:
+        m_logger->LogDebug("VxWorks new CDM image type detected");
+        break;
+    case VxWorksUnsupportedImageType:
+        break;
+    default:
+        break;
+    }
+
+    return imageType != VxWorksUnsupportedImageType;
+}
+
+
+Ref<Settings> VxWorksViewType::GetLoadSettingsForData(BinaryView *data)
+{
+	Ref<BinaryView> viewRef = Parse(data);
+	if (!viewRef || !viewRef->Init())
+	{
+		m_logger->LogError("View type '%s' could not be created", GetName().c_str());
+		return nullptr;
+	}
+
+	// specify default load settings that can be overridden
+	Ref<Settings> settings = GetDefaultLoadSettingsForData(viewRef);
+	vector<string> overrides = {"loader.platform", "loader.imageBase"};
+	for (const auto& override : overrides)
+	{
+		if (settings->Contains(override))
+			settings->UpdateProperty(override, "readOnly", false);
+	}
+
+	return settings;
+}
+
+
+extern "C"
+{
+	BN_DECLARE_CORE_ABI_VERSION
+
+#ifdef DEMO_VERSION
+    bool VxWorksPluginInit()
+#else
+	BINARYNINJAPLUGIN bool CorePluginInit()
+#endif
+	{
+		InitVxWorksViewType();
+		return true;
+	}
+}

--- a/view/vxworks/vxworksview.cpp
+++ b/view/vxworks/vxworksview.cpp
@@ -7,364 +7,347 @@ using namespace std;
 
 static VxWorksViewType* g_vxWorksViewType = nullptr;
 
-#define NEW_CDM_SIGNATURE_OFFSET 0x0
-#define NEW_CDM_SIGNATURE_SIZE 0xb
-#define PACKAGED_CDM_SIGNATURE_SIZE 0x3
-#define PACKAGED_CDM_SIGNATURE_OFFSET 0x50
-static VxWorksImageType IdentifyVxWorksImageType(BinaryReader* reader)
-{
-    reader->Seek(0);
-    uint32_t magic;
-    if (!reader->TryRead32(magic))
-        return VxWorksUnsupportedImageType;
-
-    if (magic == 0x7c6000a6 || magic == 0x7c631a78)
-        return VxWorksStandardImageType;
-
-    uint8_t newCDMSignature[NEW_CDM_SIGNATURE_SIZE];
-    reader->Seek(NEW_CDM_SIGNATURE_OFFSET);
-    if (!reader->TryRead(newCDMSignature, NEW_CDM_SIGNATURE_SIZE))
-        return VxWorksUnsupportedImageType;
-    if (memcmp(newCDMSignature, "vxWorks.pkg", NEW_CDM_SIGNATURE_SIZE) == 0)
-        return VxWorksCDMNewImageType;
-
-    uint8_t oldCMSSignature[PACKAGED_CDM_SIGNATURE_SIZE];
-    reader->Seek(PACKAGED_CDM_SIGNATURE_OFFSET);
-    if (!reader->TryRead(oldCMSSignature, PACKAGED_CDM_SIGNATURE_SIZE))
-        return VxWorksUnsupportedImageType;
-    if (memcmp(oldCMSSignature, "CDM", PACKAGED_CDM_SIGNATURE_SIZE) == 0)
-        return VxWorksCDMPackagedImageType;
-
-    return VxWorksUnsupportedImageType;
-}
-
 
 void BinaryNinja::InitVxWorksViewType()
 {
-    static VxWorksViewType type;
-    BinaryViewType::Register(&type);
-    g_vxWorksViewType = &type;
+	static VxWorksViewType type;
+	BinaryViewType::Register(&type);
+	g_vxWorksViewType = &type;
 }
 
 
 VxWorksView::VxWorksView(BinaryView* data, bool parseOnly): BinaryView("VxWorks", data->GetFile(), data),
-    m_parseOnly(parseOnly)
+	m_parseOnly(parseOnly)
 {
-    CreateLogger("BinaryView");
-    m_logger = CreateLogger("BinaryView.VxWorksView");
+	CreateLogger("BinaryView");
+	m_logger = CreateLogger("BinaryView.VxWorksView");
 }
 
 
-bool VxWorksView::DetermineImageBase(BinaryReader *reader)
+#define LOWEST_TEXT_SYMBOL_ADDRESS_START 0xffffffffffffffff
+void VxWorksView::DetermineImageBaseFromSymbols()
 {
-    VxWorksImageType imageType = IdentifyVxWorksImageType(reader);
-    switch (imageType)
-    {
-    case VxWorksStandardImageType:
-    {
-        uint32_t magic;
-        reader->Seek(0);
-        if (!reader->TryRead32(magic))
-            return 0;
+	uint64_t lowestTextAddress = LOWEST_TEXT_SYMBOL_ADDRESS_START;
+	if (m_version == VxWorksVersion5)
+	{
+		for (const auto& entry : m_symbolTable5)
+		{
+			uint8_t type = VXWORKS_SYMBOL_ENTRY_TYPE(entry.flags);
+			if (type == VxWorks5GlobalTextSymbolType && entry.address < lowestTextAddress)
+				lowestTextAddress = entry.address;
+		}
+	}
 
-        // TODO: dynamically determine the image base
-        switch (magic)
-        {
-        case 0x7c6000a6: // vx5_ppc_big_endian_0x10000.bin
-            m_imageBase = 0x10000;
-            return true;
-        case 0x7810a0e3: // vx5_arm_little_endian_0x1000.bin
-            m_imageBase = 0x1000;
-        case 0x7c631a78:
-            m_imageBase = 0x400000;
-            return true;
-        default:
-            m_logger->LogError("Unsupported standard VxWorks image magic");
-            return false;
-        }
-    }
-    case VxWorksCDMPackagedImageType:
-        return false; // TODO - not implemented yet
-    case VxWorksCDMNewImageType:
-        return false; // TODO - not implemented yet
-    default:
-        m_logger->LogError("Unsupported VxWorks image type!?");
-        return 0;
-    }
+	if (lowestTextAddress == LOWEST_TEXT_SYMBOL_ADDRESS_START)
+	{
+		m_logger->LogWarn("Could not determine image base address, using default 0x%08x", DEFAULT_VXWORKS_BASE_ADDRESS);
+		m_imageBase = DEFAULT_VXWORKS_BASE_ADDRESS;
+		return;
+	}
+
+	m_logger->LogDebug("Determined image base address: 0x%016x", lowestTextAddress);
+	m_imageBase = lowestTextAddress;
 }
 
 
 bool VxWorksView::ScanForVxWorks5SymbolTable(BinaryView* parentView, BinaryReader *reader)
 {
-    uint64_t endDataAddress = m_imageBase + parentView->GetLength();
-    VxWorks5SymbolTableEntry entry;
-    uint64_t startOffset = parentView->GetLength() - sizeof(entry);
-    uint64_t endOffset = 0;
-    if (parentView->GetLength() > MAX_SYMBOL_TABLE_REGION_SIZE)
-        endOffset = parentView->GetLength() - MAX_SYMBOL_TABLE_REGION_SIZE;
-    uint64_t searchPos = startOffset;
+	VxWorks5SymbolTableEntry entry;
+	uint64_t startOffset = parentView->GetLength() - sizeof(entry);
+	uint64_t endOffset = 0;
+	if (parentView->GetLength() > MAX_SYMBOL_TABLE_REGION_SIZE)
+		endOffset = parentView->GetLength() - MAX_SYMBOL_TABLE_REGION_SIZE;
+	uint64_t searchPos = startOffset;
 
-    m_logger->LogDebug("Scanning backwards for VxWorks 5 symbol table (0x%016x-0x%016x)...",
-        m_imageBase + startOffset, m_imageBase + endOffset);
-    while (searchPos > endOffset)
-    {
-        reader->Seek(searchPos + 4); // Skip the unknown field
-        if (!reader->TryRead32(entry.name) || !reader->TryRead32(entry.address) || !reader->TryRead32(entry.flags))
-            break;
+	m_logger->LogDebug("Scanning backwards for VxWorks 5 symbol table (0x%016x-0x%016x) (endianess=%s)...",
+		startOffset, endOffset, m_endianness == BigEndian ? "big" : "little");
+	uint64_t lastNameAddress = 0;
+	while (searchPos > endOffset)
+	{
+		reader->Seek(searchPos + 4); // Skip the unknown field
+		if (!reader->TryRead32(entry.name) || !reader->TryRead32(entry.address) || !reader->TryReadBE32(entry.flags))
+			break;
 
-        if ((entry.name >= m_imageBase && entry.name < endDataAddress) &&
-            (entry.address >= m_imageBase && entry.address < endDataAddress))
-        {
-            // Name and symbol address pointers are within file
-            m_symbolTable5.push_back(entry);
-            searchPos -= sizeof(entry);
-            continue;
-        }
+		uint8_t type = VXWORKS_SYMBOL_ENTRY_TYPE(entry.flags);
+		auto it = VxWorks5SymbolTypeMap.find((VxWorks5SymbolType)type);
+		if (entry.name >= lastNameAddress && entry.address != 0 && it != VxWorks5SymbolTypeMap.end())
+		{
+			// Name address is greater than the last name address and flags has a valid symbol type
+			lastNameAddress = entry.name;
+			m_symbolTable5.push_back(entry);
+			searchPos -= sizeof(entry);
+			continue;
+		}
 
-        if (m_symbolTable5.size() > MIN_VALID_SYMBOL_ENTRIES)
-            break;
+		if (m_symbolTable5.size() > MIN_VALID_SYMBOL_ENTRIES)
+			break;
 
-        searchPos -= 4;
-        m_symbolTable5.clear();
-    }
+		searchPos -= 4;
+		lastNameAddress = 0;
+		m_symbolTable5.clear();
+	}
 
-    if (m_symbolTable5.size() < MIN_VALID_SYMBOL_ENTRIES)
-    {
-        m_symbolTable5.clear();
-        return false;
-    }
+	if (m_symbolTable5.size() < MIN_VALID_SYMBOL_ENTRIES)
+	{
+		m_symbolTable5.clear();
+		return false;
+	}
 
-    m_version = VxWorksVersion5;
-    m_logger->LogDebug("Found %d VxWorks 5 symbol table entries", m_symbolTable5.size());
-    return true;
+	m_version = VxWorksVersion5;
+	m_logger->LogDebug("Found %d VxWorks 5 symbol table entries", m_symbolTable5.size());
+	return true;
 }
 
 
 bool VxWorksView::ScanForVxWorksSymbolTable(BinaryView* parentView, BinaryReader *reader)
 {
-    // TODO scan for VxWorks 6 symbol table
-    return ScanForVxWorks5SymbolTable(parentView, reader);
+	if (ScanForVxWorks5SymbolTable(parentView, reader))
+		return true;
+
+	m_endianness = LittleEndian;
+	reader->SetEndianness(m_endianness);
+	if (ScanForVxWorks5SymbolTable(parentView, reader))
+		return true;
+
+	// TODO scan for VxWorks 6 symbol table
+	return false;
 }
 
 
 #define MAX_SYMBOL_NAME_LENGTH 128
 void VxWorksView::ProcessSymbolTable(BinaryReader *reader)
 {
-    std::set<uint64_t> textSymbolAddresses;
-    std::set<uint64_t> dataSymbolAddresses;
-    std::set<uint64_t> roDataSymbolAddresses;
-    std::set<uint64_t> externSymbolAddresses;
+	std::set<uint64_t> textSymbolAddresses;
+	std::set<uint64_t> dataSymbolAddresses;
+	std::set<uint64_t> roDataSymbolAddresses;
+	std::set<uint64_t> externSymbolAddresses;
 
-    switch (m_version)
-    {
-    case VxWorksVersion5:
-    {
-        for (const auto& entry : m_symbolTable5)
-        {
-            reader->Seek(entry.name - m_imageBase);
-            string symbolName = reader->ReadCString(MAX_SYMBOL_NAME_LENGTH);
-            uint8_t type = VXWORKS_SYMBOL_ENTRY_TYPE(entry.flags);
-            auto it = VxWorks5SymbolTypeMap.find((VxWorks5SymbolType)type);
-            if (it == VxWorks5SymbolTypeMap.end())
-            {
-                m_logger->LogError("Unknown VxWorks 5 symbol type: 0x%02x (%s)", type, symbolName.c_str());
-                continue;
-            }
+	switch (m_version)
+	{
+	case VxWorksVersion5:
+	{
+		for (const auto& entry : m_symbolTable5)
+		{
+			reader->Seek(entry.name - m_imageBase);
+			string symbolName = reader->ReadCString(MAX_SYMBOL_NAME_LENGTH);
+			uint8_t type = VXWORKS_SYMBOL_ENTRY_TYPE(entry.flags);
+			auto it = VxWorks5SymbolTypeMap.find((VxWorks5SymbolType)type);
+			if (it == VxWorks5SymbolTypeMap.end())
+			{
+				m_logger->LogError("Unknown VxWorks 5 symbol type: 0x%02x (%s)", type, symbolName.c_str());
+				continue;
+			}
 
-            auto symbolType = it->second;
-            switch (symbolType)
-            {
-            case FunctionSymbol:
-                textSymbolAddresses.insert(entry.address);
-                break;
-            case DataSymbol:
-                if (type == VxWorks5GlobalAbsoluteSymbolType)
-                    roDataSymbolAddresses.insert(entry.address);
-                else
-                    dataSymbolAddresses.insert(entry.address);
-                break;
-            case ExternalSymbol:
-                externSymbolAddresses.insert(entry.address);
-                break;
-            default:
-                break;
-            }
+			auto symbolType = it->second;
+			switch (symbolType)
+			{
+			case FunctionSymbol:
+				textSymbolAddresses.insert(entry.address);
+				AddFunctionForAnalysis(m_platform, entry.address);
+				break;
+			case DataSymbol:
+				if (type == VxWorks5GlobalAbsoluteSymbolType)
+					roDataSymbolAddresses.insert(entry.address);
+				else
+					dataSymbolAddresses.insert(entry.address);
+				break;
+			case ExternalSymbol:
+				externSymbolAddresses.insert(entry.address);
+				break;
+			default:
+				break;
+			}
 
-            DefineAutoSymbol(new Symbol(symbolType, symbolName, entry.address));
-            if (symbolName == "usrRoot")
-                m_usrRoot = entry.address;
-        }
+			DefineAutoSymbol(new Symbol(symbolType, symbolName, entry.address));
+			if (symbolName == "sysInit")
+				m_sysInit = entry.address;
+		}
 
-        break;
-    }
-    case VxWorksVersion6:
-    {
-        m_logger->LogError("VxWorks 6 symbol table not implemented yet");
-        break;
-    }
-    case VxWorksUnknownVersion:
-    default:
-        // Shouldn't get here - we set the VxWorks version when we find the symbol table
-        m_logger->LogError(
-            "VxWorks version is unknown, cannot apply symbols."
-            "Please report this issue."
-        );
-        return;
-    }
+		break;
+	}
+	case VxWorksVersion6:
+	{
+		m_logger->LogError("VxWorks 6 symbol table not implemented yet");
+		break;
+	}
+	case VxWorksUnknownVersion:
+	default:
+		// Shouldn't get here - we set the VxWorks version when we find the symbol table
+		m_logger->LogError(
+			"VxWorks version is unknown, cannot apply symbols."
+			"Please report this issue."
+		);
+		return;
+	}
 
-    if (textSymbolAddresses.size() > 1)
-    {
-        m_sections.push_back({
-            { *textSymbolAddresses.begin(), *textSymbolAddresses.rbegin() },
-            ".text",
-            ReadOnlyCodeSectionSemantics
-        });
-    }
+	if (textSymbolAddresses.size() > 1)
+	{
+		m_sections.push_back({
+			{ *textSymbolAddresses.begin(), *textSymbolAddresses.rbegin() },
+			".text",
+			ReadOnlyCodeSectionSemantics
+		});
+	}
 
-    if (dataSymbolAddresses.size() > 1)
-    {
-        m_sections.push_back({
-            { *dataSymbolAddresses.begin(), *dataSymbolAddresses.rbegin() },
-            ".data",
-            ReadWriteDataSectionSemantics
-        });
-    }
+	if (dataSymbolAddresses.size() > 1)
+	{
+		m_sections.push_back({
+			{ *dataSymbolAddresses.begin(), *dataSymbolAddresses.rbegin() },
+			".data",
+			ReadWriteDataSectionSemantics
+		});
+	}
 
-    if (externSymbolAddresses.size() > 1)
-    {
-        m_sections.push_back({
-            { *externSymbolAddresses.begin(), *externSymbolAddresses.rbegin() },
-            ".extern",
-            ExternalSectionSemantics
-        });
-    }
+	if (externSymbolAddresses.size() > 1)
+	{
+		m_sections.push_back({
+			{ *externSymbolAddresses.begin(), *externSymbolAddresses.rbegin() },
+			".extern",
+			ExternalSectionSemantics
+		});
+	}
 
-    if (roDataSymbolAddresses.size() > 1)
-    {
-        m_sections.push_back({
-            { *roDataSymbolAddresses.begin(), *roDataSymbolAddresses.rbegin() },
-            ".rodata",
-            ReadOnlyDataSectionSemantics
-        });
-    }
+	if (roDataSymbolAddresses.size() > 1)
+	{
+		m_sections.push_back({
+			{ *roDataSymbolAddresses.begin(), *roDataSymbolAddresses.rbegin() },
+			".rodata",
+			ReadOnlyDataSectionSemantics
+		});
+	}
 }
 
 
 void VxWorksView::AddSections(BinaryView *parentView)
 {
-    if (m_sections.empty())
-    {
-        m_logger->LogDebug("No sections found, creating default section");
-        AddAutoSection(".text", m_imageBase, parentView->GetLength(), ReadOnlyCodeSectionSemantics);
-        return;
-    }
+	if (m_sections.empty())
+	{
+		m_logger->LogDebug("No sections found, creating default section");
+		AddAutoSection(".text", m_imageBase, parentView->GetLength(), ReadOnlyCodeSectionSemantics);
+		return;
+	}
 
-    // Sort section information by start address (last first)
-    std::sort(m_sections.begin(), m_sections.end(), [](const VxWorksSectionInfo& a, const VxWorksSectionInfo& b)
-    {
-        return a.AddressRange.first > b.AddressRange.first;
-    });
+	// Sort section information by start address (section w/ highest start address first)
+	std::sort(m_sections.begin(), m_sections.end(), [](const VxWorksSectionInfo& a, const VxWorksSectionInfo& b)
+	{
+		return a.AddressRange.first > b.AddressRange.first;
+	});
 
-    uint64_t lastStart = 0;
-    bool lastSection = true;
-    for (const auto& section : m_sections)
-    {
-        uint64_t end = lastStart ? lastStart : section.AddressRange.second;
-        if (lastSection)
-        {
-            end = m_imageBase + parentView->GetLength();
-            lastSection = false;
-        }
+	uint64_t lastStart = 0;
+	bool lastSection = true;
+	for (const auto& section : m_sections)
+	{
+		uint64_t end = lastStart ? lastStart : section.AddressRange.second;
+		if (lastSection)
+		{
+			end = m_imageBase + parentView->GetLength();
+			lastSection = false;
+		}
 
-        m_logger->LogDebug("Creating section %s at 0x%016x-0x%016x", section.Name.c_str(),
-            section.AddressRange.first, end);
-        AddAutoSection(section.Name, section.AddressRange.first, end-section.AddressRange.first, section.Semantics);
-        lastStart = section.AddressRange.first;
-    }
+		m_logger->LogDebug("Creating section %s at 0x%016x-0x%016x", section.Name.c_str(),
+			section.AddressRange.first, end);
+		AddAutoSection(section.Name, section.AddressRange.first, end-section.AddressRange.first, section.Semantics);
+		lastStart = section.AddressRange.first;
+	}
 }
 
 
 void VxWorksView::DetermineEntryPoint()
 {
-    m_entryPoint = m_imageBase;
-    if (m_usrRoot)
-    {
-        // If we found the usrRoot function in the symbol table, use it
-        m_entryPoint = m_usrRoot;
-        return;
-    }
+	m_entryPoint = m_imageBase;
+	if (m_sysInit)
+	{
+		// If we found the sysInit function in the symbol table, use it
+		m_entryPoint = m_sysInit;
+		return;
+	}
 
-    for (const auto& section : m_sections)
-    {
-        // No symbol table, set the entry point to the start of .text, likely the _sysInit function
-        if (section.Name == ".text")
-            m_entryPoint = section.AddressRange.first;
-    }
+	for (const auto& section : m_sections)
+	{
+		// No symbol table, set the entry point to the start of .text, likely the sysInit function
+		if (section.Name == ".text")
+			m_entryPoint = section.AddressRange.first;
+	}
 }
 
 
 bool VxWorksView::Init()
 {
-    try
-    {
-        auto parentView = GetParentView();
-        if (!parentView)
-        {
-            m_logger->LogError("Failed to get parent view");
-            return false;
-        }
+	try
+	{
+		auto parentView = GetParentView();
+		if (!parentView)
+		{
+			m_logger->LogError("Failed to get parent view");
+			return false;
+		}
 
-        // TODO: identify the platform dynamically
-        auto platform = Platform::GetByName("ppc");
-        if (!platform)
-        {
-            m_logger->LogError("Failed to get platform");
-            return false;
-        }
+		BinaryReader reader(parentView, m_endianness);
+		bool isSymTable = ScanForVxWorksSymbolTable(parentView, &reader);
+		if (isSymTable)
+		{
+			DetermineImageBaseFromSymbols();
+			m_entryPoint = m_imageBase; // This will get updated later if the sysInit symbol is found
+		}
+		else
+		{
+			m_logger->LogWarn("Could not find VxWorks symbol table");
+			m_imageBase = DEFAULT_VXWORKS_BASE_ADDRESS;
+		}
 
-        m_arch = platform->GetArchitecture();
-        SetDefaultPlatform(platform);
-        SetDefaultArchitecture(m_arch);
+		AddAutoSegment(m_imageBase, parentView->GetLength(), 0, parentView->GetLength(),
+			SegmentReadable | SegmentWritable | SegmentExecutable);
 
-        BinaryReader reader(parentView, m_endianness);
-        if (!DetermineImageBase(&reader))
-            return false;
+		auto settings = GetLoadSettings(GetTypeName());
+		if (!settings || settings->IsEmpty())
+		{
+			m_endianness = BinaryView::GetDefaultEndianness();
+			m_addressSize = BinaryView::GetAddressSize();
+			return true;
+		}
 
-        AddAutoSegment(m_imageBase, parentView->GetLength(), 0, parentView->GetLength(),
-            SegmentReadable | SegmentWritable | SegmentExecutable);
+		auto platformName = settings->Get<string>("loader.platform");
+		m_platform = Platform::GetByName(platformName);
+		if (!m_platform)
+		{
+			m_logger->LogError("Failed to get platform");
+			return false;
+		}
 
-        if (m_parseOnly)
-            return true;
+		m_arch = m_platform->GetArchitecture();
+		m_addressSize = m_arch->GetAddressSize();
+		SetDefaultPlatform(m_platform);
+		SetDefaultArchitecture(m_arch);
 
-        if (ScanForVxWorksSymbolTable(parentView, &reader))
-            ProcessSymbolTable(&reader);
-        else
-            m_logger->LogWarn("Could not find VxWorks symbol table");
+		if (m_parseOnly)
+			return true;
 
-        AddSections(parentView);
-        DetermineEntryPoint();
-		AddEntryPointForAnalysis(platform, m_entryPoint);
-        return true;
-    }
-    catch (std::exception& e)
-    {
-        m_logger->LogError("Failed to load VxWorks image: %s", e.what());
-        return false;
-    }
+		if (isSymTable)
+			ProcessSymbolTable(&reader);
+		AddSections(parentView);
+		DetermineEntryPoint();
+		AddEntryPointForAnalysis(m_platform, m_entryPoint);
+		return true;
+	}
+	catch (std::exception& e)
+	{
+		m_logger->LogError("Failed to load VxWorks image: %s", e.what());
+		return false;
+	}
 
-    return true;
+	return true;
 }
 
 
 uint64_t VxWorksView::PerformGetEntryPoint() const
 {
-    return m_entryPoint;
+	return m_entryPoint;
 }
 
 
 size_t VxWorksView::PerformGetAddressSize() const
 {
-    return m_arch->GetAddressSize();
+	return m_addressSize;
 }
 
 
@@ -390,40 +373,42 @@ Ref<BinaryView> VxWorksViewType::Create(BinaryView* data)
 
 Ref<BinaryView> VxWorksViewType::Parse(BinaryView* data)
 {
-    try
-    {
-        return new VxWorksView(data, true);
-    }
-    catch (std::exception& e)
-    {
-        m_logger->LogError("%s<BinaryViewType> failed to parse view! '%s'", GetName().c_str(), e.what());
-        return nullptr;
-    }
+	try
+	{
+		return new VxWorksView(data, true);
+	}
+	catch (std::exception& e)
+	{
+		m_logger->LogError("%s<BinaryViewType> failed to parse view! '%s'", GetName().c_str(), e.what());
+		return nullptr;
+	}
 }
 
 
 bool VxWorksViewType::IsTypeValidForData(BinaryView* data)
 {
-	BinaryReader reader(data, BigEndian);
-    VxWorksImageType imageType = IdentifyVxWorksImageType(&reader);
-    switch (imageType)
-    {
-    case VxWorksStandardImageType:
-        m_logger->LogDebug("VxWorks standard image type detected");
-        break;
-    case VxWorksCDMPackagedImageType:
-        m_logger->LogDebug("VxWorks packaged CDM image type detected");
-        break;
-    case VxWorksCDMNewImageType:
-        m_logger->LogDebug("VxWorks new CDM image type detected");
-        break;
-    case VxWorksUnsupportedImageType:
-        break;
-    default:
-        break;
-    }
+	std::stringstream ss;
+	ss << "{"
+		"\"pattern\":\"VxWorks\","
+		"\"start\":0,"
+		"\"end\":" << data->GetLength()-1 << ","
+		"\"raw\":false,"
+		"\"ignoreCase\":false,"
+		"\"overlap\":false,"
+		"\"align\":1"
+	"}";
 
-    return imageType != VxWorksUnsupportedImageType;
+	bool isValid = false;;
+	auto StringSearchCallback = [&isValid](size_t index, const DataBuffer& dataBuffer) -> bool
+	{
+		isValid = true;
+		return true;
+	};
+
+	if (!data->Search(string(ss.str()), StringSearchCallback))
+		m_logger->LogWarn("Error while searching for VxWorks signatures in raw view");
+
+	return isValid;
 }
 
 
@@ -438,12 +423,15 @@ Ref<Settings> VxWorksViewType::GetLoadSettingsForData(BinaryView *data)
 
 	// specify default load settings that can be overridden
 	Ref<Settings> settings = GetDefaultLoadSettingsForData(viewRef);
-	vector<string> overrides = {"loader.platform", "loader.imageBase"};
+	vector<string> overrides = {"loader.platform", "loader.imageBase", "loader.entryPointOffset"};
 	for (const auto& override : overrides)
 	{
 		if (settings->Contains(override))
 			settings->UpdateProperty(override, "readOnly", false);
 	}
+
+	if (settings->Contains("loader.entryPointOffset"))
+		settings->UpdateProperty("loader.entryPointOffset", "default", viewRef->GetEntryPoint());
 
 	return settings;
 }
@@ -454,7 +442,7 @@ extern "C"
 	BN_DECLARE_CORE_ABI_VERSION
 
 #ifdef DEMO_VERSION
-    bool VxWorksPluginInit()
+	bool VxWorksPluginInit()
 #else
 	BINARYNINJAPLUGIN bool CorePluginInit()
 #endif

--- a/view/vxworks/vxworksview.h
+++ b/view/vxworks/vxworksview.h
@@ -87,27 +87,27 @@ namespace BinaryNinja
 		bool m_hasSymbolTable = false;
 		uint64_t m_symbolTableOffset = 0;
 		uint64_t m_entryPoint = 0;
-		uint64_t m_determinedImagebase = 0; // Determined from analysis of the symbol table
+		uint64_t m_determinedImageBase = 0; // Determined from analysis of the symbol table
 		uint64_t m_imageBase = 0; // Selected image base that could be overriden by user
 		std::vector<VxWorksSectionInfo> m_sections;
 		VxWorksVersion m_version = VxWorksUnknownVersion;
 		std::vector<VxWorksSymbolEntry> m_symbols;
 
 	private:
-		void DetermineEntryPoint();
-		void AddSections();
-		void AssignSymbolToSection(std::map<std::string, std::set<uint64_t>>& sections,
-			BNSymbolType bnSymbolType, uint8_t vxSymbolType, uint64_t address);
+		bool IsASCIIString(std::string &s);
 		void DefineSymbolTableDataVariable();
-		void ProcessSymbolTable(BinaryReader *reader);
+		uint64_t FindSysInit(BinaryReader *reader, uint64_t imageBase);
+		void AdjustImageBaseForHeaderIfPresent(BinaryReader* reader);
+		void DetermineImageBaseFromSymbols(BinaryReader* reader);
 		bool FunctionAddressesAreValid(VxWorksVersion version);
 		bool TryReadVxWorksSymbolEntry(BinaryReader *reader, uint64_t offset,
 			VxWorksSymbolEntry& entry, VxWorksVersion version);
 		bool ScanForVxWorksSystemTable(BinaryReader *reader, VxWorksVersion version, BNEndianness endianness);
 		bool FindSymbolTable(BinaryReader *reader);
-		uint64_t FindSysInit(BinaryReader *reader, uint64_t imageBase);
-		void AdjustImageBaseForHeaderIfPresent(BinaryReader* reader);
-		void DetermineImageBaseFromSymbols(BinaryReader* reader);
+		void AssignSymbolToSection(std::map<std::string, std::set<uint64_t>>& sections,
+			BNSymbolType bnSymbolType, uint8_t vxSymbolType, uint64_t address);
+		void ProcessSymbolTable(BinaryReader *reader);
+		void AddSections();
 
 	protected:
 		virtual uint64_t PerformGetStart() const override;

--- a/view/vxworks/vxworksview.h
+++ b/view/vxworks/vxworksview.h
@@ -6,8 +6,9 @@
 #pragma warning(disable: 4005)
 #endif
 
+#define DEFAULT_VXWORKS_BASE_ADDRESS 0x10000
 #define MAX_SYMBOL_TABLE_REGION_SIZE 0x2000000
-#define MIN_VALID_SYMBOL_ENTRIES 200
+#define MIN_VALID_SYMBOL_ENTRIES 256
 #define VXWORKS_SYMBOL_ENTRY_TYPE(flags) ((flags >> 8) & 0xff)
 
 enum VxWorksVersion
@@ -19,10 +20,10 @@ enum VxWorksVersion
 
 enum VxWorksImageType
 {
-    VxWorksUnsupportedImageType,
-    VxWorksStandardImageType,
-    VxWorksCDMPackagedImageType,
-    VxWorksCDMNewImageType,
+	VxWorksUnsupportedImageType,
+	VxWorksStandardImageType,
+	VxWorksCDMPackagedImageType,
+	VxWorksCDMNewImageType,
 };
 
 enum VxWorks5SymbolType
@@ -113,16 +114,18 @@ struct VxWorksSectionInfo
 
 namespace BinaryNinja
 {
-    class VxWorksView: public BinaryView
-    {
+	class VxWorksView: public BinaryView
+	{
 		Ref<Logger> m_logger;
 		bool m_parseOnly;
 		bool m_relocatable = false;
-        BNEndianness m_endianness = BigEndian;
+		BNEndianness m_endianness = BigEndian;
+		Ref<Platform> m_platform;
 		Ref<Architecture> m_arch;
+		size_t m_addressSize;
 		uint64_t m_entryPoint = 0;
 		uint64_t m_imageBase = 0;
-		uint64_t m_usrRoot = 0; // Entrypoint, if we find it in the symbol table
+		uint64_t m_sysInit = 0; // Entrypoint, if we find it in the symbol table
 		std::vector<VxWorksSectionInfo> m_sections;
 
 		VxWorksVersion m_version = VxWorksUnknownVersion;
@@ -136,7 +139,7 @@ namespace BinaryNinja
 		bool ScanForVxWorks6SymbolTable(BinaryView* parentView, BinaryReader *reader);
 		bool ScanForVxWorks5SymbolTable(BinaryView* parentView, BinaryReader *reader);
 		bool ScanForVxWorksSymbolTable(BinaryView* parentView, BinaryReader *reader);
-		bool DetermineImageBase(BinaryReader *reader);
+		void DetermineImageBaseFromSymbols();
 
 	protected:
 		virtual uint64_t PerformGetEntryPoint() const override;
@@ -148,7 +151,7 @@ namespace BinaryNinja
 	public:
 		VxWorksView(BinaryView* data, bool parseOnly = false);
 		virtual bool Init() override;
-    }; // class VxWorksView
+	}; // class VxWorksView
 
 	class VxWorksViewType: public BinaryViewType
 	{
@@ -161,7 +164,7 @@ namespace BinaryNinja
 		virtual Ref<BinaryView> Parse(BinaryView* data) override;
 		virtual bool IsTypeValidForData(BinaryView* data) override;
 		virtual Ref<Settings> GetLoadSettingsForData(BinaryView* data) override;
-        static enum VxWorksImageType IdentifyImageType(Ref<BinaryReader>& reader);
+		static enum VxWorksImageType IdentifyImageType(Ref<BinaryReader>& reader);
 	}; // class VxWorksViewType
 
 	void InitVxWorksViewType();

--- a/view/vxworks/vxworksview.h
+++ b/view/vxworks/vxworksview.h
@@ -8,8 +8,8 @@
 
 #define DEFAULT_VXWORKS_BASE_ADDRESS 0x10000
 #define MAX_SYMBOL_TABLE_REGION_SIZE 0x2000000
-#define MIN_VALID_SYMBOL_ENTRIES 256
-#define VXWORKS_SYMBOL_ENTRY_TYPE(flags) ((flags >> 8) & 0xff)
+#define MIN_VALID_SYMBOL_ENTRIES 1000
+#define VXWORKS_SYMBOL_ENTRY_TYPE(flags) (((flags >> 8) & 0xff))
 
 enum VxWorksVersion
 {
@@ -40,6 +40,10 @@ enum VxWorks5SymbolType
 	VxWorks5GlobalBSSSymbolType = 0x09,
 	VxWorks5LocalCommonSymbolType = 0x12,
 	VxWorks5GlobalCommonSymbolType = 0x13,
+	VxWorks5PowerPCLocalSDASymbolType = 0x40,
+	VxWorks5PowerPCGlobalSDASymbolType = 0x41,
+	VxWorks5PowerPCLocalSDA2SymbolType = 0x80,
+	VxWorks5PowerPCGlobalSDA2SymbolType = 0x81,
 };
 
 std::map<VxWorks5SymbolType, BNSymbolType> VxWorks5SymbolTypeMap = {
@@ -55,6 +59,10 @@ std::map<VxWorks5SymbolType, BNSymbolType> VxWorks5SymbolTypeMap = {
 	{ VxWorks5GlobalBSSSymbolType, DataSymbol },
 	{ VxWorks5LocalCommonSymbolType, DataSymbol },
 	{ VxWorks5GlobalCommonSymbolType, DataSymbol },
+	{ VxWorks5PowerPCLocalSDASymbolType, DataSymbol },
+	{ VxWorks5PowerPCGlobalSDASymbolType, DataSymbol },
+	{ VxWorks5PowerPCLocalSDA2SymbolType, DataSymbol },
+	{ VxWorks5PowerPCGlobalSDA2SymbolType, DataSymbol },
 };
 
 enum VxWorks6SymbolType
@@ -72,7 +80,7 @@ enum VxWorks6SymbolType
 	VxWorks6LocalCommonSymbolType = 0x20,
 	VxWorks6GlobalCommonSymbolType = 0x21,
 	VxWorks6LocalSymbols = 0x40,
-	VxWorks6GlobalSymboks = 0x41,
+	VxWorks6GlobalSymbols = 0x41,
 };
 
 std::map<VxWorks6SymbolType, BNSymbolType> VxWorks6SymbolTypeMap = {
@@ -89,7 +97,9 @@ std::map<VxWorks6SymbolType, BNSymbolType> VxWorks6SymbolTypeMap = {
 	{ VxWorks6LocalCommonSymbolType, DataSymbol },
 	{ VxWorks6GlobalCommonSymbolType, DataSymbol },
 	{ VxWorks6LocalSymbols, DataSymbol },
-	{ VxWorks6GlobalSymboks, DataSymbol },
+	{ VxWorks6GlobalSymbols, DataSymbol },
+	{ VxWorks6LocalSymbols, DataSymbol },
+	{ VxWorks6GlobalSymbols, DataSymbol },
 };
 
 struct VxWorks5SymbolTableEntry
@@ -140,6 +150,7 @@ namespace BinaryNinja
 		void DetermineEntryPoint();
 		void AddSections(BinaryView* parentView);
 		void ProcessSymbolTable(BinaryReader *reader);
+		bool FunctionAddressesAreValid(VxWorksVersion version);
 		bool ScanForVxWorks6SymbolTable(BinaryView* parentView, BinaryReader *reader);
 		bool ScanForVxWorks5SymbolTable(BinaryView* parentView, BinaryReader *reader);
 		bool ScanForVxWorksSymbolTable(BinaryView* parentView, BinaryReader *reader);

--- a/view/vxworks/vxworksview.h
+++ b/view/vxworks/vxworksview.h
@@ -1,0 +1,168 @@
+#pragma once
+
+#include "binaryninjaapi.h"
+
+#ifdef WIN32
+#pragma warning(disable: 4005)
+#endif
+
+#define MAX_SYMBOL_TABLE_REGION_SIZE 0x2000000
+#define MIN_VALID_SYMBOL_ENTRIES 200
+#define VXWORKS_SYMBOL_ENTRY_TYPE(flags) ((flags >> 8) & 0xff)
+
+enum VxWorksVersion
+{
+	VxWorksUnknownVersion,
+	VxWorksVersion5,
+	VxWorksVersion6,
+};
+
+enum VxWorksImageType
+{
+    VxWorksUnsupportedImageType,
+    VxWorksStandardImageType,
+    VxWorksCDMPackagedImageType,
+    VxWorksCDMNewImageType,
+};
+
+enum VxWorks5SymbolType
+{
+	VxWorks5UndefinedSymbolType = 0x00,
+	VxWorks5GlobalExternalSymbolType = 0x01,
+	VxWorks5LocalAbsoluteSymbolType = 0x02,
+	VxWorks5GlobalAbsoluteSymbolType = 0x03,
+	VxWorks5LocalTextSymbolType = 0x04,
+	VxWorks5GlobalTextSymbolType = 0x05,
+	VxWorks5LocalDataSymbolType = 0x06,
+	VxWorks5GlobalDataSymbolType = 0x07,
+	VxWorks5LocalBSSSymbolType = 0x08,
+	VxWorks5GlobalBSSSymbolType = 0x09,
+	VxWorks5LocalCommonSymbolType = 0x12,
+	VxWorks5GlobalCommonSymbolType = 0x13,
+};
+
+std::map<VxWorks5SymbolType, BNSymbolType> VxWorks5SymbolTypeMap = {
+	{ VxWorks5UndefinedSymbolType, FunctionSymbol },
+	{ VxWorks5GlobalExternalSymbolType, ImportAddressSymbol },
+	{ VxWorks5LocalAbsoluteSymbolType, DataSymbol },
+	{ VxWorks5GlobalAbsoluteSymbolType, DataSymbol },
+	{ VxWorks5LocalTextSymbolType, FunctionSymbol },
+	{ VxWorks5GlobalTextSymbolType, FunctionSymbol },
+	{ VxWorks5LocalDataSymbolType, DataSymbol },
+	{ VxWorks5GlobalDataSymbolType, DataSymbol },
+	{ VxWorks5LocalBSSSymbolType, DataSymbol },
+	{ VxWorks5GlobalBSSSymbolType, DataSymbol },
+	{ VxWorks5LocalCommonSymbolType, DataSymbol },
+	{ VxWorks5GlobalCommonSymbolType, DataSymbol },
+};
+
+enum VxWorks6SymbolType
+{
+	VxWorks6UndefinedSymbolType = 0x00,
+	VxWorks6GlobalExternalSymbolType = 0x01,
+	VxWorks6LocalAbsoluteSymbolType = 0x02,
+	VxWorks6GlobalAbsoluteSymbolType = 0x03,
+	VxWorks6LocalTextSymbolType = 0x04,
+	VxWorks6GlobalTextSymbolType = 0x05,
+	VxWorks6LocalDataSymbolType = 0x08,
+	VxWorks6GlobalDataSymbolType = 0x09,
+	VxWorks6LocalBSSSymbolType = 0x10,
+	VxWorks6GlobalBSSSymbolType = 0x11,
+	VxWorks6LocalCommonSymbolType = 0x20,
+	VxWorks6GlobalCommonSymbolType = 0x21,
+};
+
+std::map<VxWorks6SymbolType, BNSymbolType> VxWorks6SymbolTypeMap = {
+	{ VxWorks6UndefinedSymbolType, FunctionSymbol },
+	{ VxWorks6GlobalExternalSymbolType, ImportAddressSymbol },
+	{ VxWorks6LocalAbsoluteSymbolType, DataSymbol },
+	{ VxWorks6GlobalAbsoluteSymbolType, DataSymbol },
+	{ VxWorks6LocalTextSymbolType, FunctionSymbol },
+	{ VxWorks6GlobalTextSymbolType, FunctionSymbol },
+	{ VxWorks6LocalDataSymbolType, DataSymbol },
+	{ VxWorks6GlobalDataSymbolType, DataSymbol },
+	{ VxWorks6LocalBSSSymbolType, DataSymbol },
+	{ VxWorks6GlobalBSSSymbolType, DataSymbol },
+	{ VxWorks6LocalCommonSymbolType, DataSymbol },
+	{ VxWorks6GlobalCommonSymbolType, DataSymbol },
+};
+
+struct VxWorks5SymbolTableEntry
+{
+	uint32_t unknown;
+	uint32_t name;
+	uint32_t address;
+	uint32_t flags;
+};
+
+struct VxWorks6SymbolTableEntry
+{
+	uint32_t unknown1;
+	uint32_t name;
+	uint32_t address;
+	uint32_t unknown2;
+	uint32_t flags;
+};
+
+struct VxWorksSectionInfo
+{
+	std::pair<uint64_t, uint64_t> AddressRange;
+	std::string Name;
+	BNSectionSemantics Semantics;
+};
+
+namespace BinaryNinja
+{
+    class VxWorksView: public BinaryView
+    {
+		Ref<Logger> m_logger;
+		bool m_parseOnly;
+		bool m_relocatable = false;
+        BNEndianness m_endianness = BigEndian;
+		Ref<Architecture> m_arch;
+		uint64_t m_entryPoint = 0;
+		uint64_t m_imageBase = 0;
+		uint64_t m_usrRoot = 0; // Entrypoint, if we find it in the symbol table
+		std::vector<VxWorksSectionInfo> m_sections;
+
+		VxWorksVersion m_version = VxWorksUnknownVersion;
+		std::vector<VxWorks5SymbolTableEntry> m_symbolTable5;
+		std::vector<VxWorks6SymbolTableEntry> m_symbolTable6;
+
+	private:
+		void DetermineEntryPoint();
+		void AddSections(BinaryView* parentView);
+		void ProcessSymbolTable(BinaryReader *reader);
+		bool ScanForVxWorks6SymbolTable(BinaryView* parentView, BinaryReader *reader);
+		bool ScanForVxWorks5SymbolTable(BinaryView* parentView, BinaryReader *reader);
+		bool ScanForVxWorksSymbolTable(BinaryView* parentView, BinaryReader *reader);
+		bool DetermineImageBase(BinaryReader *reader);
+
+	protected:
+		virtual uint64_t PerformGetEntryPoint() const override;
+		virtual bool PerformIsExecutable() const override { return true; }
+		virtual BNEndianness PerformGetDefaultEndianness() const override { return m_endianness; }
+		virtual bool PerformIsRelocatable() const override { return m_relocatable; }
+		virtual size_t PerformGetAddressSize() const override;
+
+	public:
+		VxWorksView(BinaryView* data, bool parseOnly = false);
+		virtual bool Init() override;
+    }; // class VxWorksView
+
+	class VxWorksViewType: public BinaryViewType
+	{
+		Ref<Logger> m_logger;
+
+
+	public:
+		VxWorksViewType();
+		virtual Ref<BinaryView> Create(BinaryView* data) override;
+		virtual Ref<BinaryView> Parse(BinaryView* data) override;
+		virtual bool IsTypeValidForData(BinaryView* data) override;
+		virtual Ref<Settings> GetLoadSettingsForData(BinaryView* data) override;
+        static enum VxWorksImageType IdentifyImageType(Ref<BinaryReader>& reader);
+	}; // class VxWorksViewType
+
+	void InitVxWorksViewType();
+} // namespace BinaryNinja

--- a/view/vxworks/vxworksview.h
+++ b/view/vxworks/vxworksview.h
@@ -80,10 +80,12 @@ namespace BinaryNinja
 		Ref<Logger> m_logger;
 		bool m_parseOnly;
 		bool m_relocatable = false;
+		Ref<BinaryView> m_parentView = nullptr;
 		BNEndianness m_endianness = BigEndian;
 		Ref<Platform> m_platform;
 		Ref<Architecture> m_arch;
 		size_t m_addressSize;
+		uint64_t m_symbolTableOffset = 0;
 		uint64_t m_entryPoint = 0;
 		uint64_t m_imageBase = 0;
 		uint64_t m_sysInit = 0; // Entrypoint, if we find it in the symbol table
@@ -94,14 +96,16 @@ namespace BinaryNinja
 
 	private:
 		void DetermineEntryPoint();
-		void AddSections(BinaryView* parentView);
+		void AddSections();
 		void AssignSymbolToSection(std::map<std::string, std::set<uint64_t>>& sections,
 			BNSymbolType bnSymbolType, uint8_t vxSymbolType, uint64_t address);
+		void DefineSymbolTableDataVariable();
 		void ProcessSymbolTable(BinaryReader *reader);
 		bool FunctionAddressesAreValid(VxWorksVersion version);
-		bool ScanForVxWorks6SymbolTable(BinaryView* parentView, BinaryReader *reader);
-		bool ScanForVxWorks5SymbolTable(BinaryView* parentView, BinaryReader *reader);
-		bool ScanForVxWorksSymbolTable(BinaryView* parentView, BinaryReader *reader);
+		bool TryReadVxWorksSymbolEntry(BinaryReader *reader, uint64_t offset,
+			VxWorksSymbolEntry& entry, VxWorksVersion version);
+		bool ScanForVxWorksSystemTable(BinaryReader *reader, VxWorksVersion version, BNEndianness endianness);
+		bool FindSymbolTable(BinaryReader *reader);
 		void DetermineImageBaseFromSymbols();
 
 	protected:

--- a/view/vxworks/vxworksview.h
+++ b/view/vxworks/vxworksview.h
@@ -87,10 +87,9 @@ namespace BinaryNinja
 		bool m_hasSymbolTable = false;
 		uint64_t m_symbolTableOffset = 0;
 		uint64_t m_entryPoint = 0;
-		uint64_t m_imageBase = 0;
-		uint64_t m_sysInit = 0; // Entrypoint, if we find it in the symbol table
+		uint64_t m_determinedImagebase = 0; // Determined from analysis of the symbol table
+		uint64_t m_imageBase = 0; // Selected image base that could be overriden by user
 		std::vector<VxWorksSectionInfo> m_sections;
-
 		VxWorksVersion m_version = VxWorksUnknownVersion;
 		std::vector<VxWorksSymbolEntry> m_symbols;
 
@@ -106,9 +105,12 @@ namespace BinaryNinja
 			VxWorksSymbolEntry& entry, VxWorksVersion version);
 		bool ScanForVxWorksSystemTable(BinaryReader *reader, VxWorksVersion version, BNEndianness endianness);
 		bool FindSymbolTable(BinaryReader *reader);
-		void DetermineImageBaseFromSymbols();
+		uint64_t FindSysInit(BinaryReader *reader, uint64_t imageBase);
+		void AdjustImageBaseForHeaderIfPresent(BinaryReader* reader);
+		void DetermineImageBaseFromSymbols(BinaryReader* reader);
 
 	protected:
+		virtual uint64_t PerformGetStart() const override;
 		virtual uint64_t PerformGetEntryPoint() const override;
 		virtual bool PerformIsExecutable() const override { return true; }
 		virtual BNEndianness PerformGetDefaultEndianness() const override { return m_endianness; }

--- a/view/vxworks/vxworksview.h
+++ b/view/vxworks/vxworksview.h
@@ -71,6 +71,8 @@ enum VxWorks6SymbolType
 	VxWorks6GlobalBSSSymbolType = 0x11,
 	VxWorks6LocalCommonSymbolType = 0x20,
 	VxWorks6GlobalCommonSymbolType = 0x21,
+	VxWorks6LocalSymbols = 0x40,
+	VxWorks6GlobalSymboks = 0x41,
 };
 
 std::map<VxWorks6SymbolType, BNSymbolType> VxWorks6SymbolTypeMap = {
@@ -86,6 +88,8 @@ std::map<VxWorks6SymbolType, BNSymbolType> VxWorks6SymbolTypeMap = {
 	{ VxWorks6GlobalBSSSymbolType, DataSymbol },
 	{ VxWorks6LocalCommonSymbolType, DataSymbol },
 	{ VxWorks6GlobalCommonSymbolType, DataSymbol },
+	{ VxWorks6LocalSymbols, DataSymbol },
+	{ VxWorks6GlobalSymboks, DataSymbol },
 };
 
 struct VxWorks5SymbolTableEntry

--- a/view/vxworks/vxworksview.h
+++ b/view/vxworks/vxworksview.h
@@ -79,12 +79,12 @@ namespace BinaryNinja
 	{
 		Ref<Logger> m_logger;
 		bool m_parseOnly;
-		bool m_relocatable = false;
 		Ref<BinaryView> m_parentView = nullptr;
 		BNEndianness m_endianness = BigEndian;
 		Ref<Platform> m_platform;
 		Ref<Architecture> m_arch;
 		size_t m_addressSize;
+		bool m_hasSymbolTable = false;
 		uint64_t m_symbolTableOffset = 0;
 		uint64_t m_entryPoint = 0;
 		uint64_t m_imageBase = 0;
@@ -112,7 +112,7 @@ namespace BinaryNinja
 		virtual uint64_t PerformGetEntryPoint() const override;
 		virtual bool PerformIsExecutable() const override { return true; }
 		virtual BNEndianness PerformGetDefaultEndianness() const override { return m_endianness; }
-		virtual bool PerformIsRelocatable() const override { return m_relocatable; }
+		virtual bool PerformIsRelocatable() const override { return m_hasSymbolTable == false; }
 		virtual size_t PerformGetAddressSize() const override;
 
 	public:

--- a/view/vxworks/vxworksview.h
+++ b/view/vxworks/vxworksview.h
@@ -99,11 +99,6 @@ namespace BinaryNinja
 		uint64_t FindSysInit(BinaryReader *reader, uint64_t imageBase);
 		void AdjustImageBaseForHeaderIfPresent(BinaryReader* reader);
 		void DetermineImageBaseFromSymbols(BinaryReader* reader);
-		bool FunctionAddressesAreValid(VxWorksVersion version);
-		bool TryReadVxWorksSymbolEntry(BinaryReader *reader, uint64_t offset,
-			VxWorksSymbolEntry& entry, VxWorksVersion version);
-		bool ScanForVxWorksSystemTable(BinaryReader *reader, VxWorksVersion version, BNEndianness endianness);
-		bool FindSymbolTable(BinaryReader *reader);
 		void AssignSymbolToSection(std::map<std::string, std::set<uint64_t>>& sections,
 			BNSymbolType bnSymbolType, uint8_t vxSymbolType, uint64_t address);
 		void ProcessSymbolTable(BinaryReader *reader);


### PR DESCRIPTION
Supports VxWorks 5 and VxWorks 6 firmware images (with some limitations):
* Doesn't support VxWorks images without a traditional VxWorks 5 or VxWorks 6 symbol table
   * The VxWorks binary view identifies the base address, builds sections and segments, and more from the symbol table entries. If the symbol table has been stripped, the image might as well be loaded with mapped view while selecting a VxWorks platform.
* Has not been tested against VxWorks 7 firmware
   * No binary samples readily available to test against (still need to scour the internet);  I expect that it won't work out-of-the box
   * I'd like to look into VxWorks 7 later, as there's not much in open source about it and it will likely require a good amount of research
* Still need to add support for "force loading" binaries with the VxWorks view
   * This is being worked under a separate issue. For now, the VxWorks view is selected based on detection of strings and presence of a VxWorks symbol table.
      
      
![image](https://github.com/user-attachments/assets/27ac8709-6433-49ae-8a19-2b12df966013)