### PR TITLE
MSVC RTTI improvements

### DIFF
--- a/plugins/msvc_rtti/rtti.cpp
+++ b/plugins/msvc_rtti/rtti.cpp
@@ -6,6 +6,7 @@ constexpr int COL_SIG_REV0 = 0;
 constexpr int COL_SIG_REV1 = 1;
 constexpr int RTTI_CONFIDENCE = 100;
 
+constexpr int BCD_HASPCHD = 0x40;
 
 ClassHierarchyDescriptor::ClassHierarchyDescriptor(BinaryView *view, uint64_t address)
 {
@@ -503,8 +504,10 @@ std::optional<ClassInfo> MicrosoftRTTIProcessor::ProcessRTTI(uint64_t coLocatorA
             m_view->DefineDataVariable(baseClassTypeDescAddr,
                                     Confidence(TypeDescriptorType(m_view, baseClassTypeDesc.name.length()), RTTI_CONFIDENCE));
 
-            auto classHierarchyDescAddr = resolveAddr(baseClassDesc.pClassHierarchyDescriptor);
-            baseClasses[classHierarchyDescAddr] = baseClassInfo;
+            if (baseClassDesc.attributes & BCD_HASPCHD) {
+                auto classHierarchyDescAddr = resolveAddr(baseClassDesc.pClassHierarchyDescriptor);
+                baseClasses[classHierarchyDescAddr] = baseClassInfo;
+            }
         }
 
         return baseClasses;

--- a/plugins/msvc_rtti/rtti.cpp
+++ b/plugins/msvc_rtti/rtti.cpp
@@ -60,7 +60,7 @@ CompleteObjectLocator::CompleteObjectLocator(BinaryView *view, uint64_t address)
     offset = reader.Read32();
     cdOffset = reader.Read32();
     pTypeDescriptor = static_cast<int32_t>(reader.Read32());
-    pClassHeirarchyDescriptor = static_cast<int32_t>(reader.Read32());
+    pClassHierarchyDescriptor = static_cast<int32_t>(reader.Read32());
     if (signature == COL_SIG_REV1)
     {
         pSelf = static_cast<int32_t>(reader.Read32());
@@ -93,7 +93,7 @@ std::optional<CompleteObjectLocator> ReadCompleteObjectorLocator(BinaryView *vie
         if (outsideSection(coLocator.pTypeDescriptor + startAddr))
             return std::nullopt;
 
-        if (outsideSection(coLocator.pClassHeirarchyDescriptor + startAddr))
+        if (outsideSection(coLocator.pClassHierarchyDescriptor + startAddr))
             return std::nullopt;
     }
     else
@@ -102,7 +102,7 @@ std::optional<CompleteObjectLocator> ReadCompleteObjectorLocator(BinaryView *vie
         if (outsideSection(coLocator.pTypeDescriptor))
             return std::nullopt;
 
-        if (outsideSection(coLocator.pClassHeirarchyDescriptor))
+        if (outsideSection(coLocator.pClassHierarchyDescriptor))
             return std::nullopt;
     }
 
@@ -479,7 +479,7 @@ std::optional<ClassInfo> MicrosoftRTTIProcessor::ProcessRTTI(uint64_t coLocatorA
     m_view->DefineDataVariable(typeDescAddr,
                                Confidence(TypeDescriptorType(m_view, typeDesc.name.length()), RTTI_CONFIDENCE));
 
-    auto classHierarchyDescAddr = resolveAddr(coLocator->pClassHeirarchyDescriptor);
+    auto classHierarchyDescAddr = resolveAddr(coLocator->pClassHierarchyDescriptor);
     auto classHierarchyDesc = ClassHierarchyDescriptor(m_view, classHierarchyDescAddr);
     auto classHierarchyDescName = fmt::format("{}::`RTTI Class Hierarchy Descriptor'", classInfo.className);
     m_view->DefineAutoSymbol(new Symbol{DataSymbol, classHierarchyDescName, classHierarchyDescAddr});

--- a/plugins/msvc_rtti/rtti.h
+++ b/plugins/msvc_rtti/rtti.h
@@ -101,6 +101,8 @@ namespace BinaryNinja {
 
 		std::map<uint64_t, ClassInfo> m_classInfo;
 
+		std::set<uint64_t> m_visitedClassHierarchyDescAddrs;
+
 		void DeserializedMetadata(const Ref<Metadata> &metadata);
 
 		std::optional<std::string> DemangleName(const std::string &mangledName);

--- a/plugins/msvc_rtti/rtti.h
+++ b/plugins/msvc_rtti/rtti.h
@@ -51,7 +51,7 @@ namespace BinaryNinja {
 		uint32_t offset;
 		uint32_t cdOffset;
 		int32_t pTypeDescriptor;
-		int32_t pClassHeirarchyDescriptor;
+		int32_t pClassHierarchyDescriptor;
 		// Only on 64 bit
 		int32_t pSelf;
 


### PR DESCRIPTION
* Define `attribute` enumerations for `BaseClassDescriptor`s and `ClassHierarchyDescriptor`s
* Recursively define `ClassHierarchyDescriptor` and `TypeDescriptor` structs referenced by `BaseClassDescriptor`
  * Some base classes do not have a corresponding coLocator referencing them.
* Use the the name of the first base class for `ClassInfo` instead of the last matching base class