### PR TITLE
cmake: binaryninjaui depends on binaryninjaapi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ if(NOT HEADLESS)
         if(BinaryNinjaUI_FOUND)
             # Precompiled ui library
             add_library(binaryninjaui INTERFACE)
-            target_link_libraries(binaryninjaui INTERFACE ${BinaryNinjaUI_LIBRARIES})
+            target_link_libraries(binaryninjaui INTERFACE binaryninjaapi ${BinaryNinjaUI_LIBRARIES})
             target_link_directories(binaryninjaui INTERFACE ${BinaryNinjaUI_LIBRARY_DIRS})
             target_compile_definitions(binaryninjaui INTERFACE ${BinaryNinjaUI_DEFINITIONS})
 


### PR DESCRIPTION
Fixes building the uinotification example that only links against `binaryninjaui`.

Without this fix, there's a compilation error about not finding `binaryninjaapi.h`:

```
In file included from binaryninja-api/examples/uinotification/uinotification.cpp:2:
In file included from binaryninja-api/examples/uinotification/uinotification.h:3:
binaryninja-api/ui/uicontext.h:8:10: fatal error: 'binaryninjaapi.h' file not found
    8 | #include "binaryninjaapi.h"
      |          ^~~~~~~~~~~~~~~~~~
1 error generated.
```
