### PR TITLE
[Rust] Don't panic when a encountering an unhandled MLIL instruction

### DIFF
--- a/rust/src/medium_level_il/instruction.rs
+++ b/rust/src/medium_level_il/instruction.rs
@@ -609,9 +609,7 @@ impl MediumLevelILInstruction {
             | MLIL_CALL_PARAM_SSA
             | MLIL_CALL_OUTPUT_SSA
             | MLIL_MEMORY_INTRINSIC_OUTPUT_SSA
-            | MLIL_MEMORY_INTRINSIC_SSA => {
-                unimplemented!()
-            }
+            | MLIL_MEMORY_INTRINSIC_SSA => Op::NotYetImplemented,
         };
 
         Self {
@@ -633,6 +631,7 @@ impl MediumLevelILInstruction {
             Bp => Lifted::Bp,
             Undef => Lifted::Undef,
             Unimpl => Lifted::Unimpl,
+            NotYetImplemented => Lifted::NotYetImplemented,
             If(op) => Lifted::If(LiftedIf {
                 condition: self.lift_operand(op.condition),
                 dest_true: op.dest_true,
@@ -1629,6 +1628,9 @@ pub enum MediumLevelILInstructionKind {
     VarSsaField(VarSsaField),
     VarAliasedField(VarSsaField),
     Trap(Trap),
+    // A placeholder for instructions that the Rust bindings do not yet support.
+    // Distinct from `Unimpl` as that is a valid instruction.
+    NotYetImplemented,
 }
 
 fn get_float(value: u64, size: usize) -> f64 {

--- a/rust/src/medium_level_il/lift.rs
+++ b/rust/src/medium_level_il/lift.rs
@@ -175,6 +175,9 @@ pub enum MediumLevelILLiftedInstructionKind {
     VarSsaField(VarSsaField),
     VarAliasedField(VarSsaField),
     Trap(Trap),
+    // A placeholder for instructions that the Rust bindings do not yet support.
+    // Distinct from `Unimpl` as that is a valid instruction.
+    NotYetImplemented,
 }
 
 impl MediumLevelILLiftedInstruction {
@@ -186,6 +189,7 @@ impl MediumLevelILLiftedInstruction {
             Bp => "Bp",
             Undef => "Undef",
             Unimpl => "Unimpl",
+            NotYetImplemented => "NotYetImplemented",
             If(_) => "If",
             FloatConst(_) => "FloatConst",
             Const(_) => "Const",
@@ -318,7 +322,7 @@ impl MediumLevelILLiftedInstruction {
         use MediumLevelILLiftedInstructionKind::*;
         use MediumLevelILLiftedOperand as Operand;
         match &self.kind {
-            Nop | Noret | Bp | Undef | Unimpl => vec![],
+            Nop | Noret | Bp | Undef | Unimpl | NotYetImplemented => vec![],
             If(op) => vec![
                 ("condition", Operand::Expr(*op.condition.clone())),
                 ("dest_true", Operand::InstructionIndex(op.dest_true)),


### PR DESCRIPTION
`MediumLevelILInstruction` does not yet handle `MLIL_CALL_OUTPUT`, `MLIL_CALL_PARAM`, `MLIL_CALL_PARAM_SSA`, `MLIL_CALL_OUTPUT_SSA`, `MLIL_MEMORY_INTRINSIC_OUTPUT_SSA`, or `MLIL_MEMORY_INTRINSIC_SSA`

Map these to a `NotYetImplemented` kind rather than panicking since a panic takes down the entire app.