### PR TITLE
Fix incorrect paths in EFI Resolver, and let it run in headless mode

### DIFF
--- a/plugins/efi_resolver/include/ModuleType.h
+++ b/plugins/efi_resolver/include/ModuleType.h
@@ -13,10 +13,10 @@ enum EFIModuleType
 
 static inline EFIModuleType identifyModuleType(BinaryView* bv)
 {
-	std::string viewType = bv->GetCurrentView();
-	if (viewType == "Linear:PE")
+	FileMetadata* file = bv->GetFile();
+	if (file->GetViewOfType("PE"))
 		return DXE;
-	else if (viewType == "Linear:TE")
+	else if (file->GetViewOfType("TE"))
 		return PEI;
 	else
 		return UNKNOWN;

--- a/plugins/efi_resolver/src/Resolver.cpp
+++ b/plugins/efi_resolver/src/Resolver.cpp
@@ -44,11 +44,11 @@ static string GetBundledEfiPath()
 {
 	string path = GetBundledPluginDirectory();
 #if defined(_WIN32)
-	return path + "..\\types\\efi.c";
+	return path + "\\..\\types\\efi.c";
 #elif defined(__APPLE__)
 	return path + "/../../Resources/types/efi.c";
 #else
-	return path + "../types/efi.c";
+	return path + "/../types/efi.c";
 #endif
 }
 


### PR DESCRIPTION
EFI Resolver was failing to apply protocol definitions for me, and I traced it down to incorrect calculation of the path to `types/efi.c`. On linux, the calculated path was `/opt/binaryninja/plugins../types/efi.c`, which obviously wouldn't get interpreted correctly. Adding the missing leading separator should fix the problem. The same problem likely appears on Windows, though I haven't confirmed this.

Another bug I found was that running in headless mode seems to not trigger the workflow, and this I traced down to `identifyModuleType` calling `bv->GetCurrentView()` instead of `bv->GetFile()->GetViewOfType("...")` when checking for a DXE/PEI file.