### PR TITLE
[Rust] Avoid leaking a reference within {Medium,High}LevelILFunction::ssa_form

### DIFF
--- a/rust/src/high_level_il/function.rs
+++ b/rust/src/high_level_il/function.rs
@@ -69,13 +69,10 @@ impl HighLevelILFunction {
         unsafe { BNGetHighLevelILExprCount(self.handle) }
     }
 
-    pub fn ssa_form(&self) -> HighLevelILFunction {
+    pub fn ssa_form(&self) -> Ref<HighLevelILFunction> {
         let ssa = unsafe { BNGetHighLevelILSSAForm(self.handle) };
         assert!(!ssa.is_null());
-        HighLevelILFunction {
-            handle: ssa,
-            full_ast: self.full_ast,
-        }
+        unsafe { HighLevelILFunction::ref_from_raw(ssa, self.full_ast) }
     }
 
     pub fn function(&self) -> Ref<Function> {

--- a/rust/src/medium_level_il/function.rs
+++ b/rust/src/medium_level_il/function.rs
@@ -91,10 +91,10 @@ impl MediumLevelILFunction {
         unsafe { BNGetMediumLevelILExprCount(self.handle) }
     }
 
-    pub fn ssa_form(&self) -> MediumLevelILFunction {
+    pub fn ssa_form(&self) -> Ref<MediumLevelILFunction> {
         let ssa = unsafe { BNGetMediumLevelILSSAForm(self.handle) };
         assert!(!ssa.is_null());
-        MediumLevelILFunction { handle: ssa }
+        unsafe { MediumLevelILFunction::ref_from_raw(ssa) }
     }
 
     pub fn function(&self) -> Ref<Function> {

--- a/rust/src/metadata.rs
+++ b/rust/src/metadata.rs
@@ -239,7 +239,7 @@ impl Metadata {
                     };
                     map.insert(key, value);
                 }
-                
+
                 unsafe { BNFreeMetadataValueStore(ptr) };
 
                 Ok(map)


### PR DESCRIPTION
Return a `Ref<_>` so that the underlying core object will have its reference count decremented when the caller drops the object.