### PR TITLE
[Rust] Add generate_ssa_form to LowLevelILFunction

### DIFF
--- a/rust/src/low_level_il/function.rs
+++ b/rust/src/low_level_il/function.rs
@@ -198,6 +198,12 @@ impl LowLevelILFunction<CoreArchitecture, Mutable, NonSSA<LiftedNonSSA>> {
 
         unsafe { Self::ref_from_raw(arch, handle) }
     }
+
+    pub fn generate_ssa_form(&self) {
+        use binaryninjacore_sys::BNGenerateLowLevelILSSAForm;
+
+        unsafe { BNGenerateLowLevelILSSAForm(self.handle) };
+    }
 }
 
 impl<A, M, F> ToOwned for LowLevelILFunction<A, M, F>


### PR DESCRIPTION
Without this the changes my workflow makes to LLIL functions are not reflected in LLIL SSA and higher representations.