### PR TITLE
[SharedCache] Add the ability to install the plugin using CMake

### DIFF
--- a/view/sharedcache/CMakeLists.txt
+++ b/view/sharedcache/CMakeLists.txt
@@ -52,6 +52,7 @@ else()
             LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out/plugins
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out/plugins
             )
+    bn_install_plugin(sharedcache)
 endif()
 
 set_target_properties(sharedcache PROPERTIES

--- a/view/sharedcache/ui/CMakeLists.txt
+++ b/view/sharedcache/ui/CMakeLists.txt
@@ -50,6 +50,7 @@ else()
             LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out/plugins
             RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/out/plugins
             )
+    bn_install_plugin(sharedcacheui)
 endif()
 
 set_target_properties(sharedcacheui PROPERTIES


### PR DESCRIPTION
Using `-t install` currently doesn't install the plugin into the Binary Ninja user plugin directory. This commit fixes that.

Simple change, useful for dev.