### PR TITLE
[SharedCache] Split state into initial, loaded, and modified

### DIFF
--- a/view/sharedcache/api/sharedcache.cpp
+++ b/view/sharedcache/api/sharedcache.cpp
@@ -161,6 +161,7 @@ namespace SharedCacheAPI {
 		}
 
 		std::vector<DSCSymbol> result;
+		result.reserve(count);
 		for (size_t i = 0; i < count; i++)
 		{
 			DSCSymbol sym;

--- a/view/sharedcache/core/DSCView.cpp
+++ b/view/sharedcache/core/DSCView.cpp
@@ -603,79 +603,21 @@ bool DSCView::Init()
 	Ref<Type> filesetEntryCommandType = Type::StructureType(filesetEntryCommandStruct);
 	DefineType(filesetEntryCommandTypeId, filesetEntryCommandName, filesetEntryCommandType);
 
-	std::vector<SharedCacheCore::MemoryRegion> regionsMappedIntoMemory;
-	if (auto meta = GetParentView()->QueryMetadata(SharedCacheCore::SharedCacheMetadataTag))
+	if (auto metadata = SharedCacheCore::SharedCacheMetadata::LoadFromView(GetParentView()))
 	{
-		std::string data = GetParentView()->GetStringMetadata(SharedCacheCore::SharedCacheMetadataTag);
-		std::stringstream ss;
-		ss.str(data);
-		rapidjson::Document result(rapidjson::kObjectType);
-
-		result.Parse(data.c_str());
-
-		if (result.HasMember("metadataVersion"))
-		{
-			if (result["metadataVersion"].GetInt() != METADATA_VERSION)
-			{
-				LogError("Shared cache metadata version mismatch: expected %d, got %d", METADATA_VERSION,
-					result["metadataVersion"].GetInt());
-				return false;
-			}
-		}
-		else
-		{
-			LogError("Shared cache metadata version not found");
-			return false;
-		}
-		for (auto& imgV : result["regionsMappedIntoMemory"].GetArray())
-		{
-			SharedCacheCore::MemoryRegion region;
-			region.LoadFromValue(imgV);
-			regionsMappedIntoMemory.push_back(region);
-		}
-
-		std::unordered_map<uint64_t, std::string> imageStartToInstallName;
-		// key "m_imageStarts"
-		for (auto& imgV : result["m_imageStarts"].GetArray())
-		{
-			std::string name = imgV.GetArray()[0].GetString();
-			uint64_t addr = imgV.GetArray()[1].GetUint64();
-			imageStartToInstallName[addr] = name;
-		}
-
-		std::vector<std::pair<uint64_t, std::vector<std::pair<uint64_t, std::pair<BNSymbolType, std::string>>>>> exportInfos;
-
-		for (const auto& obj1 : result["exportInfos"].GetArray())
-		{
-			std::vector<std::pair<uint64_t, std::pair<BNSymbolType, std::string>>> innerVec;
-			for (const auto& obj2 : obj1["value"].GetArray())
-			{
-				std::pair<BNSymbolType, std::string> innerPair = { (BNSymbolType)obj2["val1"].GetUint64(), obj2["val2"].GetString() };
-				innerVec.push_back({ obj2["key"].GetUint64(), innerPair });
-			}
-
-			exportInfos.push_back({obj1["key"].GetUint64(), innerVec});
-		}
-
 		BeginBulkModifySymbols();
-		for (const auto & [imageBaseAddr, exportList] : exportInfos)
+		for (const auto& [imageBaseAddr, exportMap] : metadata->ExportInfos())
 		{
-			std::vector<Ref<Symbol>> symbolsList;
-			for (const auto & [exportAddr, exportTypeAndName] : exportList)
-			{
-				symbolsList.push_back(new Symbol(exportTypeAndName.first, exportTypeAndName.second, exportAddr));
-			}
+			auto typelib = GetTypeLibrary(metadata->InstallNameForImageBaseAddress(imageBaseAddr));
 
-			auto typelib = GetTypeLibrary(imageStartToInstallName[imageBaseAddr]);
-
-			for (const auto& symbol : symbolsList)
+			for (const auto& [address, symbol] : *exportMap)
 			{
-				if (!IsValidOffset(symbol->GetAddress()))
+				if (!IsValidOffset(address))
 					continue;
+
 				if (typelib)
 				{
-					auto type = typelib->GetNamedObject(symbol->GetRawName());
-					if (type)
+					if (auto type = typelib->GetNamedObject(symbol->GetFullName()))
 					{
 						DefineAutoSymbolAndVariableOrFunction(GetDefaultPlatform(), symbol, type);
 						continue;

--- a/view/sharedcache/core/MetadataSerializable.cpp
+++ b/view/sharedcache/core/MetadataSerializable.cpp
@@ -365,8 +365,8 @@ void Deserialize(DeserializationContext& context, std::string_view name, routine
 		return;
 	b.cmd = bArr[0].GetUint();
 	b.cmdsize = bArr[1].GetUint();
-	b.init_address = bArr[2].GetUint();
-	b.init_module = bArr[3].GetUint();
+	b.init_address = bArr[2].GetUint64();
+	b.init_module = bArr[3].GetUint64();
 }
 
 void Serialize(SerializationContext& context, const function_starts_command& value)

--- a/view/sharedcache/core/MetadataSerializable.cpp
+++ b/view/sharedcache/core/MetadataSerializable.cpp
@@ -47,6 +47,11 @@ void Serialize(SerializationContext& context, uint64_t value) {
 	context.writer.Uint64(value);
 }
 
+void Serialize(SerializationContext& context, unsigned long value)
+{
+	context.writer.Uint64(value);
+}
+
 void Deserialize(DeserializationContext& context, std::string_view name, bool& b) {
 	b = context.doc[name.data()].GetBool();
 }

--- a/view/sharedcache/core/VM.h
+++ b/view/sharedcache/core/VM.h
@@ -225,31 +225,34 @@ class MappingCollisionException : VMException {
 
 class VMReader;
 
+// Represents a range of addresses [start, end).
+// Note that `end` is not included within the range.
+struct AddressRange {
+    uint64_t start;
+    uint64_t end;
+
+    bool operator<(const AddressRange& b) const {
+        return start < b.start || (start == b.start && end < b.end);
+    }
+
+    friend bool operator<(const AddressRange& range, uint64_t address) {
+        return range.end <= address;
+    }
+
+    friend bool operator<(uint64_t address, const AddressRange& range) {
+        return address < range.start;
+    }
+};
+
+// A map keyed by address ranges that can be looked up via any
+// address within a range thanks to C++14's transparent comparators.
+template <typename Value>
+using AddressRangeMap = std::map<AddressRange, Value, std::less<>>;
 
 class VM {
-
-    // Represents a range of addresses [start, end).
-    // Note that `end` is not included within the range.
-    struct AddressRange {
-        size_t start;
-        size_t end;
-
-        bool operator<(const AddressRange& b) const {
-            return start < b.start || (start == b.start && end < b.end);
-        }
-
-        friend bool operator<(const AddressRange& range, size_t address) {
-            return range.end <= address;
-        }
-
-        friend bool operator<(size_t address, const AddressRange& range) {
-            return address < range.start;
-        }
-    };
-
     // A map keyed by address ranges that can be looked up via any
     // address within a range thanks to C++14's transparent comparators.
-    std::map<AddressRange, PageMapping, std::less<>> m_map;
+    AddressRangeMap<PageMapping> m_map;
     size_t m_pageSize;
     bool m_safe;
 


### PR DESCRIPTION
*NOTE*: I'm sending this as a draft for sake of discussion.  This is complete, but would ideally be split into smaller changes for sake of easier review. I've had it in my tree for six weeks now and haven't found the energy to split it up. I figured I'd check if there are any major objections to this approach before I spend the time trying to split it up.

The bottom line here is that this change:
1. Avoids the performance hit from repeatedly copying `SharedCache`'s state.
2. Avoids the performance hit from repeatedly serializing `SharedCache`'s state to JSON.

The end result is a > 2x performance improvement on loading images from the shared cache, with a clear path towards safely loading images in parallel.

@0cyn @WeiN76LQh

--- 

The initial state, `CacheInfo`, is initialized during `PerformInitialLoad` and is immutable after that point. This required some slight restructuring of how information about memory regions is tracked as that was previously modified as regions were loaded. Memory regions are now stored in a map from their address range to the `MemoryRegion` object. This makes it cheap to look them up by address which is a common operation.

The modified state, `ModifiedState`, consists of changes since the last save to the `DSCView` / `ViewSpecificState`. This means it is no longer necessary to copy any state when mutating a `SharedCache` instance for the first time. Instead, its data structures start off empty and are populated as images, sections, or symbol information is loaded.

The loaded state, `State`, consists of all modified state that has since been saved. It lives on the `ViewSpecificState`. Saving modified state merges it into the existing loaded state. `State` and `ModifiedState` are almost identical in what they contain, but are separate types to make it clearer which contains _all_ state vs just modifications.

This pattern is carried over to the `Metadata` stored on the `DSCView`. The initial state is stored under its own metadata key, and each modified state is stored under a key with an incrementing number. This means each save of the state only needs to serialize the state that changed, rather than reserializing all of the state all of the time.

There are two huge benefits from these changes:
1. At no point does `SharedCache` have to copy its in memory state. The basic copy-on-write approach introduced in #6129 reduced how often these copies are made, but they're still frequent and very expensive. This eliminates the 🐄.
1. At no point does `SharedCache` have to re-serialize state to JSON that it has already serialized. JSON serialization previously added hundreds of milliseconds to any mutating operation on `SharedCache`.

As a result, this speeds up the initial load of the shared cache by around 2x and loading of subsequent images improves by about the same.

One trade-off is that the serialization / deserialization logic is more complicated. There are two reasons for this:
1. The state is now split across multiple metadata keys and needs to be merged when it is loaded.
4. The in-memory representation uses pointers to identify memory regions. These relationships have to be re-established after the JSON is deserialized.

As a future direction it is worth considering whether the logic owned by `SharedCache` could be split in a similar manner to the data. The initial loading of the cache header, loading of images, and handling of symbol information are all mostly independent and work on separate data. If the logic were split into separate classes it would be easier to reason about which data is valid when, and would easily permit concurrent loading of multiple images from the shared library in a thread-safe manner.