### PR TITLE
[SharedCache] Inline `CFString`s

### DIFF
--- a/view/sharedcache/workflow/SharedCacheWorkflow.h
+++ b/view/sharedcache/workflow/SharedCacheWorkflow.h
@@ -7,6 +7,7 @@ using namespace BinaryNinja;
 #ifndef SHAREDCACHE_SHAREDCACHEWORKFLOW_H
 #define SHAREDCACHE_SHAREDCACHEWORKFLOW_H
 
+constexpr uint32_t CFSTRIntrinsicIndex = UINT32_MAX - 64;
 
 class SharedCacheWorkflow
 {


### PR DESCRIPTION
Basically just copied from the [workflow objc plugin](https://github.com/Vector35/workflow_objc) with [PR #67](https://github.com/Vector35/workflow_objc/pull/67) applied.

Ideally this would not be a copy and these 2 codebases would share the code but its unclear if Vector35 would want to import the Objective-C workflow plugin into the BN API repo and what that would look like. So this is an intermediary solution to get `CFString` inlining working in DSC.