### PR TITLE
Binary view type selection from "Open with Options"

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -6910,6 +6910,7 @@ namespace BinaryNinja {
 		static BNBinaryView* ParseCallback(void* ctxt, BNBinaryView* data);
 		static bool IsValidCallback(void* ctxt, BNBinaryView* data);
 		static bool IsDeprecatedCallback(void* ctxt);
+		static bool IsForceLoadableCallback(void *ctxt);
 		static BNSettings* GetSettingsCallback(void* ctxt, BNBinaryView* data);
 
 		BinaryViewType(BNBinaryViewType* type);
@@ -7047,6 +7048,13 @@ namespace BinaryNinja {
 			\return Whether this BinaryViewType is valid for given data
 		*/
 		virtual bool IsTypeValidForData(BinaryView* data) = 0;
+
+		/*! Check whether this BinaryViewType can be forced to load a binary, even if IsTypeValidForData returns false
+
+			\return Whether this BinaryViewType can be forced to load a binary
+		*/
+		virtual bool IsForceLoadable();
+
 		virtual Ref<Settings> GetLoadSettingsForData(BinaryView* data);
 		Ref<Settings> GetDefaultLoadSettingsForData(BinaryView* data);
 
@@ -7069,6 +7077,7 @@ namespace BinaryNinja {
 		virtual Ref<BinaryView> Parse(BinaryView* data) override;
 		virtual bool IsTypeValidForData(BinaryView* data) override;
 		virtual bool IsDeprecated() override;
+		virtual bool IsForceLoadable() override;
 		virtual Ref<Settings> GetLoadSettingsForData(BinaryView* data) override;
 	};
 

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -37,7 +37,7 @@
 // Current ABI version for linking to the core. This is incremented any time
 // there are changes to the API that affect linking, including new functions,
 // new types, or modifications to existing functions or types.
-#define BN_CURRENT_CORE_ABI_VERSION 77
+#define BN_CURRENT_CORE_ABI_VERSION 78
 
 // Minimum ABI version that is supported for loading of plugins. Plugins that
 // are linked to an ABI version less than this will not be able to load and
@@ -1657,6 +1657,7 @@ extern "C"
 		BNBinaryView* (*parse)(void* ctxt, BNBinaryView* data);
 		bool (*isValidForData)(void* ctxt, BNBinaryView* data);
 		bool (*isDeprecated)(void* ctxt);
+		bool (*isForceLoadable)(void* ctxt);
 		BNSettings* (*getLoadSettingsForData)(void* ctxt, BNBinaryView* data);
 	} BNCustomBinaryViewType;
 
@@ -4001,6 +4002,7 @@ extern "C"
 	BINARYNINJACOREAPI BNBinaryView* BNCreateBinaryViewOfType(BNBinaryViewType* type, BNBinaryView* data);
 	BINARYNINJACOREAPI BNBinaryView* BNParseBinaryViewOfType(BNBinaryViewType* type, BNBinaryView* data);
 	BINARYNINJACOREAPI bool BNIsBinaryViewTypeValidForData(BNBinaryViewType* type, BNBinaryView* data);
+	BINARYNINJACOREAPI bool BNIsBinaryViewTypeForceLoadable(BNBinaryViewType* type);
 	BINARYNINJACOREAPI BNSettings* BNGetBinaryViewDefaultLoadSettingsForData(
 	    BNBinaryViewType* type, BNBinaryView* data);
 	BINARYNINJACOREAPI BNSettings* BNGetBinaryViewLoadSettingsForData(BNBinaryViewType* type, BNBinaryView* data);

--- a/binaryviewtype.cpp
+++ b/binaryviewtype.cpp
@@ -61,6 +61,13 @@ bool BinaryViewType::IsDeprecatedCallback(void* ctxt)
 }
 
 
+bool BinaryViewType::IsForceLoadableCallback(void* ctxt)
+{
+	CallbackRef<BinaryViewType> type(ctxt);
+	return type->IsForceLoadable();
+}
+
+
 BNSettings* BinaryViewType::GetSettingsCallback(void* ctxt, BNBinaryView* data)
 {
 	CallbackRef<BinaryViewType> type(ctxt);
@@ -93,6 +100,7 @@ void BinaryViewType::Register(BinaryViewType* type)
 	callbacks.parse = ParseCallback;
 	callbacks.isValidForData = IsValidCallback;
 	callbacks.isDeprecated = IsDeprecatedCallback;
+	callbacks.isForceLoadable = IsForceLoadableCallback;
 	callbacks.getLoadSettingsForData = GetSettingsCallback;
 
 	type->AddRefForRegistration();
@@ -247,6 +255,12 @@ bool BinaryViewType::IsDeprecated()
 }
 
 
+bool BinaryViewType::IsForceLoadable()
+{
+	return false;
+}
+
+
 void BinaryViewType::RegisterBinaryViewFinalizationEvent(const function<void(BinaryView* view)>& callback)
 {
 	BinaryViewEvent* event = new BinaryViewEvent;
@@ -344,6 +358,12 @@ bool CoreBinaryViewType::IsTypeValidForData(BinaryView* data)
 bool CoreBinaryViewType::IsDeprecated()
 {
 	return BNIsBinaryViewTypeDeprecated(m_object);
+}
+
+
+bool CoreBinaryViewType::IsForceLoadable()
+{
+	return BNIsBinaryViewTypeForceLoadable(m_object);
 }
 
 

--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -1271,6 +1271,11 @@ class BinaryViewType(metaclass=_BinaryViewTypeMetaclass):
 		"""returns if the BinaryViewType is deprecated (read-only)"""
 		return core.BNIsBinaryViewTypeDeprecated(self.handle)
 
+	@property
+	def is_force_loadable(self) -> bool:
+		"""returns if the BinaryViewType is force loadable (read-only)"""
+		return core.BNIsBinaryViewTypeForceLoadable(self.handle)
+
 	def create(self, data: 'BinaryView') -> Optional['BinaryView']:
 		view = core.BNCreateBinaryViewOfType(self.handle, data.handle)
 		if view is None:
@@ -2511,6 +2516,7 @@ class BinaryView:
 		cls._registered_cb.parse = cls._registered_cb.parse.__class__(cls._parse)
 		cls._registered_cb.isValidForData = cls._registered_cb.isValidForData.__class__(cls._is_valid_for_data)
 		cls._registered_cb.isDeprecated = cls._registered_cb.isDeprecated.__class__(cls._is_deprecated)
+		cls._registered_cb.isForceLoadable = cls._registered_cb.isForceLoadable.__class__(cls._is_force_loadable)
 		cls._registered_cb.getLoadSettingsForData = cls._registered_cb.getLoadSettingsForData.__class__(
 		    cls._get_load_settings_for_data
 		)
@@ -2575,6 +2581,17 @@ class BinaryView:
 
 		try:
 			return cls.is_deprecated()  # type: ignore
+		except:
+			log_error(traceback.format_exc())
+			return False
+
+	@classmethod
+	def _is_force_loadable(cls, ctxt):
+		if not callable(getattr(cls, 'is_force_loadable', None)):
+			return False
+
+		try:
+			return cls.is_force_loadable()  # type: ignore
 		except:
 			log_error(traceback.format_exc())
 			return False

--- a/rust/examples/minidump/src/view.rs
+++ b/rust/examples/minidump/src/view.rs
@@ -48,6 +48,10 @@ impl BinaryViewTypeBase for MinidumpBinaryViewType {
         false
     }
 
+    fn is_force_loadable(&self) -> bool {
+        false
+    }
+
     fn is_valid_for(&self, data: &BinaryView) -> bool {
         let mut magic_number = Vec::<u8>::new();
         data.read_into_vec(&mut magic_number, 0, 4);

--- a/rust/src/custombinaryview.rs
+++ b/rust/src/custombinaryview.rs
@@ -68,6 +68,16 @@ where
         })
     }
 
+    extern "C" fn cb_force_loadable<T>(ctxt: *mut c_void) -> bool
+    where
+        T: CustomBinaryViewType,
+    {
+        ffi_wrap!("BinaryViewTypeBase::is_force_loadable", unsafe {
+            let view_type = &*(ctxt as *mut T);
+            view_type.is_force_loadable()
+        })
+    }
+
     extern "C" fn cb_create<T>(ctxt: *mut c_void, data: *mut BNBinaryView) -> *mut BNBinaryView
     where
         T: CustomBinaryViewType,
@@ -153,6 +163,7 @@ where
         parse: Some(cb_parse::<T>),
         isValidForData: Some(cb_valid::<T>),
         isDeprecated: Some(cb_deprecated::<T>),
+        isForceLoadable: Some(cb_force_loadable::<T>),
         getLoadSettingsForData: Some(cb_load_settings::<T>),
     };
 
@@ -179,6 +190,10 @@ pub trait BinaryViewTypeBase: AsRef<BinaryViewType> {
     fn is_valid_for(&self, data: &BinaryView) -> bool;
 
     fn is_deprecated(&self) -> bool {
+        false
+    }
+
+    fn is_force_loadable(&self) -> bool {
         false
     }
 
@@ -294,6 +309,10 @@ impl BinaryViewTypeBase for BinaryViewType {
 
     fn is_deprecated(&self) -> bool {
         unsafe { BNIsBinaryViewTypeDeprecated(self.0) }
+    }
+
+    fn is_force_loadable(&self) -> bool {
+        unsafe { BNIsBinaryViewTypeForceLoadable(self.0) }
     }
 
     fn load_settings_for_data(&self, data: &BinaryView) -> Option<Ref<Settings>> {

--- a/ui/options.h
+++ b/ui/options.h
@@ -32,8 +32,6 @@ class BINARYNINJAUIAPI OptionsDialog : public QDialog
 	QString m_fileName;
 	QLabel* m_fileLabel;
 	QComboBox* m_loadAsCombo;
-	QPushButton* m_loadAsButton;
-	QLabel* m_loadAsLabel;
 	QLabel* m_objectLabel;
 	QComboBox* m_objectCombo;
 	QTabWidget* m_tab;
@@ -67,5 +65,5 @@ class BINARYNINJAUIAPI OptionsDialog : public QDialog
 	void removeTabAndSettingsView(int index);
 	void viewTabChanged(int index);
 	void viewTabCloseRequested(int index);
-	void loadAsButtonPushed();
+	void viewTypeSelectionChanged();
 };

--- a/ui/options.h
+++ b/ui/options.h
@@ -31,6 +31,9 @@ class BINARYNINJAUIAPI OptionsDialog : public QDialog
 
 	QString m_fileName;
 	QLabel* m_fileLabel;
+	QComboBox* m_loadAsCombo;
+	QPushButton* m_loadAsButton;
+	QLabel* m_loadAsLabel;
 	QLabel* m_objectLabel;
 	QComboBox* m_objectCombo;
 	QTabWidget* m_tab;
@@ -61,6 +64,8 @@ class BINARYNINJAUIAPI OptionsDialog : public QDialog
 	void cancel();
 	void open();
 	void addSettingsViewForType(const std::string& bvtName);
+	void removeTabAndSettingsView(int index);
 	void viewTabChanged(int index);
 	void viewTabCloseRequested(int index);
+	void loadAsButtonPushed();
 };

--- a/ui/options.h
+++ b/ui/options.h
@@ -32,6 +32,7 @@ class BINARYNINJAUIAPI OptionsDialog : public QDialog
 	QString m_fileName;
 	QLabel* m_fileLabel;
 	QComboBox* m_loadAsCombo;
+	QLabel* m_loadAsLabel;
 	QLabel* m_objectLabel;
 	QComboBox* m_objectCombo;
 	QTabWidget* m_tab;


### PR DESCRIPTION
This PR adds the `IsForceLoadable` method to the `BinaryViewType` class. This was done to allow selection of binary view types for raw binary formats. It allows users to select binary views from the "Open with Options" UI regardless of whether or not `BinaryViewType->IsValidForData` returns `true`. `IsForceLoadable` returns `false` for all existing views, but can be overridden in new views for binary formats that don't contain any header information that can be used to detect compatibility.

Related PR: https://github.com/Vector35/binaryninja/pull/811