### PR TITLE
[SharedCache] Fix uninitialized `loaded` field for mappings returned by `BNDSCViewGetAllImages`

### DIFF
--- a/view/sharedcache/core/SharedCache.cpp
+++ b/view/sharedcache/core/SharedCache.cpp
@@ -3059,6 +3059,11 @@ std::vector<MemoryRegion> SharedCache::GetMappedRegions() const
 	return State().regionsMappedIntoMemory;
 }
 
+bool SharedCache::IsMemoryMapped(uint64_t address)
+{
+	return m_dscView->IsValidOffset(address);
+}
+
 extern "C"
 {
 	BNSharedCache* BNGetSharedCache(BNBinaryView* data)
@@ -3322,11 +3327,13 @@ extern "C"
 				images[i].mappings = (BNDSCImageMemoryMapping*)malloc(sizeof(BNDSCImageMemoryMapping) * header.sections.size());
 				for (size_t j = 0; j < header.sections.size(); j++)
 				{
+					const auto sectionStart = header.sections[j].addr;
 					images[i].mappings[j].rawViewOffset = header.sections[j].offset;
-					images[i].mappings[j].vmAddress = header.sections[j].addr;
+					images[i].mappings[j].vmAddress = sectionStart;
 					images[i].mappings[j].size = header.sections[j].size;
 					images[i].mappings[j].name = BNAllocString(header.sectionNames[j].c_str());
-					images[i].mappings[j].filePath = BNAllocString(vm->MappingAtAddress(header.sections[j].addr).first.filePath.c_str());
+					images[i].mappings[j].filePath = BNAllocString(vm->MappingAtAddress(sectionStart).first.filePath.c_str());
+					images[i].mappings[j].loaded = cache->object->IsMemoryMapped(sectionStart);
 				}
 				i++;
 			}

--- a/view/sharedcache/core/SharedCache.h
+++ b/view/sharedcache/core/SharedCache.h
@@ -581,6 +581,7 @@ namespace SharedCacheCore {
 		std::vector<std::string> GetAvailableImages();
 
 		std::vector<MemoryRegion> GetMappedRegions() const;
+		bool IsMemoryMapped(uint64_t address);
 
 		std::vector<std::pair<std::string, Ref<Symbol>>> LoadAllSymbolsAndWait();
 


### PR DESCRIPTION
`BNDSCViewGetAllImages` was not initializing the field `loaded` on `BNDSCImageMemoryMapping` entries in the mappings array for each `BNDSCImage`. This would result in uninitialized values being returned, incorrectly indicating whether a memory region for an image was loaded or not.

The fix asks the binary view if a section start address is a valid offset to determine if the mapping is loaded or not. I'm not sure if this is the most performant solution but it fixes the issue.