### PR TITLE
Fix for windows-x86_64 platform has empty intrinsics dictionary, breaking MLIL introspection #6727

### DIFF
--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -235,12 +235,12 @@ class ILIntrinsic:
 	@property
 	def inputs(self) -> List['architecture.IntrinsicInput']:
 		"""``inputs`` is only available if the IL intrinsic is an Architecture intrinsic """
-		return self.arch.intrinsics[self.name].inputs
+		return (self.arch.intrinsics.get(self.name, False) or self.arch._intrinsics[self.name]).inputs
 
 	@property
 	def outputs(self) -> List['types.Type']:
 		"""``outputs`` is only available if the IL intrinsic is an Architecture intrinsic """
-		return self.arch.intrinsics[self.name].outputs
+		return (self.arch.intrinsics.get(self.name, False) or self.arch._intrinsics[self.name]).outputs
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
This seems so simple, so maybe that means it's wrong. It's a bandaid for sure.

The alternative "fix" is to add `self.intrinsics = self._intrinsics_info` to the end of `architecture.CoreArchitecture.__init__`, but I'm not sure that's safe.