### PR TITLE
[SharedCache] Reduce lock contention in `SharedCache::LoadSectionAtAddress`

### DIFF
--- a/view/sharedcache/core/SharedCache.cpp
+++ b/view/sharedcache/core/SharedCache.cpp
@@ -1577,8 +1577,8 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 
 				// The region appears not to be loaded. Acquire the loading lock, re-check 
 				// that it hasn't been loaded and if it still hasn't then actually load it.
-				std::unique_lock<std::mutex> memoryRegionLoadingLockslock(ViewSpecificStateForView(m_dscView)->memoryRegionLoadingMutexesMutex);
-				auto& memoryRegionLoadingMutex = ViewSpecificStateForView(m_dscView)->memoryRegionLoadingMutexes[stubIsland.start];
+				std::unique_lock<std::mutex> memoryRegionLoadingLockslock(m_viewSpecificState->memoryRegionLoadingMutexesMutex);
+				auto& memoryRegionLoadingMutex = m_viewSpecificState->memoryRegionLoadingMutexes[stubIsland.start];
 				// Now the specific memory region's loading mutex has been retrieved, this one can be dropped
 				memoryRegionLoadingLockslock.unlock();
 				// Hold this lock until loading of the region is done
@@ -1586,10 +1586,9 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 
 				// Check the latest state to see if the memory region has been loaded while acquiring the lock
 				{
-					auto viewSpecificState = ViewSpecificStateForView(m_dscView);
-					std::unique_lock<std::mutex> viewStateCacheLock(viewSpecificState->stateMutex);
+					std::unique_lock<std::mutex> viewStateCacheLock(m_viewSpecificState->stateMutex);
 					
-					for (auto& cacheStubIsland : viewSpecificState->state->m_stubIslandRegions)
+					for (auto& cacheStubIsland : m_viewSpecificState->state->m_stubIslandRegions)
 					{
 						if (cacheStubIsland.start <= address && cacheStubIsland.start + cacheStubIsland.size > address)
 						{
@@ -1604,7 +1603,7 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 				}
 
 				// Still not loaded, so load it below
-				std::unique_lock<std::mutex> lock(ViewSpecificStateForView(m_dscView)->viewOperationsThatInfluenceMetadataMutex);
+				std::unique_lock<std::mutex> lock(m_viewSpecificState->viewOperationsThatInfluenceMetadataMutex);
 				DeserializeFromRawView();
 
 				auto vm = GetVMMap();
@@ -1657,8 +1656,8 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 
 				// The region appears not to be loaded. Acquire the loading lock, re-check 
 				// that it hasn't been loaded and if it still hasn't then actually load it.
-				std::unique_lock<std::mutex> memoryRegionLoadingLockslock(ViewSpecificStateForView(m_dscView)->memoryRegionLoadingMutexesMutex);
-				auto& memoryRegionLoadingMutex = ViewSpecificStateForView(m_dscView)->memoryRegionLoadingMutexes[dyldData.start];
+				std::unique_lock<std::mutex> memoryRegionLoadingLockslock(m_viewSpecificState->memoryRegionLoadingMutexesMutex);
+				auto& memoryRegionLoadingMutex = m_viewSpecificState->memoryRegionLoadingMutexes[dyldData.start];
 				// Now the specific memory region's loading mutex has been retrieved, this one can be dropped
 				memoryRegionLoadingLockslock.unlock();
 				// Hold this lock until loading of the region is done
@@ -1666,10 +1665,9 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 
 				// Check the latest state to see if the memory region has been loaded while acquiring the lock
 				{
-					auto viewSpecificState = ViewSpecificStateForView(m_dscView);
-					std::unique_lock<std::mutex> viewStateCacheLock(viewSpecificState->stateMutex);
+					std::unique_lock<std::mutex> viewStateCacheLock(m_viewSpecificState->stateMutex);
 					
-					for (auto& cacheDyldData : viewSpecificState->state->m_dyldDataRegions)
+					for (auto& cacheDyldData : m_viewSpecificState->state->m_dyldDataRegions)
 					{
 						if (cacheDyldData.start <= address && cacheDyldData.start + cacheDyldData.size > address)
 						{
@@ -1684,7 +1682,7 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 				}
 
 				// Still not loaded, so load it below
-				std::unique_lock<std::mutex> lock(ViewSpecificStateForView(m_dscView)->viewOperationsThatInfluenceMetadataMutex);
+				std::unique_lock<std::mutex> lock(m_viewSpecificState->viewOperationsThatInfluenceMetadataMutex);
 				DeserializeFromRawView();
 
 				auto vm = GetVMMap();
@@ -1736,8 +1734,8 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 
 				// The region appears not to be loaded. Acquire the loading lock, re-check 
 				// that it hasn't been loaded and if it still hasn't then actually load it.
-				std::unique_lock<std::mutex> memoryRegionLoadingLockslock(ViewSpecificStateForView(m_dscView)->memoryRegionLoadingMutexesMutex);
-				auto& memoryRegionLoadingMutex = ViewSpecificStateForView(m_dscView)->memoryRegionLoadingMutexes[region.start];
+				std::unique_lock<std::mutex> memoryRegionLoadingLockslock(m_viewSpecificState->memoryRegionLoadingMutexesMutex);
+				auto& memoryRegionLoadingMutex = m_viewSpecificState->memoryRegionLoadingMutexes[region.start];
 				// Now the specific memory region's loading mutex has been retrieved, this one can be dropped
 				memoryRegionLoadingLockslock.unlock();
 				// Hold this lock until loading of the region is done
@@ -1745,7 +1743,7 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 
 				// Check the latest state to see if the memory region has been loaded while acquiring the lock
 				{
-					auto viewSpecificState = ViewSpecificStateForView(m_dscView);
+					auto viewSpecificState = m_viewSpecificState;
 					std::unique_lock<std::mutex> viewStateCacheLock(viewSpecificState->stateMutex);
 					
 					for (auto& cacheRegion : viewSpecificState->state->m_nonImageRegions)
@@ -1763,7 +1761,7 @@ bool SharedCache::LoadSectionAtAddress(uint64_t address)
 				}
 
 				// Still not loaded, so load it below
-				std::unique_lock<std::mutex> lock(ViewSpecificStateForView(m_dscView)->viewOperationsThatInfluenceMetadataMutex);
+				std::unique_lock<std::mutex> lock(m_viewSpecificState->viewOperationsThatInfluenceMetadataMutex);
 				DeserializeFromRawView();
 
 				auto vm = GetVMMap();

--- a/view/sharedcache/core/SharedCache.h
+++ b/view/sharedcache/core/SharedCache.h
@@ -1108,6 +1108,8 @@ namespace SharedCacheCore {
 			m_metadataValid = true;
 		}
 
+		struct ViewSpecificState;
+
 	private:
 		Ref<Logger> m_logger;
 		/* VIEW STATE BEGIN -- SERIALIZE ALL OF THIS AND STORE IT IN RAW VIEW */
@@ -1140,6 +1142,7 @@ namespace SharedCacheCore {
 		std::vector<MemoryRegion> m_nonImageRegions;
 
 		/* VIEWSTATE END -- NOTHING PAST THIS IS SERIALIZED */
+		std::shared_ptr<ViewSpecificState> m_viewSpecificState;
 
 		/* API VIEW START */
 		BinaryNinja::Ref<BinaryNinja::BinaryView> m_dscView;

--- a/view/sharedcache/core/SharedCache.h
+++ b/view/sharedcache/core/SharedCache.h
@@ -1191,6 +1191,7 @@ namespace SharedCacheCore {
 		explicit SharedCache(BinaryNinja::Ref<BinaryNinja::BinaryView> rawView);
 		~SharedCache() override;
 
+private:
 		std::optional<SharedCacheMachOHeader> LoadHeaderForAddress(
 			std::shared_ptr<VM> vm, uint64_t address, std::string installName);
 		void InitializeHeader(
@@ -1199,6 +1200,8 @@ namespace SharedCacheCore {
 			const std::string& currentText, size_t cursor, uint32_t endGuard);
 		std::vector<Ref<Symbol>> ParseExportTrie(
 			std::shared_ptr<MMappedFileAccessor> linkeditFile, SharedCacheMachOHeader header);
+
+		Ref<TypeLibrary> TypeLibraryForImage(const std::string& installName);
 	};
 
 


### PR DESCRIPTION
When loading a number of sections, for instance when an image is loaded, many of the analysis threads bottleneck in `SharedCache::LoadSectionAtAddress` trying to acquire the `viewOperationsThatInfluenceMetadataMutex` lock. This is a very expensive lock to try and acquire as it is used in a lot of places and held for long durations.

This commit improves performance in `SharedCache::LoadSectionAtAddress` by not acquiring the `viewOperationsThatInfluenceMetadataMutex` lock until absolutely necessary, i.e. when something actually needs to be loaded. Often what happens is many threads try to load the same sections but ending up queuing up to do this one at a time. The commit adds per memory region locking so that threads only block waiting for the memory region they require to be loaded. In most cases though, if the region is already loaded they won't wait at all because no lock is required to determine if this is the case.

**Note:** this PR is built on @bdash's PR https://github.com/Vector35/binaryninja-api/pull/6196 due to the fixes and improvements in view-specific state, as this commit adds view-specific mutexes. I thought it would be prudent to make use of those changes.

To be honest I'm not 100% sure about the use of a map of mutexes to provide per memory region locking. It just feels a bit excessive but it works and the memory consumption of it won't be anything significant.