### PR TITLE
doc: Add `BackgroundTaskThread` python example

### DIFF
--- a/python/examples/update_analysis.py
+++ b/python/examples/update_analysis.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2015-2024 Vector 35 Inc
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+from binaryninja import BackgroundTaskThread, PluginCommand
+
+
+class MyPlugin(BackgroundTaskThread):
+    """
+    Sample plugin that uses a BackgroundTaskThread to perform work.
+    This prevents the UI from freezing while the plugin is running and allows the plugin to call update_analysis_and_wait.
+
+    Note this is for a python plugin, so the steps detailed here apply: https://docs.binary.ninja/dev/plugins.html
+    i.e. needing a plugin.json etc.
+    """
+    def __init__(self, bv):
+        BackgroundTaskThread.__init__(self, 'Doing my plugin stuff', True)
+        self.bv = bv
+
+    def run(self):
+        # Do stuff
+        self.bv.update_analysis_and_wait()
+
+def main(bv):
+    MyPlugin(bv).start()
+
+
+PluginCommand.register('My plugin', 'My plugin description', main)


### PR DESCRIPTION
To allow python plugins to do work not on the UI thread. 

Also allows them to call `update_analysis_and_wait()`.

Tested with a basic plugin.json as a full plugin and works.