### PR TITLE
Fix signature path lookup for core signatures in WARP

### DIFF
--- a/plugins/warp/src/matcher.rs
+++ b/plugins/warp/src/matcher.rs
@@ -63,11 +63,10 @@ impl Matcher {
         let platform_name = platform.name().to_string();
         // Get core signatures for the given platform
         let install_dir = binaryninja::install_directory().unwrap();
-        let core_dir = install_dir.parent().unwrap();
         #[cfg(target_os = "macos")]
-        let root_core_sig_dir = core_dir.join("Resources").join("signatures");
+        let root_core_sig_dir = install_dir.parent().unwrap().join("Resources").join("signatures");
         #[cfg(not(target_os = "macos"))]
-        let root_core_sig_dir = core_dir.join("signatures");
+        let root_core_sig_dir = install_dir.join("signatures");
         let plat_core_sig_dir = root_core_sig_dir.join(&platform_name);
         let mut data = get_data_from_dir(&plat_core_sig_dir);
 


### PR DESCRIPTION
Windows and linux were looking in the wrong place for the bundled WARP signatures. This fixes that