### PR TITLE
WARP: Update README with macOS library path instructions

### DIFF
--- a/plugins/warp/README.md
+++ b/plugins/warp/README.md
@@ -42,3 +42,12 @@ Example: `./sigem mylibrary.a` or `./sigem ./all-libs/`
 Once its finished you should see a `.sbin` file next to the input file, this can be moved into the corresponding signature folder (see the [user docs](https://docs.binary.ninja/dev/annotation.html?h=install+path#signature-library) for more info)
 
 If you encounter malloc errors or instability try and adjust the number of parallel threads using `RAYON_NUM_THREADS` environment variable (ex. `RAYON_NUM_THREADS=1 ./sigem mylib.a`)
+
+#### macOS
+
+If you are on macOS and the `sigem` binary fails to run due to missing `libbinaryninjacore.1.dylib`, you can set your [`DYLD_LIBRARY_PATH`](x-man-page://1/dyld) to include the `${DEP_BINARYNINJACORE_PATH}/Contents/MacOS/` directory.
+
+```sh
+export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${DEP_BINARYNINJACORE_PATH}/Contents/MacOS/"
+./sigem --help
+```

--- a/plugins/warp/README.md
+++ b/plugins/warp/README.md
@@ -42,12 +42,3 @@ Example: `./sigem mylibrary.a` or `./sigem ./all-libs/`
 Once its finished you should see a `.sbin` file next to the input file, this can be moved into the corresponding signature folder (see the [user docs](https://docs.binary.ninja/dev/annotation.html?h=install+path#signature-library) for more info)
 
 If you encounter malloc errors or instability try and adjust the number of parallel threads using `RAYON_NUM_THREADS` environment variable (ex. `RAYON_NUM_THREADS=1 ./sigem mylib.a`)
-
-#### macOS
-
-If you are on macOS and the `sigem` binary fails to run due to missing `libbinaryninjacore.1.dylib`, you can set your [`DYLD_LIBRARY_PATH`](x-man-page://1/dyld) to include the `${DEP_BINARYNINJACORE_PATH}/Contents/MacOS/` directory.
-
-```sh
-export DYLD_LIBRARY_PATH="${DYLD_LIBRARY_PATH}:${DEP_BINARYNINJACORE_PATH}/Contents/MacOS/"
-./sigem --help
-```


### PR DESCRIPTION
The README said to use `DEP_BINARYNINJACORE_PATH` but this was not referenced.

I updated the `build.rs` to use this variable, and as a treat I added the default install locations from the [User Guide](https://docs.binary.ninja/guide/)

I think this works on Windows too, but I do not have a Windows install to test. Thank you for the hard work on WARP I am excited to use it! 💜💜🥷