### PR TITLE
[SharedCache] Apply objc_msgSend call type overrides in more places

### DIFF
--- a/view/sharedcache/workflow/ObjCActivity.cpp
+++ b/view/sharedcache/workflow/ObjCActivity.cpp
@@ -54,16 +54,16 @@ void ObjCActivity::AdjustCallType(Ref<AnalysisContext> ctx)
 
 	const auto rewriteIfEligible = [bv, ssa](size_t insnIndex) {
 		auto insn = ssa->GetInstruction(insnIndex);
-		if (insn.operation != LLIL_CALL_SSA)
+		if (insn.operation != LLIL_CALL_SSA && insn.operation != LLIL_TAILCALL_SSA)
 			return;
 
 		// Filter out calls that aren't to `objc_msgSend`.
-		auto callExpr = insn.GetDestExpr<LLIL_CALL_SSA>();
+		auto callExpr = insn.GetDestExpr();
 		if (auto symbol = bv->GetSymbolByAddress(callExpr.GetValue().value))
 			if (symbol->GetRawName() != "_objc_msgSend")
 				return;
 
-		const auto params = insn.GetParameterExprs<LLIL_CALL_SSA>();
+		const auto params = insn.GetParameterExprs();
 		// The second parameter passed to the objc_msgSend call is the address of
 		// either the selector reference or the method's name, which in both cases
 		// is dereferenced to retrieve a selector.
@@ -82,13 +82,31 @@ void ObjCActivity::AdjustCallType(Ref<AnalysisContext> ctx)
 			const auto selectorRegister = params[0].GetParameterExprs<LLIL_SEPARATE_PARAM_LIST_SSA>()[1].GetSourceSSARegister<LLIL_REG_SSA>();
 			rawSelector = ssa->GetSSARegisterValue(selectorRegister).value;
 		}
-		if (!rawSelector || !bv->IsValidOffset(rawSelector))
+		if (!rawSelector)
 			return;
 
+		std::string selector;
+		if (bv->IsValidOffset(rawSelector)) {
+			BinaryReader reader(bv);
+			reader.Seek(rawSelector);
+			selector = reader.ReadCString(500);
+		} else {
+			// Look for the `sel_` symbols that ObjCProcessor adds to represent selectors
+			// whose backing regions have not yet been loaded into the view.
+			constexpr std::string_view SelectorPrefix = "sel_";
+
+			auto symbol = bv->GetSymbolByAddress(rawSelector);
+			if (!symbol)
+				return;
+
+			std::string_view name = symbol->GetRawNameRef();
+			if (name.find(SelectorPrefix) != 0)
+				return;
+
+			selector = name.substr(SelectorPrefix.length());
+		}
+
 		// -- Do callsite override
-		auto reader = BinaryReader(bv);
-		reader.Seek(rawSelector);
-		auto selector = reader.ReadCString(500);
 		auto additionalArgumentCount = std::count(selector.begin(), selector.end(), ':');
 
 		auto retType = bv->GetTypeByName({ "id" });


### PR DESCRIPTION
`fixObjCCallTypes` is updated to handle tail calls as well as regular calls.

Additionally, if the selector address is not valid it now looks for the `sel_` symbols that `DSCObjCProcessor::ReadMethodList` adds for selectors whose names reside in regions that are not yet mapped. This allows call type overrides to be applied even when a selector's name is defined in a different image. This is the common case in recent macOS shared caches at least.