### PR TITLE
Fix unexpected behavior in BasicBlockList iteration

### DIFF
--- a/python/function.py
+++ b/python/function.py
@@ -237,7 +237,7 @@ class BasicBlockList:
 		return self._count.value
 
 	def __iter__(self):
-		return self
+		return BasicBlockList(self._function)
 
 	def __next__(self) -> 'basicblock.BasicBlock':
 		if self._n >= len(self):


### PR DESCRIPTION
The culprit here is the `_n` class member which serves as the counter for the `__next__` function. That needs to be reset when iterating through the list. Making a new instance fixes that issue. Fixes #4736 