### PR TITLE
Allow the user to modify the BV during initialization

### DIFF
--- a/rust/examples/minidump/src/view.rs
+++ b/rust/examples/minidump/src/view.rs
@@ -392,7 +392,7 @@ unsafe impl CustomBinaryView for MinidumpBinaryView {
         Ok(MinidumpBinaryView::new(handle))
     }
 
-    fn init(&self, _args: Self::Args) -> BinaryViewResult<()> {
-        self.init()
+    fn init(&mut self, _args: Self::Args) -> BinaryViewResult<()> {
+        MinidumpBinaryView::init(self)
     }
 }

--- a/rust/src/custombinaryview.rs
+++ b/rust/src/custombinaryview.rs
@@ -329,7 +329,7 @@ pub unsafe trait CustomBinaryView: 'static + BinaryViewBase + Sync + Sized {
     type Args: Send;
 
     fn new(handle: &BinaryView, args: &Self::Args) -> Result<Self>;
-    fn init(&self, args: Self::Args) -> Result<()>;
+    fn init(&mut self, args: Self::Args) -> Result<()>;
 }
 
 /// Represents a partially initialized custom `BinaryView` that should be returned to the core
@@ -432,7 +432,7 @@ impl<'a, T: CustomBinaryViewType> CustomViewBuilder<'a, T> {
 
                         match context
                             .view
-                            .assume_init_ref()
+                            .assume_init_mut()
                             .init(ptr::read(&context.args))
                         {
                             Ok(_) => true,


### PR DESCRIPTION
If the method `CustomBinaryView::init` don't accept `&mut self` the user will have difficulty to incorporate `args: Self::Args` into it's data structure.