### PR TITLE
[SharedCache] Dont apply invalid symbols in the stub workflow

### DIFF
--- a/view/sharedcache/workflow/SharedCacheWorkflow.cpp
+++ b/view/sharedcache/workflow/SharedCacheWorkflow.cpp
@@ -225,6 +225,8 @@ void AnalyzeStandardFunction(Ref<Function> func, Ref<MediumLevelILFunction> mlil
 		if (view->IsValidOffset(symbolAddr))
 			return false;
 		const auto symbol = controller.GetSymbolAt(symbolAddr);
+		if (!symbol.has_value())
+			return false;
 		view->DefineAutoSymbol(symbol->GetBNSymbol(*view));
 		return true;
 	};


### PR DESCRIPTION
There was no check to ensure `symbol` actually had a value (as its a `std::optional`). This was resulting in invalid symbols being added.