### PR TITLE
fix Session init race condition

### DIFF
--- a/rust/src/headless.rs
+++ b/rust/src/headless.rs
@@ -18,8 +18,6 @@ use crate::{
 };
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::AtomicUsize;
-use std::sync::atomic::Ordering::SeqCst;
 use thiserror::Error;
 
 use crate::enterprise::release_license;
@@ -35,7 +33,7 @@ use std::time::Duration;
 static MAIN_THREAD_HANDLE: Mutex<Option<JoinHandle<()>>> = Mutex::new(None);
 
 /// Used to prevent shutting down Binary Ninja if there are other [`Session`]'s.
-static SESSION_COUNT: AtomicUsize = AtomicUsize::new(0);
+static SESSION_COUNT: Mutex<usize> = Mutex::new(0);
 
 #[derive(Error, Debug)]
 pub enum InitializationError {
@@ -47,6 +45,8 @@ pub enum InitializationError {
     InvalidLicense,
     #[error("no license could located, please see `binaryninja::set_license` for details")]
     NoLicenseFound,
+    #[error("unable to apply options to an previously created `binaryninja::headless::Session`")]
+    SessionAlreadyInitialized,
 }
 
 /// Loads plugins, core architecture, platform, etc.
@@ -284,15 +284,40 @@ pub fn license_location() -> Option<LicenseLocation> {
 }
 
 /// Wrapper for [`init`] and [`shutdown`]. Instantiating this at the top of your script will initialize everything correctly and then clean itself up at exit as well.
-pub struct Session {}
+pub struct Session {
+    /// lock that don't allow the user to create a session directly
+    _lock: std::marker::PhantomData<()>,
+}
 
 impl Session {
     /// Get a registered [`Session`] for use.
     ///
     /// This is required so that we can keep track of the [`SESSION_COUNT`].
-    fn registered_session() -> Self {
-        let _previous_count = SESSION_COUNT.fetch_add(1, SeqCst);
-        Self {}
+    fn register_session(
+        options: Option<InitializationOptions>,
+    ) -> Result<Self, InitializationError> {
+        // if we were able to locate a license, continue with initialization.
+        if license_location().is_none() {
+            // otherwise you must call [Self::new_with_license].
+            return Err(InitializationError::NoLicenseFound);
+        }
+
+        // This is required so that we call init only once
+        let mut session_count = SESSION_COUNT.lock().unwrap();
+        match (*session_count, options) {
+            // no session, just create one
+            (0, options) => init_with_opts(options.unwrap_or_default())?,
+            // session already created, can't apply options
+            (1.., Some(_)) => return Err(InitializationError::SessionAlreadyInitialized),
+            // NOTE if the existing session was created with options,
+            // returning the current session may not be exactly what the
+            // user expects.
+            (1.., None) => {}
+        }
+        *session_count += 1;
+        Ok(Self {
+            _lock: std::marker::PhantomData,
+        })
     }
 
     /// Before calling new you must make sure that the license is retrievable, otherwise the core won't be able to initialize.
@@ -300,14 +325,7 @@ impl Session {
     /// If you cannot otherwise provide a license via `BN_LICENSE_FILE` environment variable or the Binary Ninja user directory
     /// you can call [`Session::new_with_opts`] instead of this function.
     pub fn new() -> Result<Self, InitializationError> {
-        if license_location().is_some() {
-            // We were able to locate a license, continue with initialization.
-            init()?;
-            Ok(Self::registered_session())
-        } else {
-            // There was no license that could be automatically retrieved, you must call [Self::new_with_license].
-            Err(InitializationError::NoLicenseFound)
-        }
+        Self::register_session(None)
     }
 
     /// Initialize with options, the same rules apply as [`Session::new`], see [`InitializationOptions::default`] for the regular options passed.
@@ -315,8 +333,7 @@ impl Session {
     /// This differs from [`Session::new`] in that it does not check to see if there is a license that the core
     /// can discover by itself, therefor it is expected that you know where your license is when calling this directly.
     pub fn new_with_opts(options: InitializationOptions) -> Result<Self, InitializationError> {
-        init_with_opts(options)?;
-        Ok(Self::registered_session())
+        Self::register_session(Some(options))
     }
 
     /// ```no_run
@@ -410,10 +427,13 @@ impl Session {
 
 impl Drop for Session {
     fn drop(&mut self) {
-        let previous_count = SESSION_COUNT.fetch_sub(1, SeqCst);
-        if previous_count == 1 {
+        let mut session_count = SESSION_COUNT.lock().unwrap();
+        match *session_count {
+            0 => unreachable!(),
             // We were the last session, therefor we can safely shut down.
-            shutdown();
+            1 => shutdown(),
+            2.. => {}
         }
+        *session_count -= 1;
     }
 }

--- a/rust/tests/background_task.rs
+++ b/rust/tests/background_task.rs
@@ -3,13 +3,12 @@ use binaryninja::headless::Session;
 use rstest::*;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_background_task_registered(_session: &Session) {
+fn test_background_task_registered(_session: Session) {
     let task_progress = "test registered";
     let task = BackgroundTask::new(task_progress, false);
     BackgroundTask::running_tasks()
@@ -25,7 +24,7 @@ fn test_background_task_registered(_session: &Session) {
 }
 
 #[rstest]
-fn test_background_task_cancellable(_session: &Session) {
+fn test_background_task_cancellable(_session: Session) {
     let task_progress = "test cancellable";
     let task = BackgroundTask::new(task_progress, false);
     BackgroundTask::running_tasks()
@@ -38,7 +37,7 @@ fn test_background_task_cancellable(_session: &Session) {
 }
 
 #[rstest]
-fn test_background_task_progress(_session: &Session) {
+fn test_background_task_progress(_session: Session) {
     let task = BackgroundTask::new("test progress", false);
     let first_progress = task.progress_text().to_string();
     assert_eq!(first_progress, "test progress");

--- a/rust/tests/binary_reader.rs
+++ b/rust/tests/binary_reader.rs
@@ -6,13 +6,12 @@ use std::io::{Read, Seek, SeekFrom};
 use std::path::PathBuf;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_binary_reader_seek(_session: &Session) {
+fn test_binary_reader_seek(_session: Session) {
     let out_dir = env!("OUT_DIR").parse::<PathBuf>().unwrap();
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
     let mut reader = BinaryReader::new(&view);
@@ -50,7 +49,7 @@ fn test_binary_reader_seek(_session: &Session) {
 }
 
 #[rstest]
-fn test_binary_reader_read(_session: &Session) {
+fn test_binary_reader_read(_session: Session) {
     let out_dir = env!("OUT_DIR").parse::<PathBuf>().unwrap();
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
     let mut reader = BinaryReader::new(&view);

--- a/rust/tests/binary_view.rs
+++ b/rust/tests/binary_view.rs
@@ -6,13 +6,12 @@ use rstest::*;
 use std::path::PathBuf;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_binary_loading(_session: &Session) {
+fn test_binary_loading(_session: Session) {
     let out_dir = env!("OUT_DIR").parse::<PathBuf>().unwrap();
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
     assert!(view.has_initial_analysis(), "No initial analysis");
@@ -22,7 +21,7 @@ fn test_binary_loading(_session: &Session) {
 }
 
 #[rstest]
-fn test_binary_saving(_session: &Session) {
+fn test_binary_saving(_session: Session) {
     let out_dir = env!("OUT_DIR").parse::<PathBuf>().unwrap();
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
     // Verify the contents before we modify.
@@ -45,7 +44,7 @@ fn test_binary_saving(_session: &Session) {
 }
 
 #[rstest]
-fn test_binary_saving_database(_session: &Session) {
+fn test_binary_saving_database(_session: Session) {
     let out_dir = env!("OUT_DIR").parse::<PathBuf>().unwrap();
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
     // Update a symbol to verify modification

--- a/rust/tests/binary_writer.rs
+++ b/rust/tests/binary_writer.rs
@@ -7,13 +7,12 @@ use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_binary_writer_seek(_session: &Session) {
+fn test_binary_writer_seek(_session: Session) {
     let out_dir = env!("OUT_DIR").parse::<PathBuf>().unwrap();
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
     let mut writer = BinaryWriter::new(&view);
@@ -51,7 +50,7 @@ fn test_binary_writer_seek(_session: &Session) {
 }
 
 #[rstest]
-fn test_binary_writer_write(_session: &Session) {
+fn test_binary_writer_write(_session: Session) {
     let out_dir = env!("OUT_DIR").parse::<PathBuf>().unwrap();
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
     let mut reader = BinaryReader::new(&view);

--- a/rust/tests/collaboration.rs
+++ b/rust/tests/collaboration.rs
@@ -9,7 +9,6 @@ use serial_test::serial;
 use std::path::PathBuf;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
@@ -58,7 +57,7 @@ fn temp_project_scope<T: Fn(&RemoteProject)>(remote: &Remote, project_name: &str
 
 #[rstest]
 #[serial]
-fn test_connection(_session: &Session) {
+fn test_connection(_session: Session) {
     if !has_collaboration_support() {
         eprintln!("No collaboration support, skipping test...");
         return;
@@ -74,7 +73,7 @@ fn test_connection(_session: &Session) {
 
 #[rstest]
 #[serial]
-fn test_project_creation(_session: &Session) {
+fn test_project_creation(_session: Session) {
     if !has_collaboration_support() {
         eprintln!("No collaboration support, skipping test...");
         return;
@@ -155,7 +154,7 @@ fn test_project_creation(_session: &Session) {
 
 #[rstest]
 #[serial]
-fn test_project_sync(_session: &Session) {
+fn test_project_sync(_session: Session) {
     if !has_collaboration_support() {
         eprintln!("No collaboration support, skipping test...");
         return;

--- a/rust/tests/component.rs
+++ b/rust/tests/component.rs
@@ -5,13 +5,12 @@ use rstest::*;
 use std::path::PathBuf;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_component_creation(_session: &Session) {
+fn test_component_creation(_session: Session) {
     let out_dir = env!("OUT_DIR").parse::<PathBuf>().unwrap();
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
     let component = ComponentBuilder::new(view.clone()).name("test").finalize();

--- a/rust/tests/demangler.rs
+++ b/rust/tests/demangler.rs
@@ -9,13 +9,12 @@ use binaryninja::types::{QualifiedName, Type};
 use rstest::*;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_demangler_simple(_session: &Session) {
+fn test_demangler_simple(_session: Session) {
     let placeholder_arch = CoreArchitecture::by_name("x86").expect("x86 exists");
     // Example LLVM-style mangled name
     let llvm_mangled = "_Z3fooi"; // "foo(int)" in LLVM mangling
@@ -46,7 +45,7 @@ fn test_demangler_simple(_session: &Session) {
 }
 
 #[rstest]
-fn test_custom_demangler(_session: &Session) {
+fn test_custom_demangler(_session: Session) {
     struct TestDemangler;
 
     impl CustomDemangler for TestDemangler {

--- a/rust/tests/high_level_il.rs
+++ b/rust/tests/high_level_il.rs
@@ -5,13 +5,12 @@ use rstest::*;
 use std::path::PathBuf;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_hlil_info(_session: &Session) {
+fn test_hlil_info(_session: Session) {
     let out_dir = env!("OUT_DIR").parse::<PathBuf>().unwrap();
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
 

--- a/rust/tests/low_level_il.rs
+++ b/rust/tests/low_level_il.rs
@@ -12,13 +12,12 @@ use rstest::*;
 use std::path::PathBuf;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_llil_info(_session: &Session) {
+fn test_llil_info(_session: Session) {
     let out_dir = env!("OUT_DIR").parse::<PathBuf>().unwrap();
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
 
@@ -170,7 +169,7 @@ fn test_llil_info(_session: &Session) {
 }
 
 #[rstest]
-fn test_llil_visitor(_session: &Session) {
+fn test_llil_visitor(_session: Session) {
     let out_dir = env!("OUT_DIR").parse::<PathBuf>().unwrap();
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
     let platform = view.default_platform().unwrap();

--- a/rust/tests/main_thread.rs
+++ b/rust/tests/main_thread.rs
@@ -4,19 +4,18 @@ use rstest::*;
 // TODO: Add a test for MainThreadHandler
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_not_main_thread(_session: &Session) {
+fn test_not_main_thread(_session: Session) {
     // We should never be the main thread.
     assert!(!binaryninja::is_main_thread())
 }
 
 #[rstest]
-fn test_main_thread_different(_session: &Session) {
+fn test_main_thread_different(_session: Session) {
     let calling_thread = std::thread::current();
     binaryninja::main_thread::execute_on_main_thread_and_wait(move || {
         let main_thread = std::thread::current();

--- a/rust/tests/medium_level_il.rs
+++ b/rust/tests/medium_level_il.rs
@@ -5,13 +5,12 @@ use rstest::*;
 use std::path::PathBuf;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_mlil_info(_session: &Session) {
+fn test_mlil_info(_session: Session) {
     let out_dir = env!("OUT_DIR").parse::<PathBuf>().unwrap();
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
 

--- a/rust/tests/platform.rs
+++ b/rust/tests/platform.rs
@@ -3,13 +3,12 @@ use binaryninja::platform::Platform;
 use rstest::*;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_platform_lifetime(_session: &Session) {
+fn test_platform_lifetime(_session: Session) {
     let platform_0 = Platform::by_name("windows-x86_64").expect("windows-x86_64 exists");
     let platform_types_0 = platform_0.types();
     let platform_1 = Platform::by_name("windows-x86_64").expect("windows-x86_64 exists");
@@ -19,7 +18,7 @@ fn test_platform_lifetime(_session: &Session) {
 }
 
 #[rstest]
-fn test_platform_types(_session: &Session) {
+fn test_platform_types(_session: Session) {
     let platform = Platform::by_name("windows-x86_64").expect("windows-x86_64 exists");
     let platform_types = platform.types();
     // windows-x86_64 has a few thousand, not zero.
@@ -27,7 +26,7 @@ fn test_platform_types(_session: &Session) {
 }
 
 #[rstest]
-fn test_platform_calling_conventions(_session: &Session) {
+fn test_platform_calling_conventions(_session: Session) {
     let platform = Platform::by_name("windows-x86_64").expect("windows-x86_64 exists");
     assert_eq!(platform.calling_conventions().len(), 1);
 }

--- a/rust/tests/project.rs
+++ b/rust/tests/project.rs
@@ -8,7 +8,6 @@ use std::time::SystemTime;
 // TODO: We should use tempdir to manage the project directory.
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
@@ -18,7 +17,7 @@ fn unique_project(name: &str) -> String {
 }
 
 #[rstest]
-fn create_delete_empty(_session: &Session) {
+fn create_delete_empty(_session: Session) {
     use std::fs::canonicalize;
 
     let project_name = "create_delete_empty_project";
@@ -47,7 +46,7 @@ fn create_delete_empty(_session: &Session) {
 }
 
 #[rstest]
-fn create_close_open_close(_session: &Session) {
+fn create_close_open_close(_session: Session) {
     let project_name = "create_close_open_close";
     let project_path = unique_project(project_name);
     // create the project
@@ -75,7 +74,7 @@ fn create_close_open_close(_session: &Session) {
 }
 
 #[rstest]
-fn modify_project(_session: &Session) {
+fn modify_project(_session: Session) {
     let project_name = "modify_project_project";
     let project_path = unique_project(project_name);
     // create the project

--- a/rust/tests/render_layer.rs
+++ b/rust/tests/render_layer.rs
@@ -8,13 +8,12 @@ use rstest::{fixture, rstest};
 use std::path::PathBuf;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_render_layer_register(_session: &Session) {
+fn test_render_layer_register(_session: Session) {
     struct EmptyRenderLayer;
     impl RenderLayer for EmptyRenderLayer {}
     register_render_layer("Test Render Layer", EmptyRenderLayer, Default::default());
@@ -22,7 +21,7 @@ fn test_render_layer_register(_session: &Session) {
 }
 
 #[rstest]
-fn test_render_layer_linear_view(_session: &Session) {
+fn test_render_layer_linear_view(_session: Session) {
     let out_dir = env!("OUT_DIR").parse::<PathBuf>().unwrap();
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
 

--- a/rust/tests/type_archive.rs
+++ b/rust/tests/type_archive.rs
@@ -7,19 +7,17 @@ use binaryninja::type_archive::TypeArchive;
 use rstest::*;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[fixture]
-#[once]
 fn empty_view() -> Ref<BinaryView> {
     BinaryView::from_data(&FileMetadata::new(), &[]).expect("Failed to create view")
 }
 
 #[rstest]
-fn test_create_archive(_session: &Session) {
+fn test_create_archive(_session: Session) {
     let placeholder_platform = Platform::by_name("x86_64").expect("Failed to get platform");
 
     let temp_dir = tempfile::tempdir().unwrap();

--- a/rust/tests/type_container.rs
+++ b/rust/tests/type_container.rs
@@ -7,7 +7,6 @@ use binaryninja::types::Type;
 use rstest::*;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
@@ -27,7 +26,7 @@ fn empty_view() -> Ref<BinaryView> {
 }
 
 #[rstest]
-fn test_types(_session: &Session, platform: &Platform) {
+fn test_types(_session: Session, platform: &Platform) {
     let type_container = platform.type_container();
     let types = type_container.types().unwrap();
     // windows-x86_64 has a few thousand, not zero.
@@ -35,7 +34,7 @@ fn test_types(_session: &Session, platform: &Platform) {
 }
 
 #[rstest]
-fn test_type_id(_session: &Session, platform: &Platform) {
+fn test_type_id(_session: Session, platform: &Platform) {
     let type_container = platform.type_container();
     let type_ids = type_container.type_ids().unwrap();
     let first_type_id = type_ids.iter().next().unwrap();
@@ -53,7 +52,7 @@ fn test_type_id(_session: &Session, platform: &Platform) {
 }
 
 #[rstest]
-fn test_add_delete_type(_session: &Session, empty_view: &BinaryView) {
+fn test_add_delete_type(_session: Session, empty_view: &BinaryView) {
     let view_type_container = empty_view.type_container();
     let test_type = Type::int(4, true);
     assert!(
@@ -72,7 +71,7 @@ fn test_add_delete_type(_session: &Session, empty_view: &BinaryView) {
 }
 
 #[rstest]
-fn test_immutable_container(_session: &Session, platform: &Platform) {
+fn test_immutable_container(_session: Session, platform: &Platform) {
     // Platform type containers are immutable, so we shouldn't be able to delete/add/rename types.
     let plat_type_container = platform.type_container();
     assert!(
@@ -102,7 +101,7 @@ fn test_immutable_container(_session: &Session, platform: &Platform) {
 }
 
 #[rstest]
-fn test_parse_type(_session: &Session, platform: &Platform) {
+fn test_parse_type(_session: Session, platform: &Platform) {
     let type_container = platform.type_container();
     // HANDLE will be pulled in from the platform, which is `windows-x86_64`.
     let parsed_type = type_container
@@ -114,7 +113,7 @@ fn test_parse_type(_session: &Session, platform: &Platform) {
 }
 
 #[rstest]
-fn test_container_lifetime(_session: &Session, platform: &Platform, empty_view: &BinaryView) {
+fn test_container_lifetime(_session: Session, platform: &Platform, empty_view: &BinaryView) {
     let plat_type_container_dropped = platform.type_container();
     let view_type_container_dropped = empty_view.type_container();
     let _plat_types_dropped = plat_type_container_dropped.types();

--- a/rust/tests/type_parser.rs
+++ b/rust/tests/type_parser.rs
@@ -28,13 +28,12 @@ typedef struct {
 "#;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_string_to_type(_session: &Session) {
+fn test_string_to_type(_session: Session) {
     let platform = Platform::by_name("windows-x86_64").expect("windows-x86_64 exists");
     let plat_type_container = platform.type_container();
     let parser = CoreTypeParser::default();
@@ -46,7 +45,7 @@ fn test_string_to_type(_session: &Session) {
 }
 
 #[rstest]
-fn test_string_to_types(_session: &Session) {
+fn test_string_to_types(_session: Session) {
     let platform = Platform::by_name("windows-x86_64").expect("windows-x86_64 exists");
     let plat_type_container = platform.type_container();
     let parser = CoreTypeParser::default();
@@ -65,7 +64,7 @@ fn test_string_to_types(_session: &Session) {
 }
 
 #[rstest]
-fn test_parse_error(_session: &Session) {
+fn test_parse_error(_session: Session) {
     let platform = Platform::by_name("windows-x86_64").expect("windows-x86_64 exists");
     let plat_type_container = platform.type_container();
     let parser = CoreTypeParser::default();

--- a/rust/tests/types.rs
+++ b/rust/tests/types.rs
@@ -5,13 +5,12 @@ use binaryninja::types::{MemberAccess, MemberScope, StructureBuilder, StructureM
 use rstest::*;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_type_to_string(_session: &Session) {
+fn test_type_to_string(_session: Session) {
     let test_type = Type::int(4, true);
     assert_eq!(test_type.to_string(), "int32_t".to_string());
 
@@ -25,7 +24,7 @@ fn test_type_to_string(_session: &Session) {
 }
 
 #[rstest]
-fn test_structure_builder(_session: &Session) {
+fn test_structure_builder(_session: Session) {
     let mut builder = StructureBuilder::new();
     builder.insert(
         &Type::int(4, true),

--- a/rust/tests/worker_thread.rs
+++ b/rust/tests/worker_thread.rs
@@ -3,13 +3,12 @@ use rstest::*;
 use std::sync::{Arc, Barrier};
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
 
 #[rstest]
-fn test_setting_worker_thread(_session: &Session) {
+fn test_setting_worker_thread(_session: Session) {
     let original_count = binaryninja::worker_thread::worker_thread_count();
     binaryninja::worker_thread::set_worker_thread_count(original_count - 1);
     assert_eq!(
@@ -24,7 +23,7 @@ fn test_setting_worker_thread(_session: &Session) {
 }
 
 #[rstest]
-fn test_worker_thread_different(_session: &Session) {
+fn test_worker_thread_different(_session: Session) {
     let calling_thread = std::thread::current();
 
     // We need both (2) threads to synchronize

--- a/rust/tests/workflow.rs
+++ b/rust/tests/workflow.rs
@@ -4,7 +4,6 @@ use binaryninja::workflow::Workflow;
 use rstest::*;
 
 #[fixture]
-#[once]
 fn session() -> Session {
     Session::new().expect("Failed to initialize session")
 }
@@ -13,7 +12,7 @@ fn session() -> Session {
 // TODO: Test activity insertion and removal
 
 #[rstest]
-fn test_workflow_clone(_session: &Session) {
+fn test_workflow_clone(_session: Session) {
     let original_workflow = Workflow::new("core.function.baseAnalysis");
     let mut cloned_workflow = original_workflow.clone("clone_workflow");
 
@@ -31,7 +30,7 @@ fn test_workflow_clone(_session: &Session) {
 }
 
 #[rstest]
-fn test_workflow_registration(_session: &Session) {
+fn test_workflow_registration(_session: Session) {
     // Validate NULL workflows cannot be registered
     let workflow = Workflow::new("null");
     assert_eq!(workflow.name().as_str(), "null");


### PR DESCRIPTION
I'm having a few problems with tests:

1. The `#[once]` never drops the `fixture`, so the test never properly finish.
2. There is some unsoundness in `Session` creation and drop, the `init` can be called multiple times.