### PR TITLE
[Rust] Allow mapping between SSA and non-SSA forms of LLIL instructions / expressions

### DIFF
--- a/rust/src/low_level_il/expression.rs
+++ b/rust/src/low_level_il/expression.rs
@@ -104,6 +104,36 @@ where
     }
 }
 
+impl<M, R> LowLevelILExpression<'_, M, SSA, R>
+where
+    M: FunctionMutability,
+    R: ExpressionResultType,
+{
+    pub fn non_ssa_form<'func>(
+        &self,
+        non_ssa: &'func LowLevelILFunction<M, NonSSA>,
+    ) -> LowLevelILExpression<'func, M, NonSSA, R> {
+        use binaryninjacore_sys::BNGetLowLevelILNonSSAExprIndex;
+        let idx = unsafe { BNGetLowLevelILNonSSAExprIndex(self.function.handle, self.index.0) };
+        LowLevelILExpression::new(non_ssa, LowLevelExpressionIndex(idx))
+    }
+}
+
+impl<M, R> LowLevelILExpression<'_, M, NonSSA, R>
+where
+    M: FunctionMutability,
+    R: ExpressionResultType,
+{
+    pub fn ssa_form<'func>(
+        &self,
+        ssa: &'func LowLevelILFunction<M, SSA>,
+    ) -> LowLevelILExpression<'func, M, SSA, R> {
+        use binaryninjacore_sys::BNGetLowLevelILSSAExprIndex;
+        let idx = unsafe { BNGetLowLevelILSSAExprIndex(self.function.handle, self.index.0) };
+        LowLevelILExpression::new(ssa, LowLevelExpressionIndex(idx))
+    }
+}
+
 impl<'func, M> ExpressionHandler<'func, M, SSA> for LowLevelILExpression<'func, M, SSA, ValueExpr>
 where
     M: FunctionMutability,

--- a/rust/src/low_level_il/instruction.rs
+++ b/rust/src/low_level_il/instruction.rs
@@ -100,6 +100,48 @@ where
     }
 }
 
+impl<'func, M> LowLevelILInstruction<'func, M, NonSSA>
+where
+    M: FunctionMutability,
+{
+    pub fn ssa_form(
+        &self,
+        ssa: &'func LowLevelILFunction<M, SSA>,
+    ) -> LowLevelILInstruction<'func, M, SSA> {
+        use binaryninjacore_sys::BNGetLowLevelILSSAInstructionIndex;
+        let idx = unsafe { BNGetLowLevelILSSAInstructionIndex(self.function.handle, self.index.0) };
+        LowLevelILInstruction::new(ssa, LowLevelInstructionIndex(idx))
+    }
+}
+
+impl<'func, M> LowLevelILInstruction<'func, M, SSA>
+where
+    M: FunctionMutability,
+{
+    pub fn non_ssa_form(
+        &self,
+        non_ssa: &'func LowLevelILFunction<M, NonSSA>,
+    ) -> LowLevelILInstruction<'func, M, NonSSA> {
+        use binaryninjacore_sys::BNGetLowLevelILNonSSAInstructionIndex;
+        let idx =
+            unsafe { BNGetLowLevelILNonSSAInstructionIndex(self.function.handle, self.index.0) };
+        LowLevelILInstruction::new(non_ssa, LowLevelInstructionIndex(idx))
+    }
+}
+
+impl<M, F> Clone for LowLevelILInstruction<'_, M, F>
+where
+    M: FunctionMutability,
+    F: FunctionForm,
+{
+    fn clone(&self) -> Self {
+        Self {
+            function: self.function,
+            index: self.index,
+        }
+    }
+}
+
 impl<M, F> Debug for LowLevelILInstruction<'_, M, F>
 where
     M: FunctionMutability,


### PR DESCRIPTION
For `LowLeveLIL{Expression,Instruction}<M, NonSSA>` this adds:

```rust
pub fn ssa_form<'a>(&self, ssa: &'func LowLevelILFunction<M, SSA>) -> …
```

For `LowLeveLIL{Expression,Instruction}<M, SSA>` this adds:

```rust
pub fn non_ssa_form(&self, non_ssa: &'func LowLevelILFunction<M, NonSSA>) -> …
```

One thing I wasn't sure about is having these validate that `self.function` and the passed-in function represent the same underlying function object. Is there an easy way to verify that?