### PR TITLE
Fixed failure to install python dependencies on Windows

### DIFF
--- a/python/scriptingprovider.py
+++ b/python/scriptingprovider.py
@@ -1258,7 +1258,7 @@ class PythonScriptingProvider(ScriptingProvider):
 			) / f"python{sys.version_info.major}{sys.version_info.minor}" / "site-packages"
 			site_package_dir.mkdir(parents=True, exist_ok=True)
 			args.extend(["--target", str(site_package_dir)])
-		args.extend(list(filter(len, modules.split("\n"))))
+		args.extend(list(map(lambda module: f"\"{module}\"", filter(len, modules.split("\n")))))
 		logger.log_info(f"Running pip {args}")
 		status, result = self._run_args(args, env=python_env)
 		if status:


### PR DESCRIPTION
Fixed pip installation error if package names not surronded with quote marks
```
[ScriptingProvider] Error while attempting to install requirements Command '['C:\\Program Files\\Vector35\\BinaryNinja\\plugins\\python\\python.exe', '-m', 'pip', '--isolated', '--disable-pip-version-check', 'install', '--upgrade', '--upgrade-strategy', 'only-if-needed', '--target', 'C:\\Users\\<redacted>\\AppData\\Roaming\\Binary Ninja\\python310\\site-packages', 'capstone==5.0.1', 'pandas==2.2.2', 'unicorn==2.0.1.post1', 'lief==0.16.2']' returned non-zero exit status 2.
```