### PR TITLE
[SharedCache] Process the .symbols cache file

### DIFF
--- a/view/macho/machoview.cpp
+++ b/view/macho/machoview.cpp
@@ -14,13 +14,6 @@
 #include "lowlevelilinstruction.h"
 #include "rapidjsonwrapper.h"
 
-enum {
-	N_STAB = 0xe0,
-	N_PEXT = 0x10,
-	N_TYPE = 0x0e,
-	N_EXT  = 0x01
-};
-
 using namespace BinaryNinja;
 using namespace std;
 

--- a/view/sharedcache/CMakeLists.txt
+++ b/view/sharedcache/CMakeLists.txt
@@ -30,7 +30,7 @@ endif()
 set(HARD_FAIL_MODE OFF CACHE BOOL "Enable hard fail mode")
 set(SLIDEINFO_DEBUG_TAGS OFF CACHE BOOL "Enable debug tags in slideinfo")
 set(VIEW_NAME "DSCView" CACHE STRING "Name of the view")
-set(METADATA_VERSION 2 CACHE STRING "Version of the metadata")
+set(METADATA_VERSION 3 CACHE STRING "Version of the metadata")
 
 add_subdirectory(core)
 add_subdirectory(api)

--- a/view/sharedcache/api/python/_sharedcachecore.py
+++ b/view/sharedcache/api/python/_sharedcachecore.py
@@ -42,6 +42,7 @@ def free_string(value:ctypes.c_char_p) -> None:
     BNFreeString(ctypes.cast(value, ctypes.POINTER(ctypes.c_byte)))
 
 # Type definitions
+BackingCacheTypeEnum = ctypes.c_int
 from binaryninja._binaryninjacore import BNBinaryView, BNBinaryViewHandle
 class BNDSCBackingCache(ctypes.Structure):
 	@property
@@ -110,7 +111,7 @@ BNSharedCacheHandle = ctypes.POINTER(BNSharedCache)
 # Structure definitions
 BNDSCBackingCache._fields_ = [
 		("_path", ctypes.c_char_p),
-		("isPrimary", ctypes.c_bool),
+		("cacheType", BackingCacheTypeEnum),
 		("mappings", ctypes.POINTER(BNDSCBackingCacheMapping)),
 		("mappingCount", ctypes.c_ulonglong),
 	]

--- a/view/sharedcache/api/python/sharedcache.py
+++ b/view/sharedcache/api/python/sharedcache.py
@@ -52,14 +52,21 @@ class DSCBackingCacheMapping:
 @dataclasses.dataclass
 class DSCBackingCache:
 	path: str
-	isPrimary: bool
+	cacheType: BackingCacheType
 	mappings: list[DSCBackingCacheMapping]
 
 	def __str__(self):
 		return repr(self)
 
 	def __repr__(self):
-		return f"<DSCBackingCache {self.path} {'Primary' if self.isPrimary else 'Secondary'} | {len(self.mappings)} mappings>"
+		match self.cacheType:
+			case BackingCacheType.BackingCacheTypePrimary:
+				cacheTypeStr = 'Primary'
+			case BackingCacheType.BackingCacheTypeSecondary:
+				cacheTypeStr = 'Secondary'
+			case BackingCacheType.BackingCacheTypeSymbols:
+				cacheTypeStr = 'Symbols'
+		return f"<DSCBackingCache {self.path} {cacheTypeStr} | {len(self.mappings)} mappings>"
 
 
 @dataclasses.dataclass
@@ -136,7 +143,7 @@ class SharedCache:
 				mappings.append(mapping)
 			result.append(DSCBackingCache(
 				value[i].path,
-				value[i].isPrimary,
+				value[i].cacheType,
 				mappings
 			))
 

--- a/view/sharedcache/api/python/sharedcache_enums.py
+++ b/view/sharedcache/api/python/sharedcache_enums.py
@@ -1,6 +1,12 @@
 import enum
 
 
+class BackingCacheType(enum.IntEnum):
+	BackingCacheTypePrimary = 0
+	BackingCacheTypeSecondary = 1
+	BackingCacheTypeSymbols = 2
+
+
 class DSCViewLoadProgress(enum.IntEnum):
 	LoadProgressNotStarted = 0
 	LoadProgressLoadingCaches = 1

--- a/view/sharedcache/api/sharedcache.cpp
+++ b/view/sharedcache/api/sharedcache.cpp
@@ -91,7 +91,7 @@ namespace SharedCacheAPI {
 		{
 			BackingCache cache;
 			cache.path = value[i].path;
-			cache.isPrimary = value[i].isPrimary;
+			cache.cacheType = value[i].cacheType;
 			for (size_t j = 0; j < value[i].mappingCount; j++)
 			{
 				BackingCacheMapping mapping;

--- a/view/sharedcache/api/sharedcacheapi.h
+++ b/view/sharedcache/api/sharedcacheapi.h
@@ -105,7 +105,7 @@ namespace SharedCacheAPI {
 
 	struct BackingCache {
 		std::string path;
-		bool isPrimary;
+		BNBackingCacheType cacheType;
 		std::vector<BackingCacheMapping> mappings;
 	};
 

--- a/view/sharedcache/api/sharedcachecore.h
+++ b/view/sharedcache/api/sharedcachecore.h
@@ -64,6 +64,12 @@ extern "C"
 		LoadProgressFinished,
 	} BNDSCViewLoadProgress;
 
+	typedef enum BNBackingCacheType {
+		BackingCacheTypePrimary,
+		BackingCacheTypeSecondary,
+		BackingCacheTypeSymbols,
+	} BNBackingCacheType;
+
 	typedef struct BNBinaryView BNBinaryView;
 	typedef struct BNSharedCache BNSharedCache;
 
@@ -97,7 +103,7 @@ extern "C"
 
 	typedef struct BNDSCBackingCache {
 		char* path;
-		bool isPrimary;
+		BNBackingCacheType cacheType;
 		BNDSCBackingCacheMapping* mappings;
 		size_t mappingCount;
 	} BNDSCBackingCache;

--- a/view/sharedcache/core/SharedCache.h
+++ b/view/sharedcache/core/SharedCache.h
@@ -976,6 +976,27 @@ namespace SharedCacheCore {
 			}
 			m_activeContext.doc.AddMember("exportInfos", exportInfos, m_activeContext.allocator);
 
+			rapidjson::Document symbolInfos(rapidjson::kArrayType);
+			for (const auto& pair1 : m_symbolInfos)
+			{
+				rapidjson::Value subObj(rapidjson::kObjectType);
+				rapidjson::Value subArr(rapidjson::kArrayType);
+				for (const auto& pair2 : pair1.second)
+				{
+					rapidjson::Value subSubArr(rapidjson::kArrayType);
+					subSubArr.PushBack(pair2.first, m_activeContext.allocator);
+					subSubArr.PushBack(pair2.second.first, m_activeContext.allocator);
+					subSubArr.PushBack(pair2.second.second, m_activeContext.allocator);
+					subArr.PushBack(subSubArr, m_activeContext.allocator);
+				}
+
+				subObj.AddMember("key", pair1.first, m_activeContext.allocator);
+				subObj.AddMember("value", subArr, m_activeContext.allocator);
+
+				symbolInfos.PushBack(subObj, m_activeContext.allocator);
+			}
+			m_activeContext.doc.AddMember("symbolInfos", symbolInfos, m_activeContext.allocator);
+
 			rapidjson::Value backingCaches(rapidjson::kArrayType);
 			for (auto bc : m_backingCaches)
 			{
@@ -1055,12 +1076,12 @@ namespace SharedCacheCore {
 			for (auto& symbolInfo : m_activeDeserContext.doc["symbolInfos"].GetArray())
 			{
 				std::vector<std::pair<uint64_t, std::pair<BNSymbolType, std::string>>> symbolInfoVec;
-				for (auto& symbolInfoPair : symbolInfo.GetArray())
+				for (auto& symbolInfoPair : symbolInfo["value"].GetArray())
 				{
 					symbolInfoVec.push_back({symbolInfoPair[0].GetUint64(),
 						{(BNSymbolType)symbolInfoPair[1].GetUint(), symbolInfoPair[2].GetString()}});
 				}
-				m_symbolInfos[symbolInfo[0].GetUint64()] = symbolInfoVec;
+				m_symbolInfos[symbolInfo["key"].GetUint64()] = symbolInfoVec;
 			}
 			m_backingCaches.clear();
 			for (auto& bcV : m_activeDeserContext.doc["backingCaches"].GetArray())


### PR DESCRIPTION
A significant number of symbols are not being defined because there is currently no support for parsing the .symbols cache file. This commit adds that support.

Whenever `SharedCache::InitializeHeader` is called, the symbols for the image that header corresponds to, are read from the .symbols cache file and define within the binary view. This is the same place that symbols found in the Mach-O load commands and export trie are applied to the binary view. Some of the code in that function was reworked to be more DRY.

`m_symbolInfos` has been modified to be a vector of references to `Symbol`s which is similar to https://github.com/Vector35/binaryninja-api/pull/6197. It makes more sense for the use case where `m_symbolInfos` is used as a symbol cache, otherwise a bunch of time is spent transforming between the old style of `m_symbolInfos` entries to Binary Ninja `Symbol`s.

This commit does require a metadata version bump. I felt this was necessary to determine which symbols to load from the symbols cache. The problem is that the `m_images` container does not store the images in the order they are found in the DSC. The index they are at determines the location of their symbols in the symbols cache file. Rather than converting `m_images` to a vector and relying on its ordering being correct, it seemed more prudent to store the index of the image in the `CacheImage` structure. As this is serialized, the metadata version has to be bumped to accomodate the change.

**Note:** this PR is built on top of https://github.com/Vector35/binaryninja-api/pull/6174 because I felt like it made sense for that fix to be included.