### PR TITLE
[PseudoObjC] Improve how [super ...] calls are displayed

### DIFF
--- a/lang/c/objctypes.cpp
+++ b/lang/c/objctypes.cpp
@@ -1,0 +1,45 @@
+#include "objctypes.h"
+#include "binaryninjaapi.h"
+
+using namespace BinaryNinja;
+
+namespace {
+
+bool IsPointerToObjCObject(const Ref<Type>& type)
+{
+	if (!type || type->GetClass() != PointerTypeClass)
+		return false;
+
+	auto childType = type->GetChildType();
+	if (!childType || childType->GetClass() != NamedTypeReferenceClass)
+		return false;
+
+	auto namedType = childType->GetNamedTypeReference();
+	return namedType && namedType->GetName().GetString() == "objc_object";
+}
+
+}  // unnamed namespace
+
+PseudoObjCTypePrinter::PseudoObjCTypePrinter() : TypePrinter("Objective-C") {}
+
+std::vector<InstructionTextToken> PseudoObjCTypePrinter::GetTypeTokensBeforeName(
+	Ref<Type> type, Ref<Platform> platform, uint8_t baseConfidence, Ref<Type> parentType, BNTokenEscapingType escaping)
+{
+	// It is idiomatic in Objective-C to use `id` rather than `objc_object*`.
+	if (IsPointerToObjCObject(type))
+		return {InstructionTextToken {baseConfidence, TypeNameToken, "id"}};
+
+	return TypePrinter::GetDefault()->GetTypeTokensBeforeName(type, platform, baseConfidence, parentType, escaping);
+}
+
+std::vector<InstructionTextToken> PseudoObjCTypePrinter::GetTypeTokensAfterName(
+	Ref<Type> type, Ref<Platform> platform, uint8_t baseConfidence, Ref<Type> parentType, BNTokenEscapingType escaping)
+{
+	return TypePrinter::GetDefault()->GetTypeTokensAfterName(type, platform, baseConfidence, parentType, escaping);
+}
+
+std::vector<TypeDefinitionLine> PseudoObjCTypePrinter::GetTypeLines(Ref<Type> type, const TypeContainer& types,
+	const QualifiedName& name, int paddingCols, bool collapsed, BNTokenEscapingType escaping)
+{
+	return TypePrinter::GetDefault()->GetTypeLines(type, types, name, paddingCols, collapsed, escaping);
+}

--- a/lang/c/objctypes.h
+++ b/lang/c/objctypes.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "binaryninjaapi.h"
+
+class PseudoObjCTypePrinter : public BinaryNinja::TypePrinter
+{
+public:
+	PseudoObjCTypePrinter();
+
+	std::vector<BinaryNinja::InstructionTextToken> GetTypeTokensBeforeName(BinaryNinja::Ref<BinaryNinja::Type> type, 
+		BinaryNinja::Ref<BinaryNinja::Platform> platform,
+		uint8_t baseConfidence = BN_FULL_CONFIDENCE, BinaryNinja::Ref<BinaryNinja::Type> parentType = nullptr,
+		BNTokenEscapingType escaping = NoTokenEscapingType) override;
+		
+	std::vector<BinaryNinja::InstructionTextToken> GetTypeTokensAfterName(BinaryNinja::Ref<BinaryNinja::Type> type, 
+		BinaryNinja::Ref<BinaryNinja::Platform> platform,
+		uint8_t baseConfidence = BN_FULL_CONFIDENCE, BinaryNinja::Ref<BinaryNinja::Type> parentType = nullptr,
+		BNTokenEscapingType escaping = NoTokenEscapingType) override;
+		
+	std::vector<BinaryNinja::TypeDefinitionLine> GetTypeLines(BinaryNinja::Ref<BinaryNinja::Type> type, 
+		const BinaryNinja::TypeContainer& types,
+		const BinaryNinja::QualifiedName& name, int paddingCols = 64, bool collapsed = false,
+		BNTokenEscapingType escaping = NoTokenEscapingType) override;
+};

--- a/lang/c/pseudoc.cpp
+++ b/lang/c/pseudoc.cpp
@@ -615,8 +615,11 @@ void PseudoCFunction::GetExprTextInternal(const HighLevelILInstruction& instr, H
 				needSeparator = hasBlocks;
 
 				// Emit the lines for the statement itself
-				GetExprTextInternal(*i, tokens, settings, TopLevelOperatorPrecedence, true);
-				tokens.NewLine();
+				if (!ShouldSkipStatement(*i))
+				{
+					GetExprTextInternal(*i, tokens, settings, TopLevelOperatorPrecedence, true);
+					tokens.NewLine();
+				}
 			}
 		}();
 		break;
@@ -2846,6 +2849,10 @@ TypePrinter* PseudoCFunction::GetTypePrinter() const
 	return m_typePrinter;
 }
 
+bool PseudoCFunction::ShouldSkipStatement(const BinaryNinja::HighLevelILInstruction& instr)
+{
+	return false;
+}
 
 PseudoCFunctionType::PseudoCFunctionType(): LanguageRepresentationFunctionType("Pseudo C")
 {

--- a/lang/c/pseudoc.cpp
+++ b/lang/c/pseudoc.cpp
@@ -8,8 +8,12 @@ using namespace BinaryNinja;
 
 PseudoCFunction::PseudoCFunction(LanguageRepresentationFunctionType* type, Architecture* arch, Function* owner,
 	HighLevelILFunction* highLevelILFunction) :
-	LanguageRepresentationFunction(type, arch, owner, highLevelILFunction), m_highLevelIL(highLevelILFunction)
+	LanguageRepresentationFunction(type, arch, owner, highLevelILFunction), m_highLevelIL(highLevelILFunction),
+	m_typePrinter(type->GetTypePrinter())
 {
+	if (!m_typePrinter) {
+		m_typePrinter = TypePrinter::GetDefault();
+	}
 }
 
 
@@ -177,11 +181,7 @@ BNSymbolDisplayResult PseudoCFunction::AppendPointerTextToken(const HighLevelILI
 
 string PseudoCFunction::GetSizeToken(size_t size, bool isSigned)
 {
-	return TypePrinter::GetDefault()->GetTypeString(
-		Type::IntegerType(size, isSigned),
-		nullptr,
-		QualifiedName()
-	);
+	return GetTypePrinter()->GetTypeString(Type::IntegerType(size, isSigned), nullptr, QualifiedName());
 }
 
 
@@ -546,11 +546,8 @@ void PseudoCFunction::GetExprTextInternal(const HighLevelILInstruction& instr, H
 	{
 		tokens.AppendOpenParen();
 		tokens.AppendOpenParen();
-		auto typeTokens = TypePrinter::GetDefault()->GetTypeTokens(
-			instr.GetType(),
-			GetArchitecture()->GetStandalonePlatform(),
-			QualifiedName()
-		);
+		auto typeTokens = GetTypePrinter()->GetTypeTokens(
+			instr.GetType(), GetArchitecture()->GetStandalonePlatform(), QualifiedName());
 		for (auto& token: typeTokens)
 		{
 			tokens.Append(token);
@@ -1004,14 +1001,12 @@ void PseudoCFunction::GetExprTextInternal(const HighLevelILInstruction& instr, H
 
 			const auto variableType = GetHighLevelILFunction()->GetFunction()->GetVariableType(destExpr);
 			const auto platform = GetHighLevelILFunction()->GetFunction()->GetPlatform();
-			const auto prevTypeTokens =
-					variableType ?
-					TypePrinter::GetDefault()->GetTypeTokensBeforeName(variableType, platform, variableType.GetConfidence()) :
-					vector<InstructionTextToken>{};
-			const auto postTypeTokens =
-					variableType ?
-					TypePrinter::GetDefault()->GetTypeTokensAfterName(variableType, platform, variableType.GetConfidence()) :
-					vector<InstructionTextToken>{};
+			const auto prevTypeTokens = variableType ?
+				GetTypePrinter()->GetTypeTokensBeforeName(variableType, platform, variableType.GetConfidence()) :
+				vector<InstructionTextToken> {};
+			const auto postTypeTokens = variableType ?
+				GetTypePrinter()->GetTypeTokensAfterName(variableType, platform, variableType.GetConfidence()) :
+				vector<InstructionTextToken> {};
 
 			// Check to see if the variable appears live
 			bool appearsDead = false;
@@ -1070,14 +1065,12 @@ void PseudoCFunction::GetExprTextInternal(const HighLevelILInstruction& instr, H
 
 			const auto variableType = GetHighLevelILFunction()->GetFunction()->GetVariableType(variable);
 			const auto platform = GetHighLevelILFunction()->GetFunction()->GetPlatform();
-			const auto prevTypeTokens =
-					variableType ?
-					TypePrinter::GetDefault()->GetTypeTokensBeforeName(variableType, platform, variableType.GetConfidence()) :
-					vector<InstructionTextToken>{};
-			const auto postTypeTokens =
-					variableType ?
-					TypePrinter::GetDefault()->GetTypeTokensAfterName(variableType, platform, variableType.GetConfidence()) :
-					vector<InstructionTextToken>{};
+			const auto prevTypeTokens = variableType ?
+				GetTypePrinter()->GetTypeTokensBeforeName(variableType, platform, variableType.GetConfidence()) :
+				vector<InstructionTextToken> {};
+			const auto postTypeTokens = variableType ?
+				GetTypePrinter()->GetTypeTokensAfterName(variableType, platform, variableType.GetConfidence()) :
+				vector<InstructionTextToken> {};
 
 			if (variableType)
 			{
@@ -2846,6 +2839,11 @@ string PseudoCFunction::GetAnnotationEndString() const
 {
 	// Show annotations as C-style inline comments
 	return " */";
+}
+
+TypePrinter* PseudoCFunction::GetTypePrinter() const
+{
+	return m_typePrinter;
 }
 
 

--- a/lang/c/pseudoc.h
+++ b/lang/c/pseudoc.h
@@ -55,6 +55,7 @@ protected:
 
 	BinaryNinja::TypePrinter* GetTypePrinter() const;
 
+	virtual bool ShouldSkipStatement(const BinaryNinja::HighLevelILInstruction& instr);
 	virtual void GetExpr_CALL_OR_TAILCALL(const BinaryNinja::HighLevelILInstruction& instr,
 		BinaryNinja::HighLevelILTokenEmitter& tokens, BinaryNinja::DisassemblySettings* settings,
 		BNOperatorPrecedence precedence, bool statement);

--- a/lang/c/pseudoc.h
+++ b/lang/c/pseudoc.h
@@ -5,6 +5,7 @@
 class PseudoCFunction: public BinaryNinja::LanguageRepresentationFunction
 {
 	BinaryNinja::Ref<BinaryNinja::HighLevelILFunction> m_highLevelIL;
+	BinaryNinja::Ref<BinaryNinja::TypePrinter> m_typePrinter;
 
 	enum FieldDisplayType
 	{
@@ -51,6 +52,8 @@ protected:
 		const BinaryNinja::HighLevelILInstruction& instr, BinaryNinja::HighLevelILTokenEmitter& tokens) override;
 	void EndLines(
 		const BinaryNinja::HighLevelILInstruction& instr, BinaryNinja::HighLevelILTokenEmitter& tokens) override;
+
+	BinaryNinja::TypePrinter* GetTypePrinter() const;
 
 	virtual void GetExpr_CALL_OR_TAILCALL(const BinaryNinja::HighLevelILInstruction& instr,
 		BinaryNinja::HighLevelILTokenEmitter& tokens, BinaryNinja::DisassemblySettings* settings,

--- a/lang/c/pseudoobjc.cpp
+++ b/lang/c/pseudoobjc.cpp
@@ -99,6 +99,17 @@ std::optional<std::pair<uint64_t, Ref<Symbol>>> GetCallTargetInfo(const HighLeve
 	return std::make_pair(constant, symbol);
 }
 
+Ref<Type> TypeResolvingNamedTypeReference(Ref<Type> type, const Function& function)
+{
+	if (!type || !type->IsNamedTypeRefer())
+		return type;
+
+	if (auto resolvedType = function.GetView()->GetTypeByRef(type->GetNamedTypeReference()))
+		return resolvedType;
+
+	return type;
+}
+
 struct RuntimeCall
 {
 	enum Type
@@ -198,6 +209,42 @@ std::optional<RuntimeCall> DetectRewrittenDirectObjCMethodCall(const HighLevelIL
 	return RuntimeCall {RuntimeCall::MessageSend, constant, true};
 }
 
+bool VariableIsObjCSuperStruct(const Variable& variable, Function& function)
+{
+	auto variableName = function.GetVariableName(variable);
+	if (variableName != "super")
+		return false;
+
+	const auto variableType = TypeResolvingNamedTypeReference(function.GetVariableType(variable), function);
+	if (!variableType || variableType->GetClass() != StructureTypeClass)
+		return false;
+
+	if (variableType->GetStructureName().GetString() != "objc_super")
+		return false;
+
+	return true;
+}
+
+bool IsAssignmentToObjCSuperStructField(const HighLevelILInstruction& assignInstr, Function& function)
+{
+	// Check if this is an assignment to a field of the objc_super struct
+	// Pattern: HLIL_ASSIGN { dest = HLIL_STRUCT_FIELD { source = HLIL_VAR { super }, }, field = ... }
+
+	if (assignInstr.operation != HLIL_ASSIGN)
+		return false;
+
+	const auto destExpr = assignInstr.GetDestExpr();
+	if (destExpr.operation != HLIL_STRUCT_FIELD)
+		return false;
+
+	const auto sourceExpr = destExpr.GetSourceExpr();
+	if (sourceExpr.operation != HLIL_VAR)
+		return false;
+
+	auto variable = sourceExpr.GetVariable<HLIL_VAR>();
+	return VariableIsObjCSuperStruct(variable, function);
+}
+
 }  // unnamed namespace
 
 PseudoObjCFunction::PseudoObjCFunction(LanguageRepresentationFunctionType* type, Architecture* arch, Function* owner,
@@ -223,7 +270,8 @@ void PseudoObjCFunction::GetExpr_CALL_OR_TAILCALL(const BinaryNinja::HighLevelIL
 	{
 	case RuntimeCall::MessageSend:
 	case RuntimeCall::MessageSendSuper:
-		if (GetExpr_ObjCMsgSend(objCRuntimeCall->address, objCRuntimeCall->isRewritten, destExpr, tokens, settings, parameterExprs))
+		if (GetExpr_ObjCMsgSend(objCRuntimeCall->address, objCRuntimeCall->type == RuntimeCall::MessageSendSuper,
+				objCRuntimeCall->isRewritten, destExpr, tokens, settings, parameterExprs))
 		{
 			if (statement)
 				tokens.AppendSemicolon();
@@ -283,7 +331,7 @@ void PseudoObjCFunction::GetExpr_CALL_OR_TAILCALL(const BinaryNinja::HighLevelIL
 	return PseudoCFunction::GetExpr_CALL_OR_TAILCALL(instr, tokens, settings, precedence, statement);
 }
 
-bool PseudoObjCFunction::GetExpr_ObjCMsgSend(uint64_t msgSendAddress, bool isRewritten,
+bool PseudoObjCFunction::GetExpr_ObjCMsgSend(uint64_t msgSendAddress, bool isSuper, bool isRewritten,
 	const HighLevelILInstruction& instr, HighLevelILTokenEmitter& tokens, DisassemblySettings* settings,
 	const std::vector<HighLevelILInstruction>& parameterExprs)
 {
@@ -302,7 +350,10 @@ bool PseudoObjCFunction::GetExpr_ObjCMsgSend(uint64_t msgSendAddress, bool isRew
 
 	tokens.AppendOpenBracket();
 
-	GetExprText(parameterExprs[0], tokens, settings);
+	if (isSuper)
+		tokens.Append(LocalVariableToken, "super", instr.address);
+	else
+		GetExprText(parameterExprs[0], tokens, settings);
 
 	for (size_t index = 2; index < parameterExprs.size(); index++)
 	{
@@ -402,10 +453,7 @@ void PseudoObjCFunction::GetExpr_CONST_PTR(const BinaryNinja::HighLevelILInstruc
 	if (!hasVariable)
 		return PseudoCFunction::GetExpr_CONST_PTR(instr, tokens, settings, precedence, statement);
 
-	auto type = variable.type->IsNamedTypeRefer() ?
-		GetFunction()->GetView()->GetTypeByRef(variable.type->GetNamedTypeReference()) :
-		variable.type.GetValue();
-
+	auto type = TypeResolvingNamedTypeReference(variable.type, *GetFunction());
 	if (!type || type->GetClass() != StructureTypeClass)
 		return PseudoCFunction::GetExpr_CONST_PTR(instr, tokens, settings, precedence, statement);
 
@@ -489,7 +537,7 @@ void PseudoObjCFunction::GetExpr_IMPORT(const BinaryNinja::HighLevelILInstructio
 	BNOperatorPrecedence precedence, bool statement)
 {
 	const auto constant = instr.GetConstant<HLIL_IMPORT>();
-	auto symbol = GetHighLevelILFunction()->GetFunction()->GetView()->GetSymbolByAddress(constant);
+	auto symbol = GetFunction()->GetView()->GetSymbolByAddress(constant);
 	const auto symbolType = symbol->GetType();
 
 	if (symbol && (symbolType == ImportedDataSymbol || symbolType == ImportAddressSymbol))
@@ -509,6 +557,28 @@ void PseudoObjCFunction::GetExpr_IMPORT(const BinaryNinja::HighLevelILInstructio
 	}
 
 	PseudoCFunction::GetExpr_IMPORT(instr, tokens, settings, precedence, statement);
+}
+
+bool PseudoObjCFunction::ShouldSkipStatement(const BinaryNinja::HighLevelILInstruction& instr)
+{
+	// Skip statements that are compiler-generated artifacts of Objective-C runtime calls
+	// For now this is limited to the declaration / initialization of the `objc_super` variable
+	// used for `objc_msgSendSuper` calls.
+	switch (instr.operation)
+	{
+	case HLIL_VAR_DECLARE:
+		if (VariableIsObjCSuperStruct(instr.GetVariable<HLIL_VAR_DECLARE>(), *GetFunction()))
+			return true;
+		break;
+	case HLIL_ASSIGN:
+		if (IsAssignmentToObjCSuperStructField(instr, *GetFunction()))
+			return true;
+		break;
+	default:
+		break;
+	}
+
+	return PseudoCFunction::ShouldSkipStatement(instr);
 }
 
 

--- a/lang/c/pseudoobjc.cpp
+++ b/lang/c/pseudoobjc.cpp
@@ -2,6 +2,7 @@
 
 #include "binaryninjaapi.h"
 #include "highlevelilinstruction.h"
+#include "objctypes.h"
 #include <optional>
 #include <string>
 #include <string_view>
@@ -517,4 +518,9 @@ Ref<LanguageRepresentationFunction> PseudoObjCFunctionType::Create(
 	Architecture* arch, Function* owner, HighLevelILFunction* highLevelILFunction)
 {
 	return new PseudoObjCFunction(this, arch, owner, highLevelILFunction);
+}
+
+Ref<TypePrinter> PseudoObjCFunctionType::GetTypePrinter()
+{
+	return new PseudoObjCTypePrinter();
 }

--- a/lang/c/pseudoobjc.cpp
+++ b/lang/c/pseudoobjc.cpp
@@ -112,6 +112,9 @@ struct RuntimeCall
 		Autorelease,
 		RetainAutorelease,
 		Class,
+		Self,
+		RespondsToSelector,
+		IsKindOfClass
 	};
 
 	Type type;
@@ -129,6 +132,9 @@ constexpr std::array RUNTIME_CALLS = {
 	std::make_pair("_objc_msgSendSuper2", RuntimeCall::MessageSendSuper),
 	std::make_pair("_objc_opt_class", RuntimeCall::Class),
 	std::make_pair("_objc_opt_new", RuntimeCall::New),
+	std::make_pair("_objc_opt_self", RuntimeCall::Self),
+	std::make_pair("_objc_opt_respondsToSelector", RuntimeCall::RespondsToSelector),
+	std::make_pair("_objc_opt_isKindOfClass", RuntimeCall::IsKindOfClass),
 	std::make_pair("_objc_release", RuntimeCall::Release),
 	std::make_pair("_objc_retain", RuntimeCall::Retain),
 	std::make_pair("_objc_retainAutoreleasedReturnValue", RuntimeCall::Retain),
@@ -143,6 +149,9 @@ constexpr std::array RUNTIME_CALLS = {
 	std::make_pair("j__objc_msgSendSuper2", RuntimeCall::MessageSendSuper),
 	std::make_pair("j__objc_opt_class", RuntimeCall::Class),
 	std::make_pair("j__objc_opt_new", RuntimeCall::New),
+	std::make_pair("j__objc_opt_self", RuntimeCall::Self),
+	std::make_pair("j__objc_opt_respondsToSelector", RuntimeCall::RespondsToSelector),
+	std::make_pair("j__objc_opt_isKindOfClass", RuntimeCall::IsKindOfClass),
 	std::make_pair("j__objc_release", RuntimeCall::Release),
 	std::make_pair("j__objc_retain", RuntimeCall::Retain),
 	std::make_pair("j__objc_retainAutoreleasedReturnValue", RuntimeCall::Retain),
@@ -244,7 +253,20 @@ void PseudoObjCFunction::GetExpr_CALL_OR_TAILCALL(const BinaryNinja::HighLevelIL
 	case RuntimeCall::Class:
 		runtimeCallTokens = {"class"};
 		break;
-	default:
+	case RuntimeCall::Self:
+		runtimeCallTokens = {"self"};
+		break;
+	case RuntimeCall::RespondsToSelector:
+	case RuntimeCall::IsKindOfClass:
+		std::string_view selectorToken =
+			objCRuntimeCall->type == RuntimeCall::RespondsToSelector ? "respondsToSelector:" : "isKindOfClass:";
+		if (GetExpr_TwoParamObjCRuntimeCall(
+				objCRuntimeCall->address, instr, tokens, settings, parameterExprs, selectorToken))
+		{
+			if (statement)
+				tokens.AppendSemicolon();
+			return;
+		}
 		break;
 	}
 
@@ -329,6 +351,24 @@ bool PseudoObjCFunction::GetExpr_GenericObjCRuntimeCall(uint64_t address, const 
 		tokens.Append(CodeSymbolToken, StringReferenceTokenContext, std::string(token), instr.address, address);
 		tokens.AppendCloseBracket();
 	}
+	return true;
+}
+
+bool PseudoObjCFunction::GetExpr_TwoParamObjCRuntimeCall(uint64_t address, const HighLevelILInstruction& instr,
+	HighLevelILTokenEmitter& tokens, DisassemblySettings* settings,
+	const std::vector<HighLevelILInstruction>& parameterExprs, std::string_view selectorToken)
+{
+	if (parameterExprs.size() < 2)
+		return false;
+
+	tokens.AppendOpenBracket();
+
+	GetExprText(parameterExprs[0], tokens, settings);
+	tokens.Append(TextToken, " ");
+	tokens.Append(CodeSymbolToken, StringReferenceTokenContext, std::string(selectorToken), instr.address, address);
+	GetExprText(parameterExprs[1], tokens, settings, MemberAndFunctionOperatorPrecedence);
+	tokens.AppendCloseBracket();
+
 	return true;
 }
 

--- a/lang/c/pseudoobjc.cpp
+++ b/lang/c/pseudoobjc.cpp
@@ -4,6 +4,7 @@
 #include "highlevelilinstruction.h"
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using namespace BinaryNinja;
@@ -350,6 +351,11 @@ void PseudoObjCFunction::GetExpr_CONST_PTR(const BinaryNinja::HighLevelILInstruc
 			return;
 	}
 
+	if (shortName.rfind("sel_", 0) == 0
+		&& GetExpr_Selector(
+			std::string_view(shortName).substr(4), constant, instr, tokens, settings, precedence, statement))
+		return;
+
 	DataVariable variable {};
 	auto hasVariable = GetFunction()->GetView()->GetDataVariableAtAddress(constant, variable);
 	if (!hasVariable)
@@ -389,6 +395,21 @@ bool PseudoObjCFunction::GetExpr_OBJC_CLASS(const Symbol& symbol, uint64_t const
 	tokens.Append(DataSymbolToken, ConstDataTokenContext, className, instr.address, constant);
 	if (statement)
 		tokens.AppendSemicolon();
+
+	return true;
+}
+
+bool PseudoObjCFunction::GetExpr_Selector(std::string_view selector, uint64_t constant,
+	const BinaryNinja::HighLevelILInstruction& instr, BinaryNinja::HighLevelILTokenEmitter& tokens,
+	BinaryNinja::DisassemblySettings* settings, BNOperatorPrecedence precedence, bool statement)
+{
+	if (selector.empty())
+		return false;
+
+	tokens.Append(KeywordToken, "@selector");
+	tokens.AppendOpenParen();
+	tokens.Append(DataSymbolToken, ConstDataTokenContext, std::string(selector), instr.address, constant);
+	tokens.AppendCloseParen();
 
 	return true;
 }

--- a/lang/c/pseudoobjc.h
+++ b/lang/c/pseudoobjc.h
@@ -21,8 +21,10 @@ protected:
 		BinaryNinja::HighLevelILTokenEmitter& tokens, BinaryNinja::DisassemblySettings* settings,
 		BNOperatorPrecedence precedence, bool statement) override;
 
+	bool ShouldSkipStatement(const BinaryNinja::HighLevelILInstruction& instr) override;
+
 private:
-	bool GetExpr_ObjCMsgSend(uint64_t msgSendAddress, bool isRewritten, const BinaryNinja::HighLevelILInstruction& expr,
+	bool GetExpr_ObjCMsgSend(uint64_t msgSendAddress, bool isSuper, bool isRewritten, const BinaryNinja::HighLevelILInstruction& expr,
 		BinaryNinja::HighLevelILTokenEmitter& tokens, BinaryNinja::DisassemblySettings* settings,
 		const std::vector<BinaryNinja::HighLevelILInstruction>& parameterExprs);
 	bool GetExpr_GenericObjCRuntimeCall(uint64_t address, const BinaryNinja::HighLevelILInstruction& expr,

--- a/lang/c/pseudoobjc.h
+++ b/lang/c/pseudoobjc.h
@@ -28,6 +28,9 @@ private:
 	bool GetExpr_GenericObjCRuntimeCall(uint64_t address, const BinaryNinja::HighLevelILInstruction& expr,
 		BinaryNinja::HighLevelILTokenEmitter& tokens, BinaryNinja::DisassemblySettings* settings,
 		const std::vector<BinaryNinja::HighLevelILInstruction>& parameterExprs, const std::vector<std::string_view>& selectorTokens);
+	bool GetExpr_TwoParamObjCRuntimeCall(uint64_t address, const BinaryNinja::HighLevelILInstruction& expr,
+		BinaryNinja::HighLevelILTokenEmitter& tokens, BinaryNinja::DisassemblySettings* settings,
+		const std::vector<BinaryNinja::HighLevelILInstruction>& parameterExprs, std::string_view selectorToken);
 	bool GetExpr_OBJC_CLASS(const BinaryNinja::Symbol& symbol, uint64_t constant,
 		const BinaryNinja::HighLevelILInstruction& expr, BinaryNinja::HighLevelILTokenEmitter& tokens,
 		BinaryNinja::DisassemblySettings* settings, BNOperatorPrecedence precedence, bool statement);

--- a/lang/c/pseudoobjc.h
+++ b/lang/c/pseudoobjc.h
@@ -47,4 +47,5 @@ public:
 	PseudoObjCFunctionType();
 	BinaryNinja::Ref<BinaryNinja::LanguageRepresentationFunction> Create(BinaryNinja::Architecture* arch,
 		BinaryNinja::Function* owner, BinaryNinja::HighLevelILFunction* highLevelILFunction) override;
+	BinaryNinja::Ref<BinaryNinja::TypePrinter> GetTypePrinter() override;
 };

--- a/lang/c/pseudoobjc.h
+++ b/lang/c/pseudoobjc.h
@@ -31,6 +31,9 @@ private:
 	bool GetExpr_OBJC_CLASS(const BinaryNinja::Symbol& symbol, uint64_t constant,
 		const BinaryNinja::HighLevelILInstruction& expr, BinaryNinja::HighLevelILTokenEmitter& tokens,
 		BinaryNinja::DisassemblySettings* settings, BNOperatorPrecedence precedence, bool statement);
+	bool GetExpr_Selector(std::string_view selector, uint64_t constant,
+		const BinaryNinja::HighLevelILInstruction& expr, BinaryNinja::HighLevelILTokenEmitter& tokens,
+		BinaryNinja::DisassemblySettings* settings, BNOperatorPrecedence precedence, bool statement);
 	bool GetExpr_NSConstantString(BinaryNinja::Ref<BinaryNinja::Type> type, uint64_t constant,
 		const BinaryNinja::HighLevelILInstruction& expr, BinaryNinja::HighLevelILTokenEmitter& tokens,
 		BinaryNinja::DisassemblySettings* settings, BNOperatorPrecedence precedence, bool statement);


### PR DESCRIPTION
1. Skip displaying the declaration and initialization of the `objc_super` struct since that's an artifact of how `objc_msgSendSuper` is called.
2. Display the message receiver as `super` rather than `&super`