### PR TITLE
[SharedCache] Fix parsing of Objective-C metadata

### DIFF
--- a/view/sharedcache/core/ObjC.cpp
+++ b/view/sharedcache/core/ObjC.cpp
@@ -88,7 +88,7 @@ std::shared_ptr<ObjCReader> SharedCacheObjCProcessor::GetReader()
 	// TODO: This should never happen.
 	if (!controller)
 		throw std::runtime_error("SharedCacheController not found for SharedCacheObjCProcessor::GetReader!");
-	auto reader = VirtualMemoryReader(controller->GetCache().GetVirtualMemory(), m_data->GetAddressSize());
+	auto reader = VirtualMemoryReader(controller->GetCache().GetVirtualMemory());
 	return std::make_shared<SharedCacheObjCReader>(reader);
 }
 

--- a/view/sharedcache/core/VirtualMemory.cpp
+++ b/view/sharedcache/core/VirtualMemory.cpp
@@ -178,10 +178,9 @@ void VirtualMemory::Read(void* dest, uint64_t address, size_t length)
 	region->fileAccessor.lock()->Read(dest, offset, length);
 }
 
-VirtualMemoryReader::VirtualMemoryReader(std::shared_ptr<VirtualMemory> memory, uint64_t addressSize)
+VirtualMemoryReader::VirtualMemoryReader(std::shared_ptr<VirtualMemory> memory)
 {
 	m_memory = memory;
-	m_addressSize = addressSize;
 	m_cursor = 0;
 }
 
@@ -265,7 +264,7 @@ uint64_t VirtualMemoryReader::ReadPointer()
 
 uint64_t VirtualMemoryReader::ReadPointer(uint64_t address)
 {
-	m_cursor = address + m_addressSize;
+	m_cursor = address + m_memory->GetAddressSize();
 	return m_memory->ReadPointer(address);
 }
 

--- a/view/sharedcache/core/VirtualMemory.cpp
+++ b/view/sharedcache/core/VirtualMemory.cpp
@@ -265,7 +265,7 @@ uint64_t VirtualMemoryReader::ReadPointer()
 
 uint64_t VirtualMemoryReader::ReadPointer(uint64_t address)
 {
-	m_cursor = m_memory->GetAddressSize();
+	m_cursor = address + m_addressSize;
 	return m_memory->ReadPointer(address);
 }
 

--- a/view/sharedcache/core/VirtualMemory.h
+++ b/view/sharedcache/core/VirtualMemory.h
@@ -94,11 +94,10 @@ class VirtualMemoryReader
 {
 	std::shared_ptr<VirtualMemory> m_memory;
 	uint64_t m_cursor;
-	uint64_t m_addressSize;
 	BNEndianness m_endianness = LittleEndian;
 
 public:
-	explicit VirtualMemoryReader(std::shared_ptr<VirtualMemory> memory, uint64_t addressSize = 8);
+	explicit VirtualMemoryReader(std::shared_ptr<VirtualMemory> memory);
 
 	void SetEndianness(BNEndianness endianness) { m_endianness = endianness; }
 


### PR DESCRIPTION
8267ab475cb2ac82fd3724c009f21e8e30143f6b introduced a logic error in `VirtualMemoryReader::ReadPointer` that caused `VirtualMemoryReader` to attempt to read pointers from the wrong address, breaking parsing of Objective-C metadata.

@emesare 