### PR TITLE
[SharedCache] Cache type libraries

### DIFF
--- a/view/sharedcache/core/SharedCache.h
+++ b/view/sharedcache/core/SharedCache.h
@@ -538,6 +538,8 @@ namespace SharedCacheCore {
 
 		struct State;
 
+		struct ViewSpecificState;
+
 	private:
 		Ref<Logger> m_logger;
 		/* VIEW STATE BEGIN -- SERIALIZE ALL OF THIS AND STORE IT IN RAW VIEW */
@@ -552,6 +554,7 @@ namespace SharedCacheCore {
 		bool m_metadataValid = false;
 
 		/* VIEWSTATE END -- NOTHING PAST THIS IS SERIALIZED */
+		std::shared_ptr<ViewSpecificState> m_viewSpecificState;
 
 		/* API VIEW START */
 		BinaryNinja::Ref<BinaryNinja::BinaryView> m_dscView;

--- a/view/sharedcache/core/SharedCache.h
+++ b/view/sharedcache/core/SharedCache.h
@@ -603,6 +603,7 @@ namespace SharedCacheCore {
 		explicit SharedCache(BinaryNinja::Ref<BinaryNinja::BinaryView> rawView);
 		virtual ~SharedCache();
 
+private:
 		std::optional<SharedCacheMachOHeader> LoadHeaderForAddress(
 			std::shared_ptr<VM> vm, uint64_t address, std::string installName);
 		void InitializeHeader(
@@ -611,6 +612,8 @@ namespace SharedCacheCore {
 			uint64_t textBase, const std::string& currentText, size_t cursor, uint32_t endGuard);
 		std::vector<Ref<Symbol>> ParseExportTrie(
 			std::shared_ptr<MMappedFileAccessor> linkeditFile, SharedCacheMachOHeader header);
+
+		Ref<TypeLibrary> TypeLibraryForImage(const std::string& installName);
 
 		const State& State() const { return *m_state; }
 		struct State& MutableState() { AssertMutable(); return *m_state; }


### PR DESCRIPTION
Type libraries are surprisingly expensive to look up via `BinaryView`. Caching them can speed up `FindSymbolAtAddrAndApplyToAddr` significantly.

1. View-specific state

    The first commit refactors how view-specific state is stored to make it easier to work with. This was motivated by wanting to be able to clean up view-specific state when a view goes away, and some data races I noticed in how the existing view-specific state is accessed.

    The existing view-specific state was stored in several global unordered maps. Many of these were accessed without locking, including `viewSpecificMutexes`, which is racy in the face of multiple threads. The view-specific state is never cleaned up and remains in place after the given view is gone.

    View-specific state is now stored in a heap-allocated `ViewSpecificState` struct that is reference counted via `std::shared_ptr`. A static map holds a `std::weak_ptr` to each view-specific state, keyed by the session's file id. `SharedCache` retrieves or creates its view-specific state during its constructor.

    Since `ViewSpecificState` is reference counted it will naturally be deallocated when the last `SharedCache` instance that references it goes away. Its corresponding entry will remain in the static map, though since it only holds a `std::weak_ptr` rather than any state it will not use much memory. The next time view-specific state is retrieved any expired entries will be removed from the map.

2. The caching

    The second commit moves lookup of type libraries into a function and has it first consult a cache on the view-specific state. The cache stores both found type libraries and the absence of a type library (`nullptr`). The type library is only looked up on the view if it's not present in the cache.

---

This was inspired by investigation done by @WeiN76LQh and solves the same problem as their #6195.