### PR TITLE
[RTTI] Handle type names emitted by GCC with a leading `*`

### DIFF
--- a/plugins/rtti/rtti.cpp
+++ b/plugins/rtti/rtti.cpp
@@ -21,14 +21,15 @@ std::optional<std::string> RTTI::DemangleNameGNU3(BinaryView* view, bool allowMa
 
     std::string adjustedMangledName = mangledName;
     // For some reason some of the names that start with ZN are not prefixed by `_`.
-    if (adjustedMangledName.find("ZN") == 0)
+    if (adjustedMangledName.rfind("ZN", 0) == 0)
         adjustedMangledName = "_" + adjustedMangledName;
-    // Sometimes some std types will have a * prefixed, IDK what it means, but we need to remove it to demangle.
-    if (adjustedMangledName.find("*N") == 0)
+    // GCC emits a leading * to indicate that the type info is internal and its
+    // name can be compared via pointer equality. It is not part of the type name.
+    if (adjustedMangledName.rfind("*", 0) == 0)
         adjustedMangledName = adjustedMangledName.substr(1);
     // All types at this point should have a _Z prefix, if not, we likely need to just call the demangler directly, as this
     // function is specific to dealing with mangled _type_ names.
-    if (adjustedMangledName.find("_Z") != 0)
+    if (adjustedMangledName.rfind("_Z", 0) != 0)
         adjustedMangledName = "_Z" + adjustedMangledName;
 
     if (!DemangleGNU3(view->GetDefaultArchitecture(), adjustedMangledName, outType, demangledName, true))


### PR DESCRIPTION
[GCC emits a leading `*`](https://github.com/gcc-mirror/gcc/blob/3c7c2a6b86da641f7729dba89b25fc1b8b74d96f/gcc/cp/rtti.cc#L385-L388) to indicate that the type info is internal and its name can be compared via pointer equality. It is [not part of the type name](https://github.com/gcc-mirror/gcc/blob/3c7c2a6b86da641f7729dba89b25fc1b8b74d96f/libstdc%2B%2B-v3/libsupc%2B%2B/typeinfo#L102-L105). This was only being handled when followed with `N`, but it can apply to any mangled name.

Additionally, this updates some `std::string::find(...) == 0` calls in the adjacent code to use `std::string::rfind(..., 0) == 0` as that bails out of the string comparison as soon as the prefix does not match, rather than continuing to search the entire string.
