### PR TITLE
[SharedCache] Limit sections being added in `SharedCache::InitializeHeader` to the regions being loaded

### DIFF
--- a/view/sharedcache/core/SharedCache.cpp
+++ b/view/sharedcache/core/SharedCache.cpp
@@ -2424,13 +2424,13 @@ void SharedCache::InitializeHeader(
 
 	for (size_t i = 0; i < header.sections.size(); i++)
 	{
-		bool skip = false;
+		bool skip = true;
 		for (const auto& region : regionsToLoad)
 		{
 			if (header.sections[i].addr >= region->start && header.sections[i].addr < region->start + region->size)
 			{
-				if (MemoryRegionIsHeaderInitialized(lock, *region))
-					skip = true;
+				if (!MemoryRegionIsHeaderInitialized(lock, *region))
+					skip = false;
 				break;
 			}
 		}


### PR DESCRIPTION
The logic before would default to adding a section unless it was from a region in the `regionsToLoad` argument and its header had already been initialized. However if a user does `Load Section by Address` then there's only one region in `regionsToLoad`. All sections not in that region would be automatically added, even if they had already been or the user hadn't requested them to be loaded.