### PR TITLE
[SharedCache] Improvements and fixes for `MMappedFileAccessor` stuff

### DIFF
--- a/view/sharedcache/core/VM.h
+++ b/view/sharedcache/core/VM.h
@@ -21,10 +21,30 @@ public:
 		cv_.notify_all();
 	}
 
-	void acquire() {
+    // Blocks for the specified number of seconds (or indefinitely if its 0) 
+    // or until the semaphore has a reference available. The timeout is to 
+    // prevent deadlocking if the caller is concerned about that. The caller 
+    // can determine if a ref was acquired by checking the return value. If a 
+    // ref was not acquired then a timeout occurred.
+	bool acquire(std::chrono::seconds timeout) {
 		std::unique_lock<std::mutex> lock(mutex_);
-		cv_.wait(lock, [this]() { return count_ > 0; });
-		--count_;
+		if (count_ > 0) {
+			--count_;
+			return true;
+		}
+		bool acquired = false;
+        if (timeout != std::chrono::seconds(0))
+        {
+            acquired = cv_.wait_for(lock, timeout, [this]() { return count_ > 0; });
+        }
+        else
+        {
+            cv_.wait(lock, [this]() { return count_ > 0; });
+            acquired = true;
+        }
+        if (acquired)
+		    --count_;
+        return acquired;
 	}
 
 	bool try_acquire() {
@@ -106,8 +126,8 @@ class MMAP {
 
 static uint64_t maxFPLimit;
 static std::mutex fileAccessorDequeMutex;
-static std::unordered_map<uint64_t, std::deque<std::shared_ptr<MMappedFileAccessor>>> fileAccessorReferenceHolder;
-static std::set<uint64_t> blockedSessionIDs;
+static std::unordered_map<uint64_t, std::deque<std::shared_ptr<MMappedFileAccessor>>> fileAccessorReferenceHolder; // access is protected by `fileAccessorDequeMutex`
+static std::set<uint64_t> blockedSessionIDs; // access is protected by `fileAccessorDequeMutex`
 static std::mutex fileAccessorsMutex;
 static std::unordered_map<std::string, std::shared_ptr<SelfAllocatingWeakPtr<MMappedFileAccessor>>> fileAccessors;
 static counting_semaphore fileAccessorSemaphore(0);


### PR DESCRIPTION
`MMappedFileAccessor::Open` wasn't really behaving as I think it was intended. It tried to use `fileAccessorSemaphore` to limit the number of concurrent files Binary Ninja could open. It didn't really confirm it had acquired a reference on `fileAccessorSemaphore` but then would always release one back when a `MMappedFileAccessor` was deallocated. This could actually inflate the count of `fileAccessorSemaphore` meaning it could end up with a higher file limit than originally set. Also using a worker to deallocate a `MMappedFileAccessor` on another thread felt like a bit of a gross hack and made synchronizing dropping a ref and acquiring one on `fileAccessorSemaphore` harder than it needed to be. This resulted in a bit of a rewrite of `MMappedFileAccessor::Open` to mitigate these issues. It now should respect the file limit set on startup but can go over it temporarily in extreme circumstances that I don't expect to occur in real world experiences.

Additionally there seemed to be some insufficient use of locking to synchronize accesses to certain data structures. I believe this commit has cleaned those up. They were causing very intermittent crashes.