### PR TITLE
Fix calls to BNFreeString in kernel cache API

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -11433,6 +11433,9 @@ namespace BinaryNinja {
 		bool IsConditionInverted(uint64_t addr);
 		void SetConditionInverted(uint64_t addr, bool invert);
 
+		BNEarlyReturn GetEarlyReturn(uint64_t addr);
+		void SetEarlyReturn(uint64_t addr, BNEarlyReturn mode);
+
 		std::map<Variable, std::set<Variable>> GetMergedVariables();
 		void MergeVariables(const Variable& target, const std::set<Variable>& sources);
 		void UnmergeVariables(const Variable& target, const std::set<Variable>& sources);

--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -11430,6 +11430,9 @@ namespace BinaryNinja {
 		BNExprFolding GetExprFolding(uint64_t addr);
 		void SetExprFolding(uint64_t addr, BNExprFolding mode);
 
+		bool IsConditionInverted(uint64_t addr);
+		void SetConditionInverted(uint64_t addr, bool invert);
+
 		std::map<Variable, std::set<Variable>> GetMergedVariables();
 		void MergeVariables(const Variable& target, const std::set<Variable>& sources);
 		void UnmergeVariables(const Variable& target, const std::set<Variable>& sources);

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -37,7 +37,7 @@
 // Current ABI version for linking to the core. This is incremented any time
 // there are changes to the API that affect linking, including new functions,
 // new types, or modifications to existing functions or types.
-#define BN_CURRENT_CORE_ABI_VERSION 109
+#define BN_CURRENT_CORE_ABI_VERSION 110
 
 // Minimum ABI version that is supported for loading of plugins. Plugins that
 // are linked to an ABI version less than this will not be able to load and
@@ -1027,6 +1027,9 @@ extern "C"
 
 		// HLIL condition can be displayed as the inverse
 		HLILInvertableCondition = 0x200,
+
+		// HLIL condition can be rewritten as an early return
+		HLILEarlyReturnPossible = 0x400,
 	} BNILInstructionAttribute;
 
 	typedef enum BNIntrinsicClass
@@ -3241,6 +3244,15 @@ extern "C"
 		AllowExprFolding
 	} BNExprFolding;
 
+	typedef enum BNEarlyReturn
+	{
+		DefaultEarlyReturn,
+		PreventEarlyReturn,
+		SmallestSideEarlyReturn,
+		TrueSideEarlyReturn,
+		FalseSideEarlyReturn
+	} BNEarlyReturn;
+
 	typedef struct BNDebugFunctionInfo
 	{
 		char* shortName;
@@ -4998,6 +5010,8 @@ extern "C"
 	BINARYNINJACOREAPI void BNSetExprFolding(BNFunction* func, uint64_t addr, BNExprFolding mode);
 	BINARYNINJACOREAPI bool BNIsConditionInverted(BNFunction* func, uint64_t addr);
 	BINARYNINJACOREAPI void BNSetConditionInverted(BNFunction* func, uint64_t addr, bool invert);
+	BINARYNINJACOREAPI BNEarlyReturn BNGetEarlyReturn(BNFunction* func, uint64_t addr);
+	BINARYNINJACOREAPI void BNSetEarlyReturn(BNFunction* func, uint64_t addr, BNEarlyReturn mode);
 	BINARYNINJACOREAPI BNMergedVariable* BNGetMergedVariables(BNFunction* func, size_t* count);
 	BINARYNINJACOREAPI void BNFreeMergedVariableList(BNMergedVariable* vars, size_t count);
 	BINARYNINJACOREAPI void BNMergeVariables(BNFunction* func, const BNVariable* target, const BNVariable* sources,

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -37,7 +37,7 @@
 // Current ABI version for linking to the core. This is incremented any time
 // there are changes to the API that affect linking, including new functions,
 // new types, or modifications to existing functions or types.
-#define BN_CURRENT_CORE_ABI_VERSION 108
+#define BN_CURRENT_CORE_ABI_VERSION 109
 
 // Minimum ABI version that is supported for loading of plugins. Plugins that
 // are linked to an ABI version less than this will not be able to load and
@@ -1024,6 +1024,9 @@ extern "C"
 
 		// HLIL expression can be folded into other expressions or has been folded
 		HLILFoldableExpr = 0x100,
+
+		// HLIL condition can be displayed as the inverse
+		HLILInvertableCondition = 0x200,
 	} BNILInstructionAttribute;
 
 	typedef enum BNIntrinsicClass
@@ -4993,6 +4996,8 @@ extern "C"
 	    BNFunction* func, const BNVariable* var, BNDeadStoreElimination mode);
 	BINARYNINJACOREAPI BNExprFolding BNGetExprFolding(BNFunction* func, uint64_t addr);
 	BINARYNINJACOREAPI void BNSetExprFolding(BNFunction* func, uint64_t addr, BNExprFolding mode);
+	BINARYNINJACOREAPI bool BNIsConditionInverted(BNFunction* func, uint64_t addr);
+	BINARYNINJACOREAPI void BNSetConditionInverted(BNFunction* func, uint64_t addr, bool invert);
 	BINARYNINJACOREAPI BNMergedVariable* BNGetMergedVariables(BNFunction* func, size_t* count);
 	BINARYNINJACOREAPI void BNFreeMergedVariableList(BNMergedVariable* vars, size_t count);
 	BINARYNINJACOREAPI void BNMergeVariables(BNFunction* func, const BNVariable* target, const BNVariable* sources,

--- a/function.cpp
+++ b/function.cpp
@@ -2837,6 +2837,18 @@ void Function::SetConditionInverted(uint64_t addr, bool invert)
 }
 
 
+BNEarlyReturn Function::GetEarlyReturn(uint64_t addr)
+{
+	return BNGetEarlyReturn(m_object, addr);
+}
+
+
+void Function::SetEarlyReturn(uint64_t addr, BNEarlyReturn mode)
+{
+	BNSetEarlyReturn(m_object, addr, mode);
+}
+
+
 std::map<Variable, std::set<Variable>> Function::GetMergedVariables()
 {
 	size_t count;

--- a/function.cpp
+++ b/function.cpp
@@ -2825,6 +2825,18 @@ void Function::SetExprFolding(uint64_t addr, BNExprFolding mode)
 }
 
 
+bool Function::IsConditionInverted(uint64_t addr)
+{
+	return BNIsConditionInverted(m_object, addr);
+}
+
+
+void Function::SetConditionInverted(uint64_t addr, bool invert)
+{
+	BNSetConditionInverted(m_object, addr, invert);
+}
+
+
 std::map<Variable, std::set<Variable>> Function::GetMergedVariables()
 {
 	size_t count;

--- a/objectivec/objc.cpp
+++ b/objectivec/objc.cpp
@@ -955,6 +955,7 @@ void ObjCProcessor::ReadMethodList(ObjCReader* reader, ClassBase& cls, std::stri
 				DefineObjCSymbol(DataSymbol, Type::PointerType(m_data->GetAddressSize(), selType),
 					"selRef_" + method.name, meth.name, true);
 			}
+
 			// workflow objc support
 			if (selAddr)
 				m_selToImplementations[selAddr].push_back(meth.imp);
@@ -967,6 +968,11 @@ void ObjCProcessor::ReadMethodList(ObjCReader* reader, ClassBase& cls, std::stri
 			method.imp = meth.imp;
 			cls.methodList[cursor] = method;
 			m_localMethods[cursor] = method;
+
+			if (selAddr)
+				m_data->AddUserDataReference(selAddr, meth.imp);
+			if (selRefAddr)
+				m_data->AddUserDataReference(selRefAddr, meth.imp);
 		}
 		catch (...)
 		{

--- a/python/function.py
+++ b/python/function.py
@@ -29,7 +29,7 @@ from . import _binaryninjacore as core
 from .enums import (
 	AnalysisSkipReason, FunctionGraphType, SymbolType, InstructionTextTokenType, HighlightStandardColor,
 	HighlightColorStyle, DisassemblyOption, IntegerDisplayType, FunctionAnalysisSkipOverride, FunctionUpdateType,
-	BuiltinType, ExprFolding
+	BuiltinType, ExprFolding, EarlyReturn
 )
 
 from . import associateddatastore  # Required in the main scope due to being an argument for _FunctionAssociatedDataStore
@@ -3475,6 +3475,16 @@ class Function:
 		if isinstance(addr, highlevelil.HighLevelILInstruction):
 			addr = addr.address
 		core.BNSetConditionInverted(self.handle, addr, invert)
+
+	def get_early_return(self, addr: Union[int, highlevelil.HighLevelILInstruction]) -> EarlyReturn:
+		if isinstance(addr, highlevelil.HighLevelILInstruction):
+			addr = addr.address
+		return EarlyReturn(core.BNGetEarlyReturn(self.handle, addr))
+
+	def set_early_return(self, addr: Union[int, highlevelil.HighLevelILInstruction], value: EarlyReturn):
+		if isinstance(addr, highlevelil.HighLevelILInstruction):
+			addr = addr.address
+		core.BNSetEarlyReturn(self.handle, addr, value)
 
 
 class AdvancedFunctionAnalysisDataRequestor:

--- a/python/function.py
+++ b/python/function.py
@@ -3466,6 +3466,16 @@ class Function:
 			addr = addr.address
 		core.BNSetExprFolding(self.handle, addr, value)
 
+	def is_condition_inverted(self, addr: Union[int, highlevelil.HighLevelILInstruction]) -> bool:
+		if isinstance(addr, highlevelil.HighLevelILInstruction):
+			addr = addr.address
+		return core.BNIsConditionInverted(self.handle, addr)
+
+	def set_condition_inverted(self, addr: Union[int, highlevelil.HighLevelILInstruction], invert: bool):
+		if isinstance(addr, highlevelil.HighLevelILInstruction):
+			addr = addr.address
+		core.BNSetConditionInverted(self.handle, addr, invert)
+
 
 class AdvancedFunctionAnalysisDataRequestor:
 	def __init__(self, func: Optional['Function'] = None):

--- a/ui/commands.h
+++ b/ui/commands.h
@@ -98,6 +98,7 @@ TypeRef GetFunctionType(BinaryViewRef data, TypeRef type);
 std::optional<uint64_t> getFoldableExprAddress(
 	BinaryNinja::HighLevelILFunction* hlil, const HighlightTokenState& highlight);
 std::optional<uint64_t> getInvertableConditionAddress(BinaryNinja::HighLevelILFunction* hlil, size_t instrIndex);
+std::optional<uint64_t> getEarlyReturnAddress(BinaryNinja::HighLevelILFunction* hlil, size_t instrIndex);
 
 /*!
     @}

--- a/ui/commands.h
+++ b/ui/commands.h
@@ -97,6 +97,7 @@ TypeRef GetFunctionType(BinaryViewRef data, TypeRef type);
 
 std::optional<uint64_t> getFoldableExprAddress(
 	BinaryNinja::HighLevelILFunction* hlil, const HighlightTokenState& highlight);
+std::optional<uint64_t> getInvertableConditionAddress(BinaryNinja::HighLevelILFunction* hlil, size_t instrIndex);
 
 /*!
     @}

--- a/ui/flowgraphwidget.h
+++ b/ui/flowgraphwidget.h
@@ -170,6 +170,8 @@ class BINARYNINJAUIAPI FlowGraphWidget :
 	BNExprFolding getCurrentExprFolding();
 	std::optional<uint64_t> getCurrentInvertableConditionAddress();
 	bool getCurrentConditionInverted();
+	std::optional<uint64_t> getCurrentEarlyReturnAddress();
+	BNEarlyReturn getCurrentEarlyReturn();
 	std::optional<std::pair<BinaryNinja::Variable, BinaryNinja::Variable>> getMergeVariablesAtCurrentLocation();
 
   protected:
@@ -401,6 +403,7 @@ class BINARYNINJAUIAPI FlowGraphWidget :
 	void setCurrentVariableDeadStoreElimination(BNDeadStoreElimination elimination);
 	void setCurrentExprFolding(BNExprFolding folding);
 	void toggleConditionInverted();
+	void setCurrentEarlyReturn(BNEarlyReturn earlyReturn);
 	void splitToNewTabAndNavigateFromCursorPosition();
 	void splitToNewWindowAndNavigateFromCursorPosition();
 	void splitToNewPaneAndNavigateFromCursorPosition();

--- a/ui/flowgraphwidget.h
+++ b/ui/flowgraphwidget.h
@@ -168,6 +168,8 @@ class BINARYNINJAUIAPI FlowGraphWidget :
 	BNDeadStoreElimination getCurrentVariableDeadStoreElimination();
 	std::optional<uint64_t> getCurrentFoldableExprAddress();
 	BNExprFolding getCurrentExprFolding();
+	std::optional<uint64_t> getCurrentInvertableConditionAddress();
+	bool getCurrentConditionInverted();
 	std::optional<std::pair<BinaryNinja::Variable, BinaryNinja::Variable>> getMergeVariablesAtCurrentLocation();
 
   protected:
@@ -398,6 +400,7 @@ class BINARYNINJAUIAPI FlowGraphWidget :
 
 	void setCurrentVariableDeadStoreElimination(BNDeadStoreElimination elimination);
 	void setCurrentExprFolding(BNExprFolding folding);
+	void toggleConditionInverted();
 	void splitToNewTabAndNavigateFromCursorPosition();
 	void splitToNewWindowAndNavigateFromCursorPosition();
 	void splitToNewPaneAndNavigateFromCursorPosition();

--- a/ui/linearview.h
+++ b/ui/linearview.h
@@ -320,6 +320,8 @@ class BINARYNINJAUIAPI LinearView : public QAbstractScrollArea, public View, pub
 	BNExprFolding getCurrentExprFolding();
 	std::optional<uint64_t> getCurrentInvertableConditionAddress();
 	bool getCurrentConditionInverted();
+	std::optional<uint64_t> getCurrentEarlyReturnAddress();
+	BNEarlyReturn getCurrentEarlyReturn();
 
 	void setDataButtonVisible(bool visible);
 	std::optional<std::pair<BinaryNinja::Variable, BinaryNinja::Variable>> getMergeVariablesAtCurrentLocation();
@@ -412,6 +414,7 @@ private Q_SLOTS:
 	void setCurrentVariableDeadStoreElimination(BNDeadStoreElimination elimination);
 	void setCurrentExprFolding(BNExprFolding folding);
 	void toggleConditionInverted();
+	void setCurrentEarlyReturn(BNEarlyReturn earlyReturn);
 
 Q_SIGNALS:
 	void notifyResizeEvent(int width, int height);

--- a/ui/linearview.h
+++ b/ui/linearview.h
@@ -318,6 +318,8 @@ class BINARYNINJAUIAPI LinearView : public QAbstractScrollArea, public View, pub
 	BNDeadStoreElimination getCurrentVariableDeadStoreElimination();
 	std::optional<uint64_t> getCurrentFoldableExprAddress();
 	BNExprFolding getCurrentExprFolding();
+	std::optional<uint64_t> getCurrentInvertableConditionAddress();
+	bool getCurrentConditionInverted();
 
 	void setDataButtonVisible(bool visible);
 	std::optional<std::pair<BinaryNinja::Variable, BinaryNinja::Variable>> getMergeVariablesAtCurrentLocation();
@@ -409,6 +411,7 @@ private Q_SLOTS:
 
 	void setCurrentVariableDeadStoreElimination(BNDeadStoreElimination elimination);
 	void setCurrentExprFolding(BNExprFolding folding);
+	void toggleConditionInverted();
 
 Q_SIGNALS:
 	void notifyResizeEvent(int width, int height);

--- a/view/kernelcache/api/kernelcache.cpp
+++ b/view/kernelcache/api/kernelcache.cpp
@@ -20,10 +20,9 @@ namespace KernelCacheAPI {
 		return BNKCViewFastGetImageCount(view->GetObject());
 	}
 
-	bool KernelCache::LoadImageWithInstallName(std::string installName)
+	bool KernelCache::LoadImageWithInstallName(const std::string& installName)
 	{
-		char* str = BNAllocString(installName.c_str());
-		return BNKCViewLoadImageWithInstallName(m_object, str);
+		return BNKCViewLoadImageWithInstallName(m_object, installName.c_str());
 	}
 
 	bool KernelCache::LoadImageContainingAddress(uint64_t addr)
@@ -161,10 +160,9 @@ namespace KernelCacheAPI {
 		return result;
 	}
 
-	std::optional<KernelCacheMachOHeader> KernelCache::GetMachOHeaderForImage(std::string name)
+	std::optional<KernelCacheMachOHeader> KernelCache::GetMachOHeaderForImage(const std::string& name)
 	{
-		char* str = BNAllocString(name.c_str());
-		char* outputStr = BNKCViewGetImageHeaderForName(m_object, str);
+		char* outputStr = BNKCViewGetImageHeaderForName(m_object, name.c_str());
 		if (outputStr == nullptr)
 			return {};
 		std::string output = outputStr;

--- a/view/kernelcache/api/kernelcacheapi.h
+++ b/view/kernelcache/api/kernelcacheapi.h
@@ -254,7 +254,7 @@ namespace KernelCacheAPI {
 		static BNKCViewLoadProgress GetLoadProgress(Ref<BinaryView> view);
 		static uint64_t FastGetImageCount(Ref<BinaryView> view);
 
-		bool LoadImageWithInstallName(std::string installName);
+		bool LoadImageWithInstallName(const std::string& installName);
 		bool LoadImageContainingAddress(uint64_t addr);
 		std::vector<std::string> GetAvailableImages();
 
@@ -268,7 +268,7 @@ namespace KernelCacheAPI {
 		std::vector<KCImage> GetImages();
 		std::vector<KCImage> GetLoadedImages();
 
-		std::optional<KernelCacheMachOHeader> GetMachOHeaderForImage(std::string name);
+		std::optional<KernelCacheMachOHeader> GetMachOHeaderForImage(const std::string& name);
 		std::optional<KernelCacheMachOHeader> GetMachOHeaderForAddress(uint64_t address);
 	};
 }

--- a/view/kernelcache/api/kernelcachecore.h
+++ b/view/kernelcache/api/kernelcachecore.h
@@ -106,7 +106,7 @@ extern "C"
 
 	KERNELCACHE_FFI_API char** BNKCViewGetInstallNames(BNKernelCache* cache, size_t* count);
 
-	KERNELCACHE_FFI_API bool BNKCViewLoadImageWithInstallName(BNKernelCache* cache, char* name);
+	KERNELCACHE_FFI_API bool BNKCViewLoadImageWithInstallName(BNKernelCache* cache, const char* name);
 	KERNELCACHE_FFI_API bool BNKCViewLoadImageContainingAddress(BNKernelCache* cache, uint64_t address);
 
 	KERNELCACHE_FFI_API bool BNKCViewIsImageLoaded(BNKernelCache* cache, uint64_t address);
@@ -128,7 +128,7 @@ extern "C"
 	KERNELCACHE_FFI_API void BNKCViewFreeLoadedImages(BNKCImage* images, size_t count);
 
 	KERNELCACHE_FFI_API char* BNKCViewGetImageHeaderForAddress(BNKernelCache* cache, uint64_t address);
-	KERNELCACHE_FFI_API char* BNKCViewGetImageHeaderForName(BNKernelCache* cache, char* name);
+	KERNELCACHE_FFI_API char* BNKCViewGetImageHeaderForName(BNKernelCache* cache, const char* name);
 
 #ifdef __cplusplus
 }

--- a/view/kernelcache/api/python/_kernelcachecore_template.py
+++ b/view/kernelcache/api/python/_kernelcachecore_template.py
@@ -8,6 +8,7 @@ import platform
 core = None
 core_platform = platform.system()
 
+from binaryninja._binaryninjacore import BNFreeString, BNFreeStringList, BNAllocString
 from binaryninja import Settings
 if Settings().get_bool("corePlugins.view.kernelCache"):
     from binaryninja._binaryninjacore import BNGetBundledPluginDirectory

--- a/view/kernelcache/api/python/kernelcache.py
+++ b/view/kernelcache/api/python/kernelcache.py
@@ -207,15 +207,10 @@ class KernelCache:
 		"""
 		Return a KernelCacheMachOHeader for the image with the given install name.
 		"""
-		s = BNAllocString(name)
-		outputStr = kccore.BNKCViewGetImageHeaderForName(self.handle, s)
+		outputStr = kccore.BNKCViewGetImageHeaderForName(self.handle, name)
 		if outputStr is None:
 			return None
-		output = outputStr
-		BNFreeString(outputStr)
-		if output == "":
-			return None
-		return KernelCacheMachOHeader.LoadFromString(output)
+		return KernelCacheMachOHeader.LoadFromString(outputStr)
 
 	def get_macho_header_for_address(self, address: int):
 		"""
@@ -224,11 +219,7 @@ class KernelCache:
 		outputStr = kccore.BNKCViewGetImageHeaderForAddress(self.handle, address)
 		if outputStr is None:
 			return None
-		output = outputStr
-		BNFreeString(outputStr)
-		if output == "":
-			return None
-		return KernelCacheMachOHeader.LoadFromString(output)
+		return KernelCacheMachOHeader.LoadFromString(outputStr)
 
 	@property
 	def state(self):

--- a/view/kernelcache/core/KernelCache.cpp
+++ b/view/kernelcache/core/KernelCache.cpp
@@ -2145,11 +2145,9 @@ extern "C"
 		cache->object->ReleaseAPIRef();
 	}
 
-	bool BNKCViewLoadImageWithInstallName(BNKernelCache* cache, char* name)
+	bool BNKCViewLoadImageWithInstallName(BNKernelCache* cache, const char* name)
 	{
 		std::string imageName = std::string(name);
-		// FIXME !!!!!!!! BNFreeString(name);
-
 		if (cache->object)
 			return cache->object->LoadImageWithInstallName(imageName);
 
@@ -2321,10 +2319,9 @@ extern "C"
 		return nullptr;
 	}
 
-	char* BNKCViewGetImageHeaderForName(BNKernelCache* cache, char* name)
+	char* BNKCViewGetImageHeaderForName(BNKernelCache* cache, const char* name)
 	{
 		std::string imageName = std::string(name);
-		BNFreeString(name);
 		if (cache->object)
 		{
 			auto header = cache->object->SerializedImageHeaderForName(imageName);

--- a/view/kernelcache/ui/kctriage.cpp
+++ b/view/kernelcache/ui/kctriage.cpp
@@ -93,7 +93,7 @@ void KCTriageView::loadImagesWithAddr(const std::vector<uint64_t>& addresses) {
 		{
 			if (imageLoadTask.IsCancelled())
 				break;
-			std::string newLoad = fmt::format("Loading images... ({}/{})", loadedImages++, images.size());
+			const std::string newLoad = fmt::format("Loading images... ({}/{})", loadedImages++, images.size());
 			imageLoadTask.SetProgressText(newLoad);
 			if (m_cache->LoadImageWithInstallName(imageName))
 				setImageLoaded(addr);

--- a/view/macho/machoview.cpp
+++ b/view/macho/machoview.cpp
@@ -448,7 +448,7 @@ MachOHeader MachoView::HeaderForAddress(BinaryView* data, uint64_t address, bool
 							sect.flags,
 							sect.reserved1,
 							sect.reserved2);
-						if (!strncmp(sect.sectname, "__mod_init_func", 15))
+						if (!strncmp(sect.sectname, "__mod_init_func", 15) || !strncmp(sect.sectname, "__init_offsets", 14))
 							header.moduleInitSections.push_back(sect);
 						if ((sect.flags & (S_ATTR_SELF_MODIFYING_CODE | S_SYMBOL_STUBS)) == (S_ATTR_SELF_MODIFYING_CODE | S_SYMBOL_STUBS))
 							header.symbolStubSections.push_back(sect);
@@ -551,7 +551,7 @@ MachOHeader MachoView::HeaderForAddress(BinaryView* data, uint64_t address, bool
 							sect.reserved1,
 							sect.reserved2,
 							sect.reserved3);
-						if (!strncmp(sect.sectname, "__mod_init_func", 15))
+						if (!strncmp(sect.sectname, "__mod_init_func", 15) || !strncmp(sect.sectname, "__init_offsets", 14))
 							header.moduleInitSections.push_back(sect);
 						if ((sect.flags & (S_ATTR_SELF_MODIFYING_CODE | S_SYMBOL_STUBS)) == (S_ATTR_SELF_MODIFYING_CODE | S_SYMBOL_STUBS))
 							header.symbolStubSections.push_back(sect);
@@ -1640,7 +1640,7 @@ bool MachoView::InitializeHeader(MachOHeader& header, bool isMainHeader, uint64_
 
 		string type;
 		BNSectionSemantics semantics = DefaultSectionSemantics;
-		switch (header.sections[i].flags & 0xff)
+		switch (header.sections[i].flags & SECTION_TYPE)
 		{
 		case S_REGULAR:
 			if (header.sections[i].flags & S_ATTR_PURE_INSTRUCTIONS)
@@ -1730,6 +1730,10 @@ bool MachoView::InitializeHeader(MachOHeader& header, bool isMainHeader, uint64_
 			break;
 		case S_THREAD_LOCAL_INIT_FUNCTION_POINTERS:
 			type = "THREAD_LOCAL_INIT_FUNCTION_POINTERS";
+			break;
+		case S_INIT_FUNC_OFFSETS:
+			type = "INIT_FUNC_OFFSETS";
+			semantics = ReadOnlyDataSectionSemantics;
 			break;
 		default:
 			type = "UNKNOWN";
@@ -1897,30 +1901,55 @@ bool MachoView::InitializeHeader(MachOHeader& header, bool isMainHeader, uint64_
 		if (find(threadStarts.begin(), threadStarts.end(), moduleInitSection.offset) != threadStarts.end())
 			continue;
 
-		// The mod_init section contains a list of function pointers called at initialization
-		// if we don't have a defined entrypoint then use the first one in the list as the entrypoint
 		size_t i = 0;
 		reader.Seek(moduleInitSection.offset);
-		for (; i < (moduleInitSection.size / m_addressSize); i++)
-		{
-			uint64_t target = (m_addressSize == 4) ? reader.Read32() : reader.Read64();
-			target += m_imageBaseAdjustment;
-			if (m_header.ident.filetype == MH_FILESET)
-			{
-				// FIXME: This isn't a super robust way of detagging,
-				// 	  should look into xnu source and the tools used to build this cache (if they're public)
-				//	  and see if anything better can be done
 
-				// mask out top 8 bits
-				uint64_t tag = 0xFFFFFFFF00000000 & header.textBase;
-				// and combine them with bottom 8 of the original entry
-				target = tag | (target & 0xFFFFFFFF);
+		if (!strncmp(moduleInitSection.sectname, "__mod_init_func", 15))
+		{
+			// The mod_init section contains a list of function pointers called at initialization
+			// if we don't have a defined entrypoint then use the first one in the list as the entrypoint
+			for (; i < (moduleInitSection.size / m_addressSize); i++)
+			{
+				uint64_t target = (m_addressSize == 4) ? reader.Read32() : reader.Read64();
+				target += m_imageBaseAdjustment;
+				if (m_header.ident.filetype == MH_FILESET)
+				{
+					// FIXME: This isn't a super robust way of detagging,
+					// 	  should look into xnu source and the tools used to build this cache (if they're public)
+					//	  and see if anything better can be done
+
+					// mask out top 8 bits
+					uint64_t tag = 0xFFFFFFFF00000000 & header.textBase;
+					// and combine them with bottom 8 of the original entry
+					target = tag | (target & 0xFFFFFFFF);
+				}
+				Ref<Platform> targetPlatform = GetDefaultPlatform()->GetAssociatedPlatformByAddress(target);
+				auto name = "mod_init_func_" + to_string(modInitFuncCnt++);
+				AddEntryPointForAnalysis(targetPlatform, target);
+				auto symbol = new Symbol(FunctionSymbol, name, target, GlobalBinding);
+				DefineAutoSymbol(symbol);
 			}
-			Ref<Platform> targetPlatform = GetDefaultPlatform()->GetAssociatedPlatformByAddress(target);
-			auto name = "mod_init_func_" + to_string(modInitFuncCnt++);
-			AddEntryPointForAnalysis(targetPlatform, target);
-			auto symbol = new Symbol(FunctionSymbol, name, target, GlobalBinding);
-			DefineAutoSymbol(symbol);
+		}
+		else if (!strncmp(moduleInitSection.sectname, "__init_offsets", 14))
+		{
+			// The init_offsets section contains a list of 32-bit RVA offsets to functions called at initialization
+			// if we don't have a defined entrypoint then use the first one in the list as the entrypoint
+			for (; i < (moduleInitSection.size / 4); i++)
+			{
+				uint64_t target = reader.Read32();
+				target += header.textBase;
+				Ref<Platform> targetPlatform = GetDefaultPlatform()->GetAssociatedPlatformByAddress(target);
+				auto name = "mod_init_func_" + to_string(modInitFuncCnt++);
+				AddEntryPointForAnalysis(targetPlatform, target);
+				auto symbol = new Symbol(FunctionSymbol, name, target, GlobalBinding);
+				DefineAutoSymbol(symbol);
+
+				// FIXME: i don't know how to define proper pointer type at this stage of analysis
+				Ref<Type> pointerVar = TypeBuilder::PointerType(4, Type::VoidType())
+						.SetPointerBase(RelativeToConstantPointerBaseType, header.textBase)
+						.Finalize();
+				DefineDataVariable(GetStart() + reader.GetOffset() - 4, pointerVar);
+			}
 		}
 	}
 

--- a/view/macho/machoview.h
+++ b/view/macho/machoview.h
@@ -144,6 +144,7 @@ typedef int vm_prot_t;
 #define S_THREAD_LOCAL_VARIABLES              0x13
 #define S_THREAD_LOCAL_VARIABLE_POINTERS      0x14
 #define S_THREAD_LOCAL_INIT_FUNCTION_POINTERS 0x15
+#define S_INIT_FUNC_OFFSETS                   0x16
 
 //Mach-O Commands
 #define LC_REQ_DYLD              0x80000000


### PR DESCRIPTION
Amends calls to BNFreeString in kernel cache API that were causing `get_macho_header_for_address`, `get_macho_header_for_image`, `get_image_name_for_address`, and `get_name_for_address` to fail.

Fixes https://github.com/Vector35/binaryninja-api/issues/6855