### PR TITLE
[ObjC] Rewrite a couple of additional runtime calls

### DIFF
--- a/lang/c/pseudoobjc.cpp
+++ b/lang/c/pseudoobjc.cpp
@@ -112,6 +112,9 @@ struct RuntimeCall
 		Autorelease,
 		RetainAutorelease,
 		Class,
+		Self,
+		RespondsToSelector,
+		IsKindOfClass
 	};
 
 	Type type;
@@ -129,6 +132,9 @@ constexpr std::array RUNTIME_CALLS = {
 	std::make_pair("_objc_msgSendSuper2", RuntimeCall::MessageSendSuper),
 	std::make_pair("_objc_opt_class", RuntimeCall::Class),
 	std::make_pair("_objc_opt_new", RuntimeCall::New),
+	std::make_pair("_objc_opt_self", RuntimeCall::Self),
+	std::make_pair("_objc_opt_respondsToSelector", RuntimeCall::RespondsToSelector),
+	std::make_pair("_objc_opt_isKindOfClass", RuntimeCall::IsKindOfClass),
 	std::make_pair("_objc_release", RuntimeCall::Release),
 	std::make_pair("_objc_retain", RuntimeCall::Retain),
 	std::make_pair("_objc_retainAutoreleasedReturnValue", RuntimeCall::Retain),
@@ -143,6 +149,9 @@ constexpr std::array RUNTIME_CALLS = {
 	std::make_pair("j__objc_msgSendSuper2", RuntimeCall::MessageSendSuper),
 	std::make_pair("j__objc_opt_class", RuntimeCall::Class),
 	std::make_pair("j__objc_opt_new", RuntimeCall::New),
+	std::make_pair("j__objc_opt_self", RuntimeCall::Self),
+	std::make_pair("j__objc_opt_respondsToSelector", RuntimeCall::RespondsToSelector),
+	std::make_pair("j__objc_opt_isKindOfClass", RuntimeCall::IsKindOfClass),
 	std::make_pair("j__objc_release", RuntimeCall::Release),
 	std::make_pair("j__objc_retain", RuntimeCall::Retain),
 	std::make_pair("j__objc_retainAutoreleasedReturnValue", RuntimeCall::Retain),
@@ -244,7 +253,20 @@ void PseudoObjCFunction::GetExpr_CALL_OR_TAILCALL(const BinaryNinja::HighLevelIL
 	case RuntimeCall::Class:
 		runtimeCallTokens = {"class"};
 		break;
-	default:
+	case RuntimeCall::Self:
+		runtimeCallTokens = {"self"};
+		break;
+	case RuntimeCall::RespondsToSelector:
+	case RuntimeCall::IsKindOfClass:
+		std::string_view selectorToken =
+			objCRuntimeCall->type == RuntimeCall::RespondsToSelector ? "respondsToSelector:" : "isKindOfClass:";
+		if (GetExpr_TwoParamObjCRuntimeCall(
+				objCRuntimeCall->address, instr, tokens, settings, parameterExprs, selectorToken))
+		{
+			if (statement)
+				tokens.AppendSemicolon();
+			return;
+		}
 		break;
 	}
 
@@ -329,6 +351,24 @@ bool PseudoObjCFunction::GetExpr_GenericObjCRuntimeCall(uint64_t address, const 
 		tokens.Append(CodeSymbolToken, StringReferenceTokenContext, std::string(token), instr.address, address);
 		tokens.AppendCloseBracket();
 	}
+	return true;
+}
+
+bool PseudoObjCFunction::GetExpr_TwoParamObjCRuntimeCall(uint64_t address, const HighLevelILInstruction& instr,
+	HighLevelILTokenEmitter& tokens, DisassemblySettings* settings,
+	const std::vector<HighLevelILInstruction>& parameterExprs, std::string_view selectorToken)
+{
+	if (parameterExprs.size() < 2)
+		return false;
+
+	tokens.AppendOpenBracket();
+
+	GetExprText(parameterExprs[0], tokens, settings);
+	tokens.Append(TextToken, " ");
+	tokens.Append(CodeSymbolToken, StringReferenceTokenContext, std::string(selectorToken), instr.address, address);
+	GetExprText(parameterExprs[1], tokens, settings, MemberAndFunctionOperatorPrecedence);
+	tokens.AppendCloseBracket();
+
 	return true;
 }
 

--- a/lang/c/pseudoobjc.cpp
+++ b/lang/c/pseudoobjc.cpp
@@ -4,6 +4,7 @@
 #include "highlevelilinstruction.h"
 #include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 using namespace BinaryNinja;
@@ -350,6 +351,11 @@ void PseudoObjCFunction::GetExpr_CONST_PTR(const BinaryNinja::HighLevelILInstruc
 			return;
 	}
 
+	if (shortName.rfind("sel_", 0) == 0
+		&& GetExpr_Selector(
+			std::string_view(shortName).substr(4), constant, instr, tokens, settings, precedence, statement))
+		return;
+
 	DataVariable variable {};
 	auto hasVariable = GetFunction()->GetView()->GetDataVariableAtAddress(constant, variable);
 	if (!hasVariable)
@@ -389,6 +395,21 @@ bool PseudoObjCFunction::GetExpr_OBJC_CLASS(const Symbol& symbol, uint64_t const
 	tokens.Append(DataSymbolToken, ConstDataTokenContext, className, instr.address, constant);
 	if (statement)
 		tokens.AppendSemicolon();
+
+	return true;
+}
+
+bool PseudoObjCFunction::GetExpr_Selector(std::string_view selector, uint64_t constant,
+	const BinaryNinja::HighLevelILInstruction& instr, BinaryNinja::HighLevelILTokenEmitter& tokens,
+	BinaryNinja::DisassemblySettings* settings, BNOperatorPrecedence precedence, bool statement)
+{
+	if (selector.empty())
+		return false;
+
+	tokens.Append(KeywordToken, "@selector");
+	tokens.AppendOpenParen();
+	tokens.Append(DataSymbolToken, ConstDataTokenContext, std::string(selector), instr.address, constant);
+	tokens.AppendCloseParen();
 
 	return true;
 }

--- a/lang/c/pseudoobjc.h
+++ b/lang/c/pseudoobjc.h
@@ -28,6 +28,9 @@ private:
 	bool GetExpr_GenericObjCRuntimeCall(uint64_t address, const BinaryNinja::HighLevelILInstruction& expr,
 		BinaryNinja::HighLevelILTokenEmitter& tokens, BinaryNinja::DisassemblySettings* settings,
 		const std::vector<BinaryNinja::HighLevelILInstruction>& parameterExprs, const std::vector<std::string_view>& selectorTokens);
+	bool GetExpr_TwoParamObjCRuntimeCall(uint64_t address, const BinaryNinja::HighLevelILInstruction& expr,
+		BinaryNinja::HighLevelILTokenEmitter& tokens, BinaryNinja::DisassemblySettings* settings,
+		const std::vector<BinaryNinja::HighLevelILInstruction>& parameterExprs, std::string_view selectorToken);
 	bool GetExpr_OBJC_CLASS(const BinaryNinja::Symbol& symbol, uint64_t constant,
 		const BinaryNinja::HighLevelILInstruction& expr, BinaryNinja::HighLevelILTokenEmitter& tokens,
 		BinaryNinja::DisassemblySettings* settings, BNOperatorPrecedence precedence, bool statement);

--- a/lang/c/pseudoobjc.h
+++ b/lang/c/pseudoobjc.h
@@ -31,6 +31,9 @@ private:
 	bool GetExpr_OBJC_CLASS(const BinaryNinja::Symbol& symbol, uint64_t constant,
 		const BinaryNinja::HighLevelILInstruction& expr, BinaryNinja::HighLevelILTokenEmitter& tokens,
 		BinaryNinja::DisassemblySettings* settings, BNOperatorPrecedence precedence, bool statement);
+	bool GetExpr_Selector(std::string_view selector, uint64_t constant,
+		const BinaryNinja::HighLevelILInstruction& expr, BinaryNinja::HighLevelILTokenEmitter& tokens,
+		BinaryNinja::DisassemblySettings* settings, BNOperatorPrecedence precedence, bool statement);
 	bool GetExpr_NSConstantString(BinaryNinja::Ref<BinaryNinja::Type> type, uint64_t constant,
 		const BinaryNinja::HighLevelILInstruction& expr, BinaryNinja::HighLevelILTokenEmitter& tokens,
 		BinaryNinja::DisassemblySettings* settings, BNOperatorPrecedence precedence, bool statement);


### PR DESCRIPTION
* `objc_opt_self(…)` becomes `[... self]`
* `objc_opt_isKindOfClass(…, …)` becomes `[... isKindOfClass:...]`
* `objc_opt_respondsToSelector(…, …)` becomes `[... respondsToSelector:...]`
