### PR TITLE
[SharedCache] Avoid copying strings on each call to VM::MappingAtAddress

### DIFF
--- a/view/sharedcache/core/SharedCache.cpp
+++ b/view/sharedcache/core/SharedCache.cpp
@@ -780,7 +780,7 @@ void SharedCache::PerformInitialLoad()
 				if (imageHeader->linkeditPresent && vm->AddressIsMapped(imageHeader->linkeditSegment.vmaddr))
 				{
 					auto mapping = vm->MappingAtAddress(imageHeader->linkeditSegment.vmaddr);
-					imageHeader->exportTriePath = mapping.first.filePath;
+					imageHeader->exportTriePath = mapping.first.fileAccessor->filePath();
 				}
 				MutableState().headers[start.second] = imageHeader.value();
 				CacheImage image;
@@ -3330,7 +3330,8 @@ extern "C"
 						images[i].mappings[j].vmAddress = sectionStart;
 						images[i].mappings[j].size = header.sections[j].size;
 						images[i].mappings[j].name = BNAllocString(header.sectionNames[j].c_str());
-						images[i].mappings[j].filePath = BNAllocString(vm->MappingAtAddress(sectionStart).first.filePath.c_str());
+						auto fileAccessor = vm->MappingAtAddress(sectionStart).first.fileAccessor;
+						images[i].mappings[j].filePath = BNAllocStringWithLength(fileAccessor->filePath().data(), fileAccessor->filePath().length());
 						images[i].mappings[j].loaded = cache->object->IsMemoryMapped(sectionStart);
 					}
 					i++;


### PR DESCRIPTION
`PageMapping` was storing the path to the file it points within. This was causing unnecessary work within `VM::MappingAtAddress` as the `PageMapping`, and thus the path, is copied into the return value. This copying was more expensive than the map lookup.

The file path is now stored within a `LazyMappedFileAccessor` class that wraps the `SelfAllocatingWeakPtr`. This means the path is still available via the `PageMapping`, but it does not need to be copied as often.

This includes two additional improvements / minor optimizations made while I was touching the code in question:
1. `MMappedFileAccessor::Open` no longer performs two hash lookups when a file accessor already exists.
2. `VM::MapPages` takes the path by const reference to avoid an unnecessary copy.