### PR TITLE
[SharedCache] Add activities to core.function.metaAnalysis rather than a new named workflow

### DIFF
--- a/view/sharedcache/core/SharedCacheView.cpp
+++ b/view/sharedcache/core/SharedCacheView.cpp
@@ -241,11 +241,11 @@ bool SharedCacheView::Init()
 		Ref<Settings> programSettings = Settings::Instance();
 		auto previousWorkflow = programSettings->Get<std::string>("analysis.workflows.functionWorkflow", this);
 
-		// If we are a new file (not a database) lets go ahead and set the function workflow.
-		// We do not set the workflow on database as the user might have changed it in load options prior.
-		// We also need to update usages of `core.function.dsc` to `core.function.sharedCache`
-		if (!GetFile()->IsBackedByDatabase() || previousWorkflow == "core.function.dsc")
-			programSettings->Set("analysis.workflows.functionWorkflow", "core.function.sharedCache", this);
+		// Earlier versions of the shared cache plug-in used a named workflow rather than
+		// modifying `core.function.metaAnalysis`. Update reference to those older workflow
+		// names to `core.function.metaAnalysis`.
+		if (previousWorkflow == "core.function.dsc" || previousWorkflow == "core.function.sharedCache")
+			programSettings->Set("analysis.workflows.functionWorkflow", "core.function.metaAnalysis", this);
 	}
 
 	if (m_parseOnly)

--- a/view/sharedcache/workflow/ObjCActivity.cpp
+++ b/view/sharedcache/workflow/ObjCActivity.cpp
@@ -7,8 +7,21 @@ using namespace BinaryNinja;
 
 void ObjCActivity::Register(Workflow &workflow)
 {
-    workflow.RegisterActivity(new Activity("core.analysis.objc.adjustCallType", &AdjustCallType));
-	workflow.Insert("core.function.analyzeTailCalls", "core.analysis.objc.adjustCallType");
+    workflow.RegisterActivity(new Activity(R"({
+	  "name": "core.analysis.sharedCache.objc.adjustCallType",
+	  "eligibility": {
+	    "predicates": [
+	      {
+	        "type": "viewType",
+	        "operator": "in",
+	        "value": [
+	          "DSCView"
+	        ]
+	      }
+	    ]
+	  }
+	})", &AdjustCallType));
+	workflow.Insert("core.function.analyzeTailCalls", "core.analysis.sharedCache.objc.adjustCallType");
 }
 
 std::vector<std::string> splitSelector(const std::string& selector) {

--- a/view/sharedcache/workflow/SharedCacheWorkflow.cpp
+++ b/view/sharedcache/workflow/SharedCacheWorkflow.cpp
@@ -365,21 +365,28 @@ void AnalyzeFunction(Ref<AnalysisContext> ctx)
 
 void SharedCacheWorkflow::Register()
 {
-	Ref<Workflow> workflow = Workflow::Instance("core.function.baseAnalysis")->Clone("core.function.sharedCache");
+	Ref<Workflow> workflow = Workflow::Instance("core.function.metaAnalysis")->Clone("core.function.metaAnalysis");
 
 	// Register and insert activities here.
 	ObjCActivity::Register(*workflow);
-	workflow->RegisterActivity(new Activity("core.analysis.sharedCache.analysis", &AnalyzeFunction));
+	workflow->RegisterActivity(new Activity(R"({
+	  "name": "core.analysis.sharedCache.analysis",
+	  "eligibility": {
+	    "predicates": [
+	      {
+	        "type": "viewType",
+	        "operator": "in",
+	        "value": [
+	          "DSCView"
+	        ]
+	      }
+	    ]
+	  }
+	})", &AnalyzeFunction));
 	std::vector<std::string> inserted = { "core.analysis.sharedCache.analysis" };
 	workflow->Insert("core.function.analyzeTailCalls", inserted);
 
-	static constexpr auto WORKFLOW_DESCRIPTION = R"({
-	  "title": "Shared Cache Workflow",
-	  "description": "Shared Cache Workflow",
-	  "capabilities": []
-	})";
-
-	Workflow::RegisterWorkflow(workflow, WORKFLOW_DESCRIPTION);
+	Workflow::RegisterWorkflow(workflow);
 }
 
 extern "C"


### PR DESCRIPTION
Activities are registered with a `viewType` predicate to ensure they only run in shared cache views.

Adding activities to `core.function.metaAnalysis` lets activities registered by plug-ins run in the shared cache without the plug-ins having to be aware of the shared cache.

Work towards #6779.