### PR TITLE
MachO/ObjC: Avoid generating names containing non-printable chars

### DIFF
--- a/view/macho/objc.cpp
+++ b/view/macho/objc.cpp
@@ -1441,12 +1441,22 @@ void ObjCProcessor::ProcessCFStrings()
 					uint8_t* rawData = static_cast<uint8_t*>(data.GetData());
 					uint8_t* offsetAddress = rawData + bufferOff;
 					uint16_t c = *reinterpret_cast<uint16_t*>(offsetAddress);
-					if (c == 0x20)
+					if (c == 0x20) {
 						str.push_back('_');
-					else if (c < 0x80)
+					} else if (c == '\r') {
+						str.push_back('\\');
+						str.push_back('r');
+					} else if (c == '\n') {
+						str.push_back('\\');
+						str.push_back('n');
+					} else if (c == '\t') {
+						str.push_back('\\');
+						str.push_back('t');
+					} else if (c > 0x20 && c < 0x80) {
 						str.push_back(c);
-					else
+					} else {
 						str.push_back('?');
+					}
 				}
 				DefineObjCSymbol(
 					DataSymbol, Type::ArrayType(Type::WideCharType(2), size + 1), "ustr_" + str, strLoc, true);
@@ -1456,11 +1466,26 @@ void ObjCProcessor::ProcessCFStrings()
 			else  // UTF8 / ASCII
 			{
 				reader.Seek(strLoc);
-				str = reader.ReadCString(size + 1);
-				for (auto& c : str)
+				std::string rawStr = reader.ReadCString(size + 1);
+				str = "";
+				for (signed char c : rawStr)
 				{
-					if (c == ' ')
-						c = '_';
+					if (c == 0x20) {
+						str.push_back('_');
+					} else if (c == '\r') {
+						str.push_back('\\');
+						str.push_back('r');
+					} else if (c == '\n') {
+						str.push_back('\\');
+						str.push_back('n');
+					} else if (c == '\t') {
+						str.push_back('\\');
+						str.push_back('t');
+					} else if (c > 0x20 || c < 0) {
+						str.push_back(c);
+					} else {
+						str.push_back('?');
+					}
 				}
 				DefineObjCSymbol(DataSymbol, Type::ArrayType(Type::IntegerType(1, true), str.size() + 1), "cstr_" + str,
 					strLoc, true);


### PR DESCRIPTION
Avoid generating ObjC symbol names containing ASCII control characters for both 8 and 16 bit character encodings.

Behaviour is like before for each, except that ASCII control characters (0..0x1f) are replaced by ?, except for carriage return, line feed, and tabulator characters, which are replaced by \r, \n and \t respectively.

For an example CF string of `"Hello world!\r\n"`, with this change, the symbol would be named `cfstr_Hello_world!\r\n`, instead of w/o this change `cfstr_Hello_world!  ` with embedded CR/LF that display as slightly weird spaces.

Tested on latest stable by rebasing this change on top of [v4.2.6455-stable](https://github.com/Vector35/binaryninja-api/releases/tag/v4.2.6455-stable).