### PR TITLE
[ObjC] Handle Objective-C ivars with an offset of 0

### DIFF
--- a/objectivec/objc.cpp
+++ b/objectivec/objc.cpp
@@ -936,8 +936,17 @@ void ObjCProcessor::ReadIvarList(ObjCReader* reader, ClassBase& cls, std::string
 			ivarStruct.alignmentRaw = reader->Read32();
 			ivarStruct.size = reader->Read32();
 
-			reader->Seek(ivarStruct.offset);
-			ivar.offset = reader->Read32();
+			if (ivarStruct.offset)
+			{
+				reader->Seek(ivarStruct.offset);
+				ivar.offset = reader->Read32();
+			}
+			else
+			{
+				// `offset` can be 0 if the ivar is an anonymous bitfield.
+				ivar.offset = 0;
+			}
+
 			reader->Seek(ivarStruct.name);
 			ivar.name = reader->ReadCString();
 			reader->Seek(ivarStruct.type);


### PR DESCRIPTION
objc-runtime-new.mm mentions an offset of 0 is used for anonymous bitfields.

There are a few libraries in the shared cache that were hitting this. Previously this would throw an exception when attempting to read from offset 0 and the types would not be applied for the ivar.