### PR TITLE
Fix compilation with MSVC: arm64/disassembler/decode_scratchpad.c

### DIFF
--- a/arch/arm64/disassembler/decode_scratchpad.c
+++ b/arch/arm64/disassembler/decode_scratchpad.c
@@ -4625,7 +4625,7 @@ int decode_scratchpad(context* ctx, Instruction* instr)
 		case ENC_BFI_BFM_32M_BITFIELD:
 		case ENC_SBFIZ_SBFM_32M_BITFIELD:
 		case ENC_UBFIZ_UBFM_32M_BITFIELD:
-			lsb = -IMMR % 32;
+			lsb = IMMR % 32;
 			width = IMMS + 1;
 			break;
 		default:

--- a/arch/arm64/disassembler/decode_scratchpad.c
+++ b/arch/arm64/disassembler/decode_scratchpad.c
@@ -4625,7 +4625,7 @@ int decode_scratchpad(context* ctx, Instruction* instr)
 		case ENC_BFI_BFM_32M_BITFIELD:
 		case ENC_SBFIZ_SBFM_32M_BITFIELD:
 		case ENC_UBFIZ_UBFM_32M_BITFIELD:
-			lsb = IMMR % 32;
+			lsb = -(int64_t)IMMR % 32;
 			width = IMMS + 1;
 			break;
 		default:


### PR DESCRIPTION
MSVC shows several warnings, but this one is shown as an error, preventing compilation.

[error C4146: unary minus operator applied to unsigned type, result still unsigned](https://stackoverflow.com/questions/36347748/error-c4146-unary-minus-operator-applied-to-unsigned-type-result-still-unsigne)