### PR TITLE
Add licensing check for Rust code

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,3 +54,21 @@ jobs:
         uses: crate-ci/typos@v1.29.4
         with:
           files: ./rust
+
+  # Check licensing and produce a list of licenses
+  licensing:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install cargo-about
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-about
+          version: "0.6.6"
+      - name: Run license check
+        run: cargo about generate about.hbs > license.html
+      - name: Archive license file
+        uses: actions/upload-artifact@v4
+        with:
+          name: license
+          path: license.html

--- a/about.hbs
+++ b/about.hbs
@@ -1,0 +1,70 @@
+<html>
+
+<head>
+    <style>
+        @media (prefers-color-scheme: dark) {
+            body {
+                background: #333;
+                color: white;
+            }
+            a {
+                color: skyblue;
+            }
+        }
+        .container {
+            font-family: sans-serif;
+            max-width: 800px;
+            margin: 0 auto;
+        }
+        .intro {
+            text-align: center;
+        }
+        .licenses-list {
+            list-style-type: none;
+            margin: 0;
+            padding: 0;
+        }
+        .license-used-by {
+            margin-top: -10px;
+        }
+        .license-text {
+            max-height: 200px;
+            overflow-y: scroll;
+            white-space: pre-wrap;
+        }
+    </style>
+</head>
+
+<body>
+<main class="container">
+    <div class="intro">
+        <h1>Third Party Licenses</h1>
+        <p>This page lists the licenses of the **rust** projects used in binaryninja-api.</p>
+    </div>
+
+    <h2>Overview of licenses:</h2>
+    <ul class="licenses-overview">
+        {{#each overview}}
+            <li><a href="#{{id}}">{{name}}</a> ({{count}})</li>
+        {{/each}}
+    </ul>
+
+    <h2>All license text:</h2>
+    <ul class="licenses-list">
+        {{#each licenses}}
+            <li class="license">
+                <h3 id="{{id}}">{{name}}</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    {{#each used_by}}
+                        <li><a href="{{#if crate.repository}} {{crate.repository}} {{else}} https://crates.io/crates/{{crate.name}} {{/if}}">{{crate.name}} {{crate.version}}</a></li>
+                    {{/each}}
+                </ul>
+                <pre class="license-text">{{text}}</pre>
+            </li>
+        {{/each}}
+    </ul>
+</main>
+</body>
+
+</html>

--- a/about.toml
+++ b/about.toml
@@ -1,0 +1,10 @@
+accepted = [
+    "Apache-2.0",
+    "MIT",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "ISC",
+    "BSD-3-Clause",
+    "BSL-1.0",
+    "LicenseRef-scancode-google-patent-license-fuchsia"
+]

--- a/arch/msp430/Cargo.toml
+++ b/arch/msp430/Cargo.toml
@@ -3,6 +3,7 @@ name = "arch_msp430"
 version = "0.1.0"
 authors = ["jrozner"]
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 binaryninja.workspace = true

--- a/arch/riscv/Cargo.toml
+++ b/arch/riscv/Cargo.toml
@@ -3,6 +3,7 @@ name = "arch_riscv"
 version = "0.1.0"
 authors = ["Ryan Snyder <ryan.snyder.or@gmail.com>"]
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 binaryninja.workspace = true

--- a/arch/riscv/disasm/Cargo.toml
+++ b/arch/riscv/disasm/Cargo.toml
@@ -3,6 +3,7 @@ name = "riscv-dis"
 version = "0.1.0"
 authors = ["Ryan Snyder <ryan.snyder.or@gmail.com>"]
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 byteorder = "1"

--- a/plugins/dwarf/dwarf_export/Cargo.toml
+++ b/plugins/dwarf/dwarf_export/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dwarf_export"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/plugins/dwarf/dwarf_import/Cargo.toml
+++ b/plugins/dwarf/dwarf_import/Cargo.toml
@@ -2,6 +2,7 @@
 name = "dwarf_import"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/plugins/dwarf/dwarfdump/Cargo.toml
+++ b/plugins/dwarf/dwarfdump/Cargo.toml
@@ -3,6 +3,7 @@ name = "dwarfdump"
 version = "0.1.0"
 authors = ["Kyle Martin <kyle@vector35.com>"]
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/plugins/dwarf/shared/Cargo.toml
+++ b/plugins/dwarf/shared/Cargo.toml
@@ -3,6 +3,7 @@ name = "dwarfreader"
 version = "0.1.0"
 authors = ["Kyle Martin <kyle@vector35.com>"]
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 binaryninja.workspace = true

--- a/plugins/idb_import/Cargo.toml
+++ b/plugins/idb_import/Cargo.toml
@@ -3,6 +3,7 @@ name = "idb_import"
 version = "0.1.0"
 authors = ["Rubens Brandao <git@rubens.io>"]
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/plugins/pdb-ng/Cargo.toml
+++ b/plugins/pdb-ng/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pdb-import-plugin"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]

--- a/plugins/pdb-ng/demo/Cargo.toml
+++ b/plugins/pdb-ng/demo/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pdb-import-plugin-static"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 crate-type = ["staticlib"]

--- a/plugins/warp/Cargo.toml
+++ b/plugins/warp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "warp_ninja"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 crate-type = ["lib", "cdylib"]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Ryan Snyder <ryan@vector35.com>", "Kyle Martin <kyle@vector35.com>"]
 edition = "2021"
 rust-version = "1.83.0"
+license = "Apache-2.0"
 
 [features]
 # This is used when statically linking to prevent exporting CorePluginABIVersion and UiPluginABIVersion.

--- a/rust/binaryninjacore-sys/Cargo.toml
+++ b/rust/binaryninjacore-sys/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Ryan Snyder <ryan@vector35.com>", "Kyle Martin <kyle@vector35.com>"]
 build = "build.rs"
 edition = "2021"
 links = "binaryninjacore"
+license = "Apache-2.0"
 
 [build-dependencies]
 bindgen = "0.71.1"

--- a/view/minidump/Cargo.toml
+++ b/view/minidump/Cargo.toml
@@ -2,6 +2,7 @@
 name = "minidump_bn"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
If we add new rust dependencies we should now be alerted when a new license type is added.