### PR TITLE
[SharedCache] Always load image dependencies

### DIFF
--- a/view/sharedcache/ui/dsctriage.cpp
+++ b/view/sharedcache/ui/dsctriage.cpp
@@ -82,10 +82,11 @@ void DSCTriageView::loadImagesWithAddr(const std::vector<uint64_t>& addresses, b
 	for (const uint64_t& addr : addresses)
 	{
 		auto image = controller->GetImageContaining(addr);
-		// Only try to load if we have not already.
-		if (image.has_value() && !controller->IsImageLoaded(*image))
+		if (image.has_value())
 		{
-			images.insert({image->headerAddress, *image});
+			// Only try to load if we have not already.
+			if (!controller->IsImageLoaded(*image))
+				images.insert({image->headerAddress, *image});
 
 			// TODO: We currently only add direct dependencies, may want to make the depth configurable?
 			if (includeDependencies)


### PR DESCRIPTION
Simple change that means an image's dependencies can be loaded via the DSC triage view whether the primary image has already been loaded or not. Sometimes I've already loaded an image and then later on decide I want to load its dependencies. Currently there is no easy way to do that in the UI.