### PR TITLE
[SharedCache] Add a section for sectionless segments

### DIFF
--- a/view/sharedcache/core/SharedCache.cpp
+++ b/view/sharedcache/core/SharedCache.cpp
@@ -2422,6 +2422,7 @@ void SharedCache::InitializeHeader(
 	if (settings && settings->Contains("loader.dsc.processFunctionStarts"))
 		applyFunctionStarts = settings->Get<bool>("loader.dsc.processFunctionStarts", view);
 
+	std::set<const MemoryRegion*> regionsWithNoSections(regionsToLoad.begin(), regionsToLoad.end());
 	for (size_t i = 0; i < header.sections.size(); i++)
 	{
 		bool skip = false;
@@ -2429,6 +2430,7 @@ void SharedCache::InitializeHeader(
 		{
 			if (header.sections[i].addr >= region->start && header.sections[i].addr < region->start + region->size)
 			{
+				regionsWithNoSections.erase(region);
 				if (MemoryRegionIsHeaderInitialized(lock, *region))
 					skip = true;
 				break;
@@ -2547,6 +2549,16 @@ void SharedCache::InitializeHeader(
 
 		view->AddUserSection(header.sectionNames[i], header.sections[i].addr, header.sections[i].size, semantics,
 			type, header.sections[i].align);
+	}
+
+	// Some segments like `libobjc.A.dylib::__OBJC_RW` don't have any sections. A section is added for segments like 
+	// this so that they display nicely in Binary Ninja. Otherwise it can be confusing where data came from if it has 
+	// no section.
+	for (const auto& region : regionsWithNoSections)
+	{
+		if (MemoryRegionIsHeaderInitialized(lock, *region))
+			continue;
+		view->AddUserSection(region->prettyName, region->start, region->size, SectionSemanticsForRegion(*region));
 	}
 
 	auto typeLib = view->GetTypeLibrary(header.installName);


### PR DESCRIPTION
In Binary Ninja it can be quite confusing when a segment is added that doesn't have any sections. `libobjc.A.dylib::__OBJC_RW` is an example of this. When scrolling through that segment there is no bar at the top of the linear view indicating where the data came from. When looking at the list of segments there are no names and with the different segment and section lists it can be hard to eyeball where a segment lands within the list of sections.

There is an argument here that the better solution is to change the way Binary Ninja displays information. For instance when scrolling through the linear view through a segment with no section, the segment information should be displayed at the top. Additionally segment names could be displayed in the segment list.