### PR TITLE
cmake: Update minimum CMake version to 3.10

### DIFF
--- a/arch/arm64/CMakeLists.txt
+++ b/arch/arm64/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(arch_arm64 CXX C)
 

--- a/arch/armv7/CMakeLists.txt
+++ b/arch/armv7/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(arch_armv7)
 

--- a/arch/mips/CMakeLists.txt
+++ b/arch/mips/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(arch_mips)
 

--- a/arch/msp430/CMakeLists.txt
+++ b/arch/msp430/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(arch_msp430)
 

--- a/arch/riscv/CMakeLists.txt
+++ b/arch/riscv/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(arch_riscv)
 

--- a/demangler/gnu3/CMakeLists.txt
+++ b/demangler/gnu3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(demangle_gnu3)
 

--- a/demangler/msvc/CMakeLists.txt
+++ b/demangler/msvc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(demangle_msvc)
 

--- a/examples/bin-info/CMakeLists.txt
+++ b/examples/bin-info/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(bin-info CXX C)
 

--- a/examples/breakpoint/CMakeLists.txt
+++ b/examples/breakpoint/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(breakpoint CXX C)
 

--- a/examples/cmdline_disasm/CMakeLists.txt
+++ b/examples/cmdline_disasm/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(cmdline_disasm CXX C)
 

--- a/examples/enterprise_test/CMakeLists.txt
+++ b/examples/enterprise_test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(enterprise_test CXX C)
 

--- a/examples/llil_parser/CMakeLists.txt
+++ b/examples/llil_parser/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(llil_parser CXX C)
 

--- a/examples/mlil_parser/CMakeLists.txt
+++ b/examples/mlil_parser/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(mlil_parser CXX C)
 

--- a/examples/print_syscalls/CMakeLists.txt
+++ b/examples/print_syscalls/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(print_syscalls CXX C)
 

--- a/examples/triage/CMakeLists.txt
+++ b/examples/triage/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(triage CXX C)
 

--- a/examples/workflows/inliner/CMakeLists.txt
+++ b/examples/workflows/inliner/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(workflow_inliner)
 

--- a/examples/workflows/tailcall/CMakeLists.txt
+++ b/examples/workflows/tailcall/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(workflow_tailcall)
 

--- a/examples/x86_extension/CMakeLists.txt
+++ b/examples/x86_extension/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(x86_extension CXX C)
 

--- a/formatter/generic/CMakeLists.txt
+++ b/formatter/generic/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(formatter_generic)
 

--- a/lang/c/CMakeLists.txt
+++ b/lang/c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(lang_pseudoc)
 

--- a/lang/rust/CMakeLists.txt
+++ b/lang/rust/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(lang_pseudorust)
 

--- a/platform/decree/CMakeLists.txt
+++ b/platform/decree/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(platform_decree)
 

--- a/platform/efi/CMakeLists.txt
+++ b/platform/efi/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(platform_efi)
 

--- a/platform/freebsd/CMakeLists.txt
+++ b/platform/freebsd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(platform_freebsd)
 

--- a/platform/linux/CMakeLists.txt
+++ b/platform/linux/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(platform_linux)
 

--- a/platform/mac-kernel/CMakeLists.txt
+++ b/platform/mac-kernel/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(platform_mac_kernel)
 

--- a/platform/mac/CMakeLists.txt
+++ b/platform/mac/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(platform_mac)
 

--- a/platform/windows-kernel/CMakeLists.txt
+++ b/platform/windows-kernel/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(platform_windows_kernel)
 

--- a/platform/windows/CMakeLists.txt
+++ b/platform/windows/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(platform_windows)
 

--- a/plugins/dwarf/dwarf_export/CMakeLists.txt
+++ b/plugins/dwarf/dwarf_export/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(dwarf_export)
 

--- a/plugins/dwarf/dwarf_import/CMakeLists.txt
+++ b/plugins/dwarf/dwarf_import/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(dwarf_import)
 

--- a/plugins/idb_import/CMakeLists.txt
+++ b/plugins/idb_import/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(idb_import)
 

--- a/plugins/pdb-ng/CMakeLists.txt
+++ b/plugins/pdb-ng/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(pdb_import_plugin)
 

--- a/plugins/rtti/CMakeLists.txt
+++ b/plugins/rtti/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(rtti)
 

--- a/plugins/stack_render_layer/CMakeLists.txt
+++ b/plugins/stack_render_layer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(stack_render_layer)
 

--- a/plugins/svd/CMakeLists.txt
+++ b/plugins/svd/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(svd_ninja)
 

--- a/plugins/warp/CMakeLists.txt
+++ b/plugins/warp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(warp_ninja)
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(python-api)
 

--- a/view/elf/CMakeLists.txt
+++ b/view/elf/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(view_elf)
 

--- a/view/kernelcache/api/python/CMakeLists.txt
+++ b/view/kernelcache/api/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(kernelcache-python-api)
 

--- a/view/kernelcache/ui/CMakeLists.txt
+++ b/view/kernelcache/ui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(kernelcacheui)
 

--- a/view/macho/CMakeLists.txt
+++ b/view/macho/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(view_macho)
 

--- a/view/md1rom/CMakeLists.txt
+++ b/view/md1rom/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(view_md1rom)
 

--- a/view/pe/CMakeLists.txt
+++ b/view/pe/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(view_pe)
 

--- a/view/sharedcache/api/python/CMakeLists.txt
+++ b/view/sharedcache/api/python/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(sharedcache-python-api)
 

--- a/view/sharedcache/ui/CMakeLists.txt
+++ b/view/sharedcache/ui/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10)
 
 project(sharedcacheui)
 


### PR DESCRIPTION
This silences the following deprecation warning when running with CMake 3.31+

```
CMake Deprecation Warning at examples/bin-info/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
```

Also remove the `FATAL_ERROR` keyword because it's ignored by CMake 2.6 and higher.

https://cmake.org/cmake/help/v3.31/command/cmake_minimum_required.html

The following script was used to make the changes

```bash
#!/bin/bash

# Find all files tracked by git
git_files=$(git ls-files)

# Loop through each file and perform the replacement
for file in $git_files; do
  # Check if the file contains the pattern we're looking for
  if grep -q "cmake_minimum_required(VERSION 3.9" "$file" 2>/dev/null; then
    echo "Updating $file"
    # Use sed to replace the entire line containing the pattern
    sed -i 's/cmake_minimum_required(VERSION 3.9.*/cmake_minimum_required(VERSION 3.10)/' "$file"
  fi
done

echo "Finished updating CMake minimum version requirements"
```