### PR TITLE
[SharedCache] Don't capture `this` within lambda passed to MMappedFileAccessor::Open

### DIFF
--- a/view/sharedcache/core/SharedCache.h
+++ b/view/sharedcache/core/SharedCache.h
@@ -596,7 +596,7 @@ namespace SharedCacheCore {
 		bool SaveCacheInfoToDSCView(std::lock_guard<std::mutex>&);
 		bool SaveModifiedStateToDSCView(std::lock_guard<std::mutex>&);
 
-		void ParseAndApplySlideInfoForFile(std::shared_ptr<MMappedFileAccessor> file, uint64_t baseAddress);
+		static void ParseAndApplySlideInfoForFile(std::shared_ptr<MMappedFileAccessor> file, uint64_t baseAddress, Ref<Logger> logger);
 		std::optional<uint64_t> GetImageStart(std::string_view installName);
 		const SharedCacheMachOHeader* HeaderForAddress(uint64_t);
 		bool LoadImageWithInstallName(std::string installName, bool skipObjC);


### PR DESCRIPTION
Nothing guarantees that the `SharedCache` lives long enough.

`ParseAndApplySlideInfoForFile` only needs access to the `SharedCache`'s logger. Make `ParseAndApplySlideInfoForFile` static, have the lambda explicitly capture the logger, and pass it as an argument to `ParseAndApplySlideInfoForFile`.

Fixes #6434.