### PR TITLE
bugfix: ARM64: missing break in il.cpp's switch

### DIFF
--- a/arch/arm64/il.cpp
+++ b/arch/arm64/il.cpp
@@ -2015,6 +2015,7 @@ bool GetLowLevelILForInstruction(
 		break;
 	case ARM64_LDXRH:
 		il.AddInstruction(il.Intrinsic({ RegisterOrFlag::Register(REG_O(operand1)) }, ARM64_INTRIN_LDXRH, { ILREG_O(operand2) }));
+		break;
 	// We don't have a way to specify intrinsic register size, so we explicitly embed the size in the intrinsic name.
 	case ARM64_LDAXR:
 		il.AddInstruction(il.Intrinsic({ RegisterOrFlag::Register(REG_O(operand1)) }, ARM64_INTRIN_LDAXR, { ILREG_O(operand2) }));


### PR DESCRIPTION
A `break` was missing in the `switch`, making the `LDXRH` instruction generate 2 IL instructions instead of 1.

I did not actually encountered the bug dynamically nor tested the fix, but it all seems pretty straightforward.

Cheers