### PR TITLE
[SharedCache] Optimize parsing and applying of slide info

### DIFF
--- a/view/sharedcache/core/SharedCache.cpp
+++ b/view/sharedcache/core/SharedCache.cpp
@@ -1078,7 +1078,6 @@ void SharedCache::ParseAndApplySlideInfoForFile(std::shared_ptr<MMappedFileAcces
 		MappingInfo map;
 
 		file->Read(&map.mappingInfo, baseHeader.mappingOffset + sizeof(dyld_cache_mapping_info), sizeof(dyld_cache_mapping_info));
-		map.file = file;
 		map.slideInfoVersion = slideInfoVersion;
 		if (map.slideInfoVersion == 2)
 			file->Read(&map.slideInfoV2, slideInfoOff, sizeof(dyld_cache_slide_info_v2));
@@ -1104,7 +1103,6 @@ void SharedCache::ParseAndApplySlideInfoForFile(std::shared_ptr<MMappedFileAcces
 			if (mappingAndSlideInfo.slideInfoFileOffset)
 			{
 				MappingInfo map;
-				map.file = file;
 				if (mappingAndSlideInfo.size == 0)
 					continue;
 				map.slideInfoVersion = file->ReadUInt32(mappingAndSlideInfo.slideInfoFileOffset);
@@ -1172,7 +1170,7 @@ void SharedCache::ParseAndApplySlideInfoForFile(std::shared_ptr<MMappedFileAcces
 			{
 				try
 				{
-					uint16_t start = mapping.file->ReadUShort(cursor);
+					uint16_t start = file->ReadUShort(cursor);
 					cursor += sizeof(uint16_t);
 					if (start == DYLD_CACHE_SLIDE_PAGE_ATTR_NO_REBASE)
 						continue;
@@ -1222,7 +1220,7 @@ void SharedCache::ParseAndApplySlideInfoForFile(std::shared_ptr<MMappedFileAcces
 							uint64_t extraCursor = extrasOffset + (j * sizeof(uint16_t));
 							try
 							{
-								auto extra = mapping.file->ReadUShort(extraCursor);
+								auto extra = file->ReadUShort(extraCursor);
 								uint16_t aStart = extra;
 								uint64_t page = mapping.mappingInfo.fileOffset + (pageSize * i);
 								uint16_t pageStartOffset = (aStart & 0x3FFF)*4;
@@ -1261,7 +1259,7 @@ void SharedCache::ParseAndApplySlideInfoForFile(std::shared_ptr<MMappedFileAcces
 			{
 				try
 				{
-					uint16_t delta = mapping.file->ReadUShort(cursor);
+					uint16_t delta = file->ReadUShort(cursor);
 					cursor += sizeof(uint16_t);
 					if (delta == DYLD_CACHE_SLIDE_V3_PAGE_ATTR_NO_REBASE)
 						continue;
@@ -1273,8 +1271,7 @@ void SharedCache::ParseAndApplySlideInfoForFile(std::shared_ptr<MMappedFileAcces
 						loc += delta * sizeof(dyld_cache_slide_pointer3);
 						try
 						{
-							dyld_cache_slide_pointer3 slideInfo;
-							file->Read(&slideInfo, loc, sizeof(slideInfo));
+							dyld_cache_slide_pointer3 slideInfo = { file->ReadULong(loc) };
 							delta = slideInfo.plain.offsetToNextPointer;
 
 							if (slideInfo.auth.authenticated)
@@ -1316,7 +1313,7 @@ void SharedCache::ParseAndApplySlideInfoForFile(std::shared_ptr<MMappedFileAcces
 			{
 				try
 				{
-					uint16_t delta = mapping.file->ReadUShort(cursor);
+					uint16_t delta = file->ReadUShort(cursor);
 					cursor += sizeof(uint16_t);
 					if (delta == DYLD_CACHE_SLIDE_V5_PAGE_ATTR_NO_REBASE)
 						continue;
@@ -1328,8 +1325,7 @@ void SharedCache::ParseAndApplySlideInfoForFile(std::shared_ptr<MMappedFileAcces
 						loc += delta * sizeof(dyld_cache_slide_pointer5);
 						try
 						{
-							dyld_cache_slide_pointer5 slideInfo;
-							file->Read(&slideInfo, loc, sizeof(slideInfo));
+							dyld_cache_slide_pointer5 slideInfo = { file->ReadULong(loc) };
 							delta = slideInfo.regular.next;
 							if (slideInfo.auth.auth)
 							{

--- a/view/sharedcache/core/SharedCache.h
+++ b/view/sharedcache/core/SharedCache.h
@@ -512,7 +512,6 @@ namespace SharedCacheCore {
 
 	struct MappingInfo
 	{
-		std::shared_ptr<MMappedFileAccessor> file;
 		dyld_cache_mapping_info mappingInfo;
 		uint32_t slideInfoVersion;
 		dyld_cache_slide_info_v2 slideInfoV2;


### PR DESCRIPTION
Slide info is parsed and applied on the main thread, below the `SharedCache` constructor, when a shared cache is opened. Time spent applying the slide is time that the main thread is blocked.

These changes eliminate some unnecessary overhead so what work remains is dominated by kernel work (paging in data, copying pages when the first modification is made).

The changes are:
1. Read slide pointers via `ReadULong` rather than the variable-length `Read` method. The compiler isn't able to eliminate the call to `memcpy` in the variable-length `Read` function, and the function call overhead is noticeable given the small size of the read and number of times it is called.
2. Remove the file member from `MappingInfo`. Slide info is applied for a single file at a time so there's no reason to track the file it belongs to. This removes unnecesssary reference counting on the `std::shared_ptr` that holds the `MMappedFileAccessor`.
