### PR TITLE
[SharedCache] Fix `DSCObjCProcessor::PostProcessObjCSections` and improve Objective-C processing

### DIFF
--- a/view/sharedcache/api/python/_sharedcachecore.py
+++ b/view/sharedcache/api/python/_sharedcachecore.py
@@ -528,15 +528,17 @@ _BNDSCViewLoadImageContainingAddress.restype = ctypes.c_bool
 _BNDSCViewLoadImageContainingAddress.argtypes = [
 		ctypes.POINTER(BNSharedCache),
 		ctypes.c_ulonglong,
+		ctypes.c_bool,
 	]
 
 
 # noinspection PyPep8Naming
 def BNDSCViewLoadImageContainingAddress(
 		cache: ctypes.POINTER(BNSharedCache), 
-		address: int
+		address: int, 
+		skipObjC: bool
 		) -> bool:
-	return _BNDSCViewLoadImageContainingAddress(cache, address)
+	return _BNDSCViewLoadImageContainingAddress(cache, address, skipObjC)
 
 
 # -------------------------------------------------------
@@ -547,15 +549,17 @@ _BNDSCViewLoadImageWithInstallName.restype = ctypes.c_bool
 _BNDSCViewLoadImageWithInstallName.argtypes = [
 		ctypes.POINTER(BNSharedCache),
 		ctypes.c_char_p,
+		ctypes.c_bool,
 	]
 
 
 # noinspection PyPep8Naming
 def BNDSCViewLoadImageWithInstallName(
 		cache: ctypes.POINTER(BNSharedCache), 
-		name: Optional[str]
+		name: Optional[str], 
+		skipObjC: bool
 		) -> bool:
-	return _BNDSCViewLoadImageWithInstallName(cache, cstr(name))
+	return _BNDSCViewLoadImageWithInstallName(cache, cstr(name), skipObjC)
 
 
 # -------------------------------------------------------

--- a/view/sharedcache/api/python/_sharedcachecore.py
+++ b/view/sharedcache/api/python/_sharedcachecore.py
@@ -582,6 +582,44 @@ def BNDSCViewLoadSectionAtAddress(
 
 
 # -------------------------------------------------------
+# _BNDSCViewProcessAllObjCSections
+
+_BNDSCViewProcessAllObjCSections = core.BNDSCViewProcessAllObjCSections
+_BNDSCViewProcessAllObjCSections.restype = None
+_BNDSCViewProcessAllObjCSections.argtypes = [
+		ctypes.POINTER(BNSharedCache),
+	]
+
+
+# noinspection PyPep8Naming
+def BNDSCViewProcessAllObjCSections(
+		cache: ctypes.POINTER(BNSharedCache)
+		) -> None:
+	return _BNDSCViewProcessAllObjCSections(cache)
+
+
+# -------------------------------------------------------
+# _BNDSCViewProcessObjCSectionsForImageWithInstallName
+
+_BNDSCViewProcessObjCSectionsForImageWithInstallName = core.BNDSCViewProcessObjCSectionsForImageWithInstallName
+_BNDSCViewProcessObjCSectionsForImageWithInstallName.restype = None
+_BNDSCViewProcessObjCSectionsForImageWithInstallName.argtypes = [
+		ctypes.POINTER(BNSharedCache),
+		ctypes.c_char_p,
+		ctypes.c_bool,
+	]
+
+
+# noinspection PyPep8Naming
+def BNDSCViewProcessObjCSectionsForImageWithInstallName(
+		cache: ctypes.POINTER(BNSharedCache), 
+		name: Optional[str], 
+		deallocName: bool
+		) -> None:
+	return _BNDSCViewProcessObjCSectionsForImageWithInstallName(cache, cstr(name), deallocName)
+
+
+# -------------------------------------------------------
 # _BNFreeSharedCacheReference
 
 _BNFreeSharedCacheReference = core.BNFreeSharedCacheReference

--- a/view/sharedcache/api/python/sharedcache.py
+++ b/view/sharedcache/api/python/sharedcache.py
@@ -108,14 +108,14 @@ class SharedCache:
 	def __init__(self, view):
 		self.handle = sccore.BNGetSharedCache(view.handle)
 
-	def load_image_with_install_name(self, installName):
-		return sccore.BNDSCViewLoadImageWithInstallName(self.handle, installName)
+	def load_image_with_install_name(self, installName, skipObjC = False):
+		return sccore.BNDSCViewLoadImageWithInstallName(self.handle, installName, skipObjC)
 
 	def load_section_at_address(self, addr):
 		return sccore.BNDSCViewLoadSectionAtAddress(self.handle, addr)
 
-	def load_image_containing_address(self, addr):
-		return sccore.BNDSCViewLoadImageContainingAddress(self.handle, addr)
+	def load_image_containing_address(self, addr, skipObjC = False):
+		return sccore.BNDSCViewLoadImageContainingAddress(self.handle, addr, skipObjC)
 
 	@property
 	def caches(self):

--- a/view/sharedcache/api/python/sharedcache.py
+++ b/view/sharedcache/api/python/sharedcache.py
@@ -117,6 +117,12 @@ class SharedCache:
 	def load_image_containing_address(self, addr, skipObjC = False):
 		return sccore.BNDSCViewLoadImageContainingAddress(self.handle, addr, skipObjC)
 
+	def process_objc_sections_for_image_with_install_name(self, installName):
+		return sccore.BNDSCViewProcessObjCSectionsForImageWithInstallName(self.handle, installName, False)
+
+	def process_all_objc_sections(self):
+		return sccore.BNDSCViewProcessAllObjCSections(self.handle)
+
 	@property
 	def caches(self):
 		count = ctypes.c_ulonglong()

--- a/view/sharedcache/api/sharedcache.cpp
+++ b/view/sharedcache/api/sharedcache.cpp
@@ -20,10 +20,10 @@ namespace SharedCacheAPI {
 		return BNDSCViewFastGetBackingCacheCount(view->GetObject());
 	}
 
-	bool SharedCache::LoadImageWithInstallName(std::string installName)
+	bool SharedCache::LoadImageWithInstallName(std::string installName, bool skipObjC)
 	{
 		char* str = BNAllocString(installName.c_str());
-		return BNDSCViewLoadImageWithInstallName(m_object, str);
+		return BNDSCViewLoadImageWithInstallName(m_object, str, skipObjC);
 	}
 
 	bool SharedCache::LoadSectionAtAddress(uint64_t addr)
@@ -31,9 +31,9 @@ namespace SharedCacheAPI {
 		return BNDSCViewLoadSectionAtAddress(m_object, addr);
 	}
 
-	bool SharedCache::LoadImageContainingAddress(uint64_t addr)
+	bool SharedCache::LoadImageContainingAddress(uint64_t addr, bool skipObjC)
 	{
-		return BNDSCViewLoadImageContainingAddress(m_object, addr);
+		return BNDSCViewLoadImageContainingAddress(m_object, addr, skipObjC);
 	}
 
 	std::vector<std::string> SharedCache::GetAvailableImages()

--- a/view/sharedcache/api/sharedcache.cpp
+++ b/view/sharedcache/api/sharedcache.cpp
@@ -55,6 +55,17 @@ namespace SharedCacheAPI {
 		return result;
 	}
 
+	void SharedCache::ProcessObjCSectionsForImageWithInstallName(std::string installName)
+	{
+		char* str = BNAllocString(installName.c_str());
+		BNDSCViewProcessObjCSectionsForImageWithInstallName(m_object, str, true);
+	}
+
+	void SharedCache::ProcessAllObjCSections()
+	{
+		BNDSCViewProcessAllObjCSections(m_object);
+	}
+
 	std::vector<DSCMemoryRegion> SharedCache::GetLoadedMemoryRegions()
 	{
 		size_t count;

--- a/view/sharedcache/api/sharedcacheapi.h
+++ b/view/sharedcache/api/sharedcacheapi.h
@@ -261,6 +261,9 @@ namespace SharedCacheAPI {
 		bool LoadSectionAtAddress(uint64_t addr);
 		bool LoadImageContainingAddress(uint64_t addr, bool skipObjC = false);
 		std::vector<std::string> GetAvailableImages();
+	
+		void ProcessObjCSectionsForImageWithInstallName(std::string installName);
+		void ProcessAllObjCSections();
 
 		std::vector<DSCSymbol> LoadAllSymbolsAndWait();
 

--- a/view/sharedcache/api/sharedcacheapi.h
+++ b/view/sharedcache/api/sharedcacheapi.h
@@ -257,9 +257,9 @@ namespace SharedCacheAPI {
 		static BNDSCViewLoadProgress GetLoadProgress(Ref<BinaryView> view);
 		static uint64_t FastGetBackingCacheCount(Ref<BinaryView> view);
 
-		bool LoadImageWithInstallName(std::string installName);
+		bool LoadImageWithInstallName(std::string installName, bool skipObjC = false);
 		bool LoadSectionAtAddress(uint64_t addr);
-		bool LoadImageContainingAddress(uint64_t addr);
+		bool LoadImageContainingAddress(uint64_t addr, bool skipObjC = false);
 		std::vector<std::string> GetAvailableImages();
 
 		std::vector<DSCSymbol> LoadAllSymbolsAndWait();

--- a/view/sharedcache/api/sharedcachecore.h
+++ b/view/sharedcache/api/sharedcachecore.h
@@ -120,9 +120,9 @@ extern "C"
 
 	SHAREDCACHE_FFI_API char** BNDSCViewGetInstallNames(BNSharedCache* cache, size_t* count);
 
-	SHAREDCACHE_FFI_API bool BNDSCViewLoadImageWithInstallName(BNSharedCache* cache, char* name);
+	SHAREDCACHE_FFI_API bool BNDSCViewLoadImageWithInstallName(BNSharedCache* cache, char* name, bool skipObjC);
 	SHAREDCACHE_FFI_API bool BNDSCViewLoadSectionAtAddress(BNSharedCache* cache, uint64_t name);
-	SHAREDCACHE_FFI_API bool BNDSCViewLoadImageContainingAddress(BNSharedCache* cache, uint64_t address);
+	SHAREDCACHE_FFI_API bool BNDSCViewLoadImageContainingAddress(BNSharedCache* cache, uint64_t address, bool skipObjC);
 
 	SHAREDCACHE_FFI_API char* BNDSCViewGetNameForAddress(BNSharedCache* cache, uint64_t address);
 	SHAREDCACHE_FFI_API char* BNDSCViewGetImageNameForAddress(BNSharedCache* cache, uint64_t address);

--- a/view/sharedcache/api/sharedcachecore.h
+++ b/view/sharedcache/api/sharedcachecore.h
@@ -123,6 +123,9 @@ extern "C"
 	SHAREDCACHE_FFI_API bool BNDSCViewLoadImageWithInstallName(BNSharedCache* cache, char* name, bool skipObjC);
 	SHAREDCACHE_FFI_API bool BNDSCViewLoadSectionAtAddress(BNSharedCache* cache, uint64_t name);
 	SHAREDCACHE_FFI_API bool BNDSCViewLoadImageContainingAddress(BNSharedCache* cache, uint64_t address, bool skipObjC);
+	
+	SHAREDCACHE_FFI_API void BNDSCViewProcessObjCSectionsForImageWithInstallName(BNSharedCache* cache, char* name, bool deallocName);
+	SHAREDCACHE_FFI_API void BNDSCViewProcessAllObjCSections(BNSharedCache* cache);
 
 	SHAREDCACHE_FFI_API char* BNDSCViewGetNameForAddress(BNSharedCache* cache, uint64_t address);
 	SHAREDCACHE_FFI_API char* BNDSCViewGetImageNameForAddress(BNSharedCache* cache, uint64_t address);

--- a/view/sharedcache/core/ObjC.cpp
+++ b/view/sharedcache/core/ObjC.cpp
@@ -1087,16 +1087,16 @@ void DSCObjCProcessor::ApplyMethodTypes(Class& cls)
 	}
 }
 
-void DSCObjCProcessor::PostProcessObjCSections(VMReader* reader)
+void DSCObjCProcessor::PostProcessObjCSections(VMReader* reader, std::string baseName)
 {
 	auto ptrSize = m_data->GetAddressSize();
-	if (auto imageInfo = m_data->GetSectionByName("__objc_imageinfo"))
+	if (auto imageInfo = m_data->GetSectionByName(baseName + "::__objc_imageinfo"))
 	{
 		auto start = imageInfo->GetStart();
 		auto type = Type::NamedType(m_data, m_typeNames.imageInfo);
 		m_data->DefineDataVariable(start, type);
 	}
-	if (auto selrefs = m_data->GetSectionByName("__objc_selrefs"))
+	if (auto selrefs = m_data->GetSectionByName(baseName + "::__objc_selrefs"))
 	{
 		auto start = selrefs->GetStart();
 		auto end = selrefs->GetEnd();
@@ -1119,7 +1119,7 @@ void DSCObjCProcessor::PostProcessObjCSections(VMReader* reader)
 			DefineObjCSymbol(DataSymbol, type, "selRef_" + sel, i, true);
 		}
 	}
-	if (auto superRefs = m_data->GetSectionByName("__objc_classrefs"))
+	if (auto superRefs = m_data->GetSectionByName(baseName + "::__objc_classrefs"))
 	{
 		auto start = superRefs->GetStart();
 		auto end = superRefs->GetEnd();
@@ -1137,7 +1137,7 @@ void DSCObjCProcessor::PostProcessObjCSections(VMReader* reader)
 			}
 		}
 	}
-	if (auto superRefs = m_data->GetSectionByName("__objc_superrefs"))
+	if (auto superRefs = m_data->GetSectionByName(baseName + "::__objc_superrefs"))
 	{
 		auto start = superRefs->GetStart();
 		auto end = superRefs->GetEnd();
@@ -1155,7 +1155,7 @@ void DSCObjCProcessor::PostProcessObjCSections(VMReader* reader)
 			}
 		}
 	}
-	if (auto protoRefs = m_data->GetSectionByName("__objc_protorefs"))
+	if (auto protoRefs = m_data->GetSectionByName(baseName + "::__objc_protorefs"))
 	{
 		auto start = protoRefs->GetStart();
 		auto end = protoRefs->GetEnd();
@@ -1173,7 +1173,7 @@ void DSCObjCProcessor::PostProcessObjCSections(VMReader* reader)
 			}
 		}
 	}
-	if (auto ivars = m_data->GetSectionByName("__objc_ivar"))
+	if (auto ivars = m_data->GetSectionByName(baseName + "::__objc_ivar"))
 	{
 		auto start = ivars->GetStart();
 		auto end = ivars->GetEnd();
@@ -1416,7 +1416,7 @@ void DSCObjCProcessor::ProcessObjCData(std::shared_ptr<VM> vm, std::string baseN
 	if (auto protoList = m_data->GetSectionByName(baseName + "::__objc_protolist"))
 		LoadProtocols(&reader, protoList);
 
-	PostProcessObjCSections(&reader);
+	PostProcessObjCSections(&reader, baseName);
 
 	auto id = m_data->BeginUndoActions();
 	m_symbolQueue->Process();

--- a/view/sharedcache/core/ObjC.h
+++ b/view/sharedcache/core/ObjC.h
@@ -222,7 +222,7 @@ namespace DSCObjC {
 		void GenerateClassTypes();
 		bool ApplyMethodType(Class& cls, Method& method, bool isInstanceMethod);
 		void ApplyMethodTypes(Class& cls);
-		void PostProcessObjCSections(VMReader* reader);
+		void PostProcessObjCSections(VMReader* reader, std::string baseName);
 	public:
 		DSCObjCProcessor(BinaryView* data, SharedCacheCore::SharedCache* cache, bool isBackedByDatabase);
 		void ProcessObjCData(std::shared_ptr<VM> vm, std::string baseName);

--- a/view/sharedcache/core/SharedCache.h
+++ b/view/sharedcache/core/SharedCache.h
@@ -574,6 +574,8 @@ namespace SharedCacheCore {
 		bool LoadImageWithInstallName(std::string installName, bool skipObjC);
 		bool LoadSectionAtAddress(uint64_t address);
 		bool LoadImageContainingAddress(uint64_t address, bool skipObjC);
+		void ProcessObjCSectionsForImageWithInstallName(std::string installName);
+		void ProcessAllObjCSections();
 		std::string NameForAddress(uint64_t address);
 		std::string ImageNameForAddress(uint64_t address);
 		std::vector<std::string> GetAvailableImages();

--- a/view/sharedcache/core/SharedCache.h
+++ b/view/sharedcache/core/SharedCache.h
@@ -571,9 +571,9 @@ namespace SharedCacheCore {
 		void ParseAndApplySlideInfoForFile(std::shared_ptr<MMappedFileAccessor> file);
 		std::optional<uint64_t> GetImageStart(std::string installName);
 		std::optional<SharedCacheMachOHeader> HeaderForAddress(uint64_t);
-		bool LoadImageWithInstallName(std::string installName);
+		bool LoadImageWithInstallName(std::string installName, bool skipObjC);
 		bool LoadSectionAtAddress(uint64_t address);
-		bool LoadImageContainingAddress(uint64_t address);
+		bool LoadImageContainingAddress(uint64_t address, bool skipObjC);
 		std::string NameForAddress(uint64_t address);
 		std::string ImageNameForAddress(uint64_t address);
 		std::vector<std::string> GetAvailableImages();


### PR DESCRIPTION
This pull request provides 3 commits that do the following:

1. The function `DSCObjCProcessor::PostProcessObjCSections` never does anything because it doesn't use the correct names to get the Objective-C sections of the recently loaded library. In fact it never does anything because the DSC never has sections with the names its searching for. This commit passes the `baseName` (the name of the library that was loaded), which is what other Objective-C section processing code does. Combining the base name with the section names it will now find them and process them as intended. This was resulting in alot of Objective-C related stuff being missed.
2. Modifies the DSC API so that there is an additional boolean argument for `load_image_containing_address` or `load_image_with_install_name` called `skipObjC` which defaults to `False`. If `True` in `SharedCache::LoadImageWithInstallName` the code that launches the Objective-C processor will be skipped. This provides users a way to manually defer Objective-C processing.
3. This commit provides a way for users to manually trigger Objective-C parsing against sections for a specific library or all libraries, via the API. 2 new API functions are added; `process_objc_sections_for_image_with_install_name` for processing the Objective-C sections of single DSC library that has been loaded, and `process_all_objc_sections` which will process Objective-C sections for all loaded libraries, even if they are only partially loaded.

The C++ API was also updated to support the API changes.

The purpose of the API changes comes down to the fact that there is a problem with processing Objective-C sections. At the time a library is loaded some of the references within those sections may refer to unload sections. This results in things like selectors not being correctly typed and named. There is currently no way for a user to trigger re-processing of Objective-C sections once the required sections have also been loaded. This pull request solves that and in addition allows the user to defer Objective-C processing until all the images they want to load have been loaded. This is more performant than processing Objective-C sections after each image is loaded and then against once they've all been loaded.

The following Python code can be used to demonstrate the new API changes:
```python
# 10 random libraries to load
libs = [
    "/System/Library/Frameworks/Foundation.framework/Foundation",
    "/usr/lib/libobjc.A.dylib",
    "/System/Library/Frameworks/AVFoundation.framework/AVFoundation",
    "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation",
    "/System/Library/Frameworks/CoreGraphics.framework/CoreGraphics",
    "/System/Library/Frameworks/CoreMedia.framework/CoreMedia",
    "/System/Library/Frameworks/CoreVideo.framework/CoreVideo",
    "/System/Library/PrivateFrameworks/AudioToolboxCore.framework/AudioToolboxCore",
    "/System/Library/PrivateFrameworks/AvatarKit.framework/AvatarKit",
    "/System/Library/PrivateFrameworks/UIKitCore.framework/UIKitCore",
]

import binaryninja.sharedcache
dsc = binaryninja.sharedcache.SharedCache(bv)

bv.set_analysis_hold(True) # hold analysis until all libraries are loaded
for lib in libs:
    print(f"Loading DSC library '{lib}'")
    dsc.load_image_with_install_name(lib, True) # skip ObjC processing

print("Processing Objective-C sections")
dsc.process_all_objc_sections() # process all the Objective-C sections of the libraries just loaded

bv.set_analysis_hold(False)
print("Running auto analysis")
bv.update_analysis_and_wait() # trigger analysis now everything is loaded and processed
```