### PR TITLE
[Python] Implement IL Source Location and Comparison Methods

### DIFF
--- a/python/ilsourcelocation.py
+++ b/python/ilsourcelocation.py
@@ -1,0 +1,26 @@
+
+from . import MediumLevelILInstruction, LowLevelILInstruction, HighLevelILInstruction
+
+
+class ILSourceLocation:
+    def __init__(self, address=None, sourceOperand=None):
+        self.address = address
+        self.sourceOperand = sourceOperand
+        self.valid = False
+
+    @classmethod
+    def from_address_operand(cls, address, operand):
+        instance = cls(address, operand)
+        instance.valid = True
+        return instance
+
+    @classmethod
+    def from_instruction(
+        cls,
+        instr: MediumLevelILInstruction
+        | LowLevelILInstruction
+        | HighLevelILInstruction,
+    ) -> "ILSourceLocation":
+        instance = cls(instr.address, instr.source_operand)
+        instance.valid = True
+        return instance


### PR DESCRIPTION
Add Class: ILSourceLocation
lowlevelil: Add loc parameter to expr, if_expr, goto, and copy_expr
lowlevelil: Fix bug in copy_expr caused by flags
mediumlevelil: Add loc parameter to expr, if_expr, goto, and copy_expr
mediumlevelil: Add methods cmp_e, cmp_ne, cmp_slt, cmp_sle, cmp_sge, cmp_sgt, cmp_ult, cmp_ule, cmp_uge,  cmp_ugt


Example:
```python
mlil.if_expr(new_condition, trueLabel, falseLabel,ILSourceLocation.from_instruction(instr))

```