### PR TITLE
Improve Rust workspace ergonomics

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+target-dir = "rust/target"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "plugins/pdb-ng",
     "plugins/warp"
 ]
+default-members = ["rust", "rust/binaryninjacore-sys"]
 
 [profile.release]
 lto = true


### PR DESCRIPTION
Right now, running `cargo doc --open` in the root of the workspace generates docs for all members, but only opens the ones for `arch/msp430`. This might be confusing to devs. If we introduce a `default-members` field to the workspace, then unless the `--workspace` flag is given to cargo, only those members will be used when running `cargo {check,build,doc}`.

IMO this makes it more obvious that the workspace is just a DX thing, and makes it more explicitly opt-in. Note that this essentially mimics having the `binaryninja` package as the root package in the workspace, where this behavior would be the default (see [here](https://doc.rust-lang.org/cargo/reference/workspaces.html#root-package)). Also, since `binaryninjacore-sys` is a dependency of `binaryninja`, it'll always be pulled in so its inclusion in the list is not strictly necessary.

Also, cargo was putting all its artifacts in `/target`, but it would be better to keep that directory from polluting the project root, so I added a local cargo config file that moves it back into the `rust` subdir.