### PR TITLE
[SharedCache] Fix detection of the class name of categories

### DIFF
--- a/objectivec/objc.cpp
+++ b/objectivec/objc.cpp
@@ -581,13 +581,26 @@ void ObjCProcessor::LoadCategories(ObjCReader* reader, Ref<Section> classPtrSect
 			categoryBaseClassName = it->second.name;
 			category.associatedName = it->second.associatedName;
 		}
-		else if (auto symbol = m_data->GetSymbolByAddress(catLocation + m_data->GetAddressSize()))
-		{
-			if (symbol->GetType() == ImportedDataSymbol || symbol->GetType() == ImportAddressSymbol)
+		else
+		{	
+			auto symbol = m_data->GetSymbolByAddress(cat.cls);
+			if (!symbol)
+				symbol = SymbolForUnmappedAddress(cat.cls);
+
+			if (symbol)
 			{
-				const auto& symbolName = symbol->GetFullName();
-				if (symbolName.size() > 14 && symbolName.rfind("_OBJC_CLASS_$_", 0) == 0)
-					categoryBaseClassName = symbolName.substr(14, symbolName.size() - 14);
+				if (symbol->GetType() == ImportedDataSymbol || symbol->GetType() == ImportAddressSymbol || symbol->GetType() == DataSymbol)
+				{
+					// Symbols named `_OBJC_CLASS_$_` are references to external classes.
+					// Symbols named `cls_` are classes defined in a loaded image other than
+					// the image currently being analyzed. Classes from the current image
+					// are found via `m_classes`.
+					const std::string_view symbolName = symbol->GetFullNameRef();
+					if (symbolName.size() > 14 && symbolName.rfind("_OBJC_CLASS_$_", 0) == 0)
+						categoryBaseClassName = symbolName.substr(14);
+					else if (symbolName.size() > 4 && symbolName.rfind("cls_", 0) == 0)
+						categoryBaseClassName = symbolName.substr(4);
+				}
 			}
 		}
 		if (categoryBaseClassName.empty())
@@ -1245,6 +1258,11 @@ ObjCProcessor::ObjCProcessor(BinaryView* data, const char* loggerName, bool isBa
 uint64_t ObjCProcessor::GetObjCRelativeMethodBaseAddress(ObjCReader* reader)
 {
 	return 0;
+}
+
+Ref<Symbol> ObjCProcessor::SymbolForUnmappedAddress(uint64_t address)
+{
+	return nullptr;
 }
 
 void ObjCProcessor::ProcessObjCData(std::optional<std::string> imageName)

--- a/objectivec/objc.h
+++ b/objectivec/objc.h
@@ -324,6 +324,7 @@ namespace BinaryNinja {
 		virtual uint64_t GetObjCRelativeMethodBaseAddress(ObjCReader* reader);
 		virtual void GetRelativeMethod(ObjCReader* reader, method_t& meth);
 		virtual std::shared_ptr<ObjCReader> GetReader() = 0;
+		virtual Ref<Symbol> SymbolForUnmappedAddress(uint64_t address);
 
 	public:
 		virtual ~ObjCProcessor() = default;

--- a/view/sharedcache/core/ObjC.cpp
+++ b/view/sharedcache/core/ObjC.cpp
@@ -148,6 +148,26 @@ uint64_t SharedCacheObjCProcessor::GetObjCRelativeMethodBaseAddress(ObjCReader* 
 	return m_customRelativeMethodSelectorBase.value_or(0);
 }
 
+Ref<Symbol> SharedCacheObjCProcessor::SymbolForUnmappedAddress(uint64_t address)
+{
+	if (const auto symbol = m_data->GetSymbolByAddress(address))
+		return nullptr;
+
+	const auto controller = DSC::SharedCacheController::FromView(*m_data);
+	if (!controller)
+		return nullptr;
+
+	// No existing symbol located, try and search through the symbols of the cache.
+	auto cacheSymbol = controller->GetCache().GetSymbolAt(address);
+	if (!cacheSymbol.has_value())
+		return nullptr;
+
+	// Define the new symbol!
+	Ref<Symbol> symbol(new Symbol(cacheSymbol->type, cacheSymbol->name, address));
+	m_data->DefineAutoSymbol(symbol);
+	return symbol;
+}
+
 SharedCacheObjCProcessor::SharedCacheObjCProcessor(BinaryView* data, bool isBackedByDatabase) :
 	ObjCProcessor(data, "SharedCache.ObjC", isBackedByDatabase, true)
 {}

--- a/view/sharedcache/core/ObjC.h
+++ b/view/sharedcache/core/ObjC.h
@@ -63,6 +63,8 @@ namespace DSCObjC {
 
 		void GetRelativeMethod(BinaryNinja::ObjCReader* reader, BinaryNinja::method_t& meth) override;
 
+		BinaryNinja::Ref<BinaryNinja::Symbol> SymbolForUnmappedAddress(uint64_t address) override;
+
 	public:
 		SharedCacheObjCProcessor(BinaryNinja::BinaryView* data, bool isBackedByDatabase);
 


### PR DESCRIPTION
The logic for determining the class name of a category did not correctly handle classes defined in other images in the shared cache. There were two problems:
1. If the class is defined in another image that is already loaded, `ObjCProcessor` has already renamed the symbol from `_OBJC_CLASS_$_` to `cls_`. Both forms of symbol name are now handled.
2. If the class is defined in an image that is not yet loaded, no symbol name is available. The category's class is now looked up in the shared cache symbol table, and the symbol's name is parsed as if it were an import symbol.

This fixes all cases of "Failed to determine base classname for category" that I have come across.