### PR TITLE
Fix Shared Cache Plugin out-of-tree build

### DIFF
--- a/view/sharedcache/CMakeLists.txt
+++ b/view/sharedcache/CMakeLists.txt
@@ -2,11 +2,14 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 
 project(sharedcache)
 
-if((NOT BN_API_PATH) AND (NOT BN_INTERNAL_BUILD))
-    set(BN_API_PATH $ENV{BN_API_PATH} CACHE STRING "Path to Binary Ninja API source")
-    if(NOT BN_API_PATH)
-        message(FATAL_ERROR "Provide path to Binary Ninja API source in BN_API_PATH")
-    endif()
+if(NOT BN_INTERNAL_BUILD)
+    find_path(
+        BN_API_PATH
+        NAMES binaryninjaapi.h
+        HINTS ../.. binaryninjaapi $ENV{BN_API_PATH}
+        REQUIRED
+    )
+    add_subdirectory(${BN_API_PATH} binaryninjaapi)
 endif()
 
 if (NOT BN_INTERNAL_BUILD)


### PR DESCRIPTION
Fixes #6275

```
❯ cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_PREFIX_PATH=/opt/homebrew/opt/qt/lib/cmake -DQT_VERSION=6.7.3 -S . -B build
-- The C compiler identification is AppleClang 16.0.0.16000026
-- The CXX compiler identification is AppleClang 16.0.0.16000026
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found BinaryNinjaCore: /Applications/Binary Ninja.app/Contents/MacOS/libbinaryninjacore.dylib
-- Found Binary Ninja Core: /Applications/Binary Ninja.app/Contents/MacOS/libbinaryninjacore.dylib
-- Binary Ninja Link Dirs: /Applications/Binary Ninja.app/Contents/MacOS
-- Binary Ninja Install Dir: /Applications/Binary Ninja.app
-- Binary Ninja User Plugins Dir: /Users/visual/Library/Application Support/Binary Ninja/plugins
-- {fmt} version: 11.0.2
-- Build type:
-- Performing Test HAS_NULLPTR_WARNING
-- Performing Test HAS_NULLPTR_WARNING - Success
-- Found Binary Ninja Core: /Applications/Binary Ninja.app/Contents/MacOS/libbinaryninjacore.dylib
-- Binary Ninja Link Dirs: /Applications/Binary Ninja.app/Contents/MacOS
-- Binary Ninja Install Dir: /Applications/Binary Ninja.app
-- Binary Ninja User Plugins Dir: /Users/visual/Library/Application Support/Binary Ninja/plugins
-- Found Qt CMake path: /opt/homebrew/lib/cmake
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Performing Test HAVE_STDATOMIC
-- Performing Test HAVE_STDATOMIC - Success
-- Found WrapAtomic: TRUE
-- Found OpenGL: /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.sdk/System/Library/Frameworks/OpenGL.framework
-- Found WrapOpenGL: TRUE
-- Could NOT find WrapVulkanHeaders (missing: Vulkan_INCLUDE_DIR)
-- Found BinaryNinjaUI: /Applications/Binary Ninja.app/Contents/MacOS/libbinaryninjaui.dylib
-- Found Binary Ninja UI: /Applications/Binary Ninja.app/Contents/MacOS/libbinaryninjaui.dylib
CMAKE_PREFIX_PATH is: /opt/homebrew/opt/qt/lib/cmake
CMake Deprecation Warning at api/python/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- RCD: OFF
CMake Deprecation Warning at ui/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.


-- Could NOT find WrapVulkanHeaders (missing: Vulkan_INCLUDE_DIR)

▓█████▄    ██████   ▄████▄     Shared Cache Plugin
▒██▀ ██▌ ▒██    ▒  ▒██▀ ▀█
░██   █▌ ░ ▓██▄    ▒▓█    ▄    Metadata Version:      3
░▓█▄  █▌   ▒   ██▒ ▒▓▓▄ ▄██▒   CMake Prefix Path:     /opt/homebrew/opt/qt/lib/cmake
░▒████▓  ▒██████▒▒▒  ▓███▀ ░   Qt Version:            6.7.3
 ▒▒▓  ▒ ▒ ▒▓▒ ▒ ░░ ░▒ ▒  ░     Crash on Failure:      OFF
 ░ ▒  ▒ ░ ░▒  ░ ░  ░  ▒        Slideinfo Debug Tags:  OFF
 ░ ░  ░ ░  ░  ░  ░             REFCOUNT_DEBUG:        OFF

-- Configuring done (1.1s)
-- Generating done (0.1s)
-- Build files have been written to: /Users/visual/Developer/binaryninja-api/view/sharedcache/build
```