### PR TITLE
[SharedCache] Optimize ReadExportNode

### DIFF
--- a/view/sharedcache/core/SharedCache.h
+++ b/view/sharedcache/core/SharedCache.h
@@ -620,11 +620,11 @@ private:
 		std::optional<SharedCacheMachOHeader> LoadHeaderForAddress(
 			std::shared_ptr<VM> vm, uint64_t address, std::string installName);
 		void InitializeHeader(
-			Ref<BinaryView> view, VM* vm, SharedCacheMachOHeader header, std::vector<MemoryRegion*> regionsToLoad);
-		void ReadExportNode(std::vector<Ref<Symbol>>& symbolList, SharedCacheMachOHeader& header, DataBuffer& buffer,
-			uint64_t textBase, const std::string& currentText, size_t cursor, uint32_t endGuard);
+			Ref<BinaryView> view, VM* vm, const SharedCacheMachOHeader& header, std::vector<MemoryRegion*> regionsToLoad);
+		void ReadExportNode(std::vector<Ref<Symbol>>& symbolList, const SharedCacheMachOHeader& header, const uint8_t* begin,
+			const uint8_t *end, const uint8_t* current, uint64_t textBase, const std::string& currentText);
 		std::vector<Ref<Symbol>> ParseExportTrie(
-			std::shared_ptr<MMappedFileAccessor> linkeditFile, SharedCacheMachOHeader header);
+			std::shared_ptr<MMappedFileAccessor> linkeditFile, const SharedCacheMachOHeader& header);
 
 		Ref<TypeLibrary> TypeLibraryForImage(const std::string& installName);
 

--- a/view/sharedcache/core/VM.cpp
+++ b/view/sharedcache/core/VM.cpp
@@ -465,6 +465,17 @@ BinaryNinja::DataBuffer MMappedFileAccessor::ReadBuffer(size_t address, size_t l
 	return BinaryNinja::DataBuffer(data, length);
 }
 
+std::pair<const uint8_t*, const uint8_t*> MMappedFileAccessor::ReadSpan(size_t address, size_t length)
+{
+	if (address > m_mmap.len)
+		throw MappingReadException();
+	if (address + length > m_mmap.len)
+		throw MappingReadException();
+	const uint8_t* data = (&(((uint8_t*)m_mmap._mmap)[address]));
+	return {data, data + length};
+}
+
+
 void MMappedFileAccessor::Read(void* dest, size_t address, size_t length)
 {
 	if (address > m_mmap.len)

--- a/view/sharedcache/core/VM.h
+++ b/view/sharedcache/core/VM.h
@@ -187,6 +187,14 @@ public:
 
     BinaryNinja::DataBuffer ReadBuffer(size_t addr, size_t length);
 
+    // Returns a range of pointers within the mapped memory region corresponding to
+    // {addr, length}.
+    // WARNING: The pointers returned by this method is only valid for the lifetime
+    // of this file accessor.
+    // TODO: This should use std::span<const uint8_t> once the minimum supported
+    // C++ version supports it.
+    std::pair<const uint8_t*, const uint8_t*> ReadSpan(size_t addr, size_t length);
+
     void Read(void *dest, size_t addr, size_t length);
 };
 


### PR DESCRIPTION
`ReadExportNode` is called frequently during the initial load of the shared cache and impacts how long it takes for parts of the shared cache UI to be functional. This is a collection of optimizations that cut the time spent within `ReadExportNode` by 50%:

1. Pass iterators to `ReadExportNode` rather than a `DataBuffer` + offset. The lack of inlining in `DataBuffer`'s `operator[]` kills performance. Ideally this would have used `std::span`, but that would require bumping the minimum C++ version to C++20.
2. Add `MMappedFileAccessor::ReadSpan` so that `ReadExportNode` can operate directly on the mapped data without first copying it.
3. Removes a call to `GetAnalysisFunctionsForAddress` whose result was unused.
4. Use `std::find` to find the nul at the end of strings rather than assembling the string a character at a time. This avoids repeatedly growing the string.
5. Avoid the usual `Symbol` constructor in favor of `BNCreateSymbol`. The `Symbol` constructor has over head in two forms:
   1. It has a `NameSpace` as an argument. Creating / destroying this allocates and deallocates memory We could create a single instance and reuse it for all calls, but...
   2. The constructor copies all fields of the `NameSpace` to the heap before calling `BNCreateSymbol` and then deallocates them afterwards. This seems unnecessary, and adds a non-trivial amount of overhead.

   This can go back to directly constructing the `Symbol` once the   constructors are improved.