### PR TITLE
[SharedCache] Avoid reading header fields outside of the header for iOS 10 and older

### DIFF
--- a/view/sharedcache/core/SharedCacheView.cpp
+++ b/view/sharedcache/core/SharedCacheView.cpp
@@ -175,9 +175,6 @@ bool SharedCacheView::Init()
 
 	m_logger = new Logger("SharedCache.View", GetFile()->GetSessionId());
 
-	uint32_t platform;
-	// NOTE: This entry only exists on ios 11 and later, older versions will just assume iOS.
-	GetParentView()->Read(&platform, 0xd8, 4);
 	char magic[17];
 	GetParentView()->Read(&magic, 0, 16);
 	magic[16] = 0;
@@ -195,6 +192,19 @@ bool SharedCacheView::Init()
 	{
 		m_logger->LogError("Unknown magic: %s", magic);
 		return false;
+	}
+
+	// Use the value of mappingOffset as an upper bound for the size of the
+	// header to avoid misinterpreting bytes outside of the header.
+	uint32_t mappingOffset;
+	GetParentView()->Read(&mappingOffset, 0x10, 4);
+
+	uint32_t platform;
+	if (mappingOffset >= 0xd8 + 4) {
+		GetParentView()->Read(&platform, 0xd8, 4);
+	} else {
+		m_logger->LogWarn("Old header without platform field: Defaulting to iOS");
+		platform = DSCPlatformiOS;
 	}
 
 	// TODO: Do we want to add any warnings about platform support here?


### PR DESCRIPTION
Use mappingOffset as an upper bound for the header size, and avoid reading any header fields from beyond that offset.

- Avoids printing garbage platform values for old (iOS 10 and older) DSCs.
- Avoids picking the wrong platform in case the bytes at the offset outside of the header just happen to have a value that is also a valid platform value, which is unlikely, but not impossible.

Fixes the remaining aspects of #6073.

Tested against 5.1.7363-dev (acd6c39c)