### PR TITLE
Remove m_reader / m_builder members from AnalysisContext

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -10017,8 +10017,7 @@ namespace BinaryNinja {
 	class AnalysisContext :
 	    public CoreRefCountObject<BNAnalysisContext, BNNewAnalysisContextReference, BNFreeAnalysisContext>
 	{
-		std::unique_ptr<Json::CharReader> m_reader;
-		Json::StreamWriterBuilder m_builder;
+		static Json::StreamWriterBuilder& JsonBuilder();
 
 	  public:
 		AnalysisContext(BNAnalysisContext* analysisContext);
@@ -10102,7 +10101,7 @@ namespace BinaryNinja {
 				               }},
 				    arg);
 
-			return Inform(Json::writeString(m_builder, request));
+			return Inform(Json::writeString(JsonBuilder(), request));
 		}
 #endif
 	};

--- a/workflow.cpp
+++ b/workflow.cpp
@@ -8,12 +8,21 @@ using namespace BinaryNinja;
 using namespace std;
 
 
-AnalysisContext::AnalysisContext(BNAnalysisContext* analysisContext) :
-    m_reader(Json::CharReaderBuilder().newCharReader())
+// static
+Json::StreamWriterBuilder& AnalysisContext::JsonBuilder()
+{
+	static Json::StreamWriterBuilder* builder = [] {
+		auto builder = new Json::StreamWriterBuilder;
+		(*builder)["indentation"] = "";
+		return builder;
+	}();
+	return *builder;
+}
+
+AnalysisContext::AnalysisContext(BNAnalysisContext* analysisContext)
 {
 	// LogError("API-Side AnalysisContext Constructed!");
 	m_object = analysisContext;
-	m_builder["indentation"] = "";
 }
 
 


### PR DESCRIPTION
Constructing these objects is very expensive compared to the cost of creating the `AnalysisContext`.

`m_reader` appears to be entirely unused so it is simply removed.

`m_builder` is only used within `Inform`. It may be appropriate to move it to a local variable within that function, but I'm not sure how often `Inform` is called. Given that the `Json::StreamWriterBuilder` is rather expensive to construct I've instead opted to make it static so it is initialized only on first use and then reused by later calls. `Json::StreamWriterBuilder::newStreamWriter` does not mutate any state so this seems ok in terms of thread-safety.