### PR TITLE
fix shrx, shlx, sarx, rorx

### DIFF
--- a/arch/x86/il.cpp
+++ b/arch/x86/il.cpp
@@ -2939,8 +2939,8 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 		il.AddInstruction(
 			WriteILOperand(il, xedd, addr, 0, 0,
 				il.RotateRight(opOneLen,
-					ReadILOperand(il, xedd, addr, 0, 0),
-					ReadILOperand(il, xedd, addr, 1, 1)
+					ReadILOperand(il, xedd, addr, 1, 1),
+					ReadILOperand(il, xedd, addr, 2, 2)
 				)));
 		break;
 
@@ -2957,8 +2957,8 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 		il.AddInstruction(
 			WriteILOperand(il, xedd, addr, 0, 0,
 				il.ArithShiftRight(opOneLen,
-					ReadILOperand(il, xedd, addr, 0, 0),
-					ReadILOperand(il, xedd, addr, 1, 1)
+					ReadILOperand(il, xedd, addr, 1, 1),
+					ReadILOperand(il, xedd, addr, 2, 2)
 				)));
 		break;
 
@@ -3128,8 +3128,8 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 		il.AddInstruction(
 			WriteILOperand(il, xedd, addr, 0, 0,
 				il.ShiftLeft(opOneLen,
-					ReadILOperand(il, xedd, addr, 0, 0),
-					ReadILOperand(il, xedd, addr, 1, 1)
+					ReadILOperand(il, xedd, addr, 1, 1),
+					ReadILOperand(il, xedd, addr, 2, 2)
 				)));
 		break;
 
@@ -3137,8 +3137,8 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 		il.AddInstruction(
 			WriteILOperand(il, xedd, addr, 0, 0,
 				il.LogicalShiftRight(opOneLen,
-					ReadILOperand(il, xedd, addr, 0, 0),
-					ReadILOperand(il, xedd, addr, 1, 1)
+					ReadILOperand(il, xedd, addr, 1, 1),
+					ReadILOperand(il, xedd, addr, 2, 2)
 				)));
 		break;
 

--- a/arch/x86/test_lifting.py
+++ b/arch/x86/test_lifting.py
@@ -103,8 +103,14 @@ tests_movd = [
     ),
 ]
 
+test_shiftx = [
+    (b'\xc4\xe2\x4b\xf7\xc0', 'LLIL_SET_REG.d(eax,LLIL_LSR.d(LLIL_REG.d(eax),LLIL_REG.d(esi)))'), # shrx eax, eax, esi
+    (b'\xc4\xe2\x49\xf7\xc0', 'LLIL_SET_REG.d(eax,LLIL_LSL.d(LLIL_REG.d(eax),LLIL_REG.d(esi)))'), # shlx eax, eax, esi
+    (b'\xc4\xe2\x4a\xf7\xc0', 'LLIL_SET_REG.d(eax,LLIL_ASR.d(LLIL_REG.d(eax),LLIL_REG.d(esi)))'), # sarx eax, eax, esi
+    (b'\xc4\xe3\x7b\xf0\xc0\x05', 'LLIL_SET_REG.d(eax,LLIL_ROR.d(LLIL_REG.d(eax),LLIL_CONST.d(0x5)))'), # rorx eax, eax, 5
+]
 
-test_cases = tests_interrupts + tests_basics + tests_movd
+test_cases = tests_interrupts + tests_basics + tests_movd + test_shiftx
 
 import re
 import sys


### PR DESCRIPTION
All had the same off by 1 in addressing operands.

ref: 
- https://www.felixcloutier.com/x86/sarx:shlx:shrx
- https://www.felixcloutier.com/x86/rorx
