### PR TITLE
Fix RISC-V JALR lift when rs1==rd

### DIFF
--- a/arch/riscv/src/lib.rs
+++ b/arch/riscv/src/lib.rs
@@ -1242,6 +1242,8 @@ impl<D: 'static + RiscVDisassembler + Send + Sync> architecture::Architecture fo
                     (1, _, _) => il.call(target).append(), // indirect call
                     (0, _, _) => il.jump(target).append(), // indirect jump
                     (_, _, _) => {
+                        // store the target in a temporary register so we don't clobber it when rd == rs1
+                        il.set_reg(max_width, llil::Register::Temp(0), target).append();
                         // indirect jump with storage of next address to non-`ra` register
                         il.set_reg(
                             max_width,
@@ -1249,7 +1251,7 @@ impl<D: 'static + RiscVDisassembler + Send + Sync> architecture::Architecture fo
                             il.const_ptr(addr.wrapping_add(inst_len)),
                         )
                         .append();
-                        il.jump(target).append();
+                        il.jump(il.reg(max_width, llil::Register::Temp(0))).append();
                     }
                 }
             }


### PR DESCRIPTION
When the source and destination register are the same, the current implementation of lifting for `jalr` in RISC-V results in the jump target being overwritten by the return address. This PR avoids the issue by copying the jump target to a LLIL temporary register before writing the destination register.

This situation comes up in certain binaries when LLVM optimizes for size and performs compiler outlining of register stack spills. The attached zipfile contains a build of a rust RISC-V Embassy project that demonstrates the issue in a function at 0x00000b08.
[riscv-jalr-issue.zip](https://github.com/user-attachments/files/17964210/riscv-jalr-issue.zip)
