### PR TITLE
[view][elf] Fixed duplicate NOTE section loading in address space.

### DIFF
--- a/view/elf/elfview.cpp
+++ b/view/elf/elfview.cpp
@@ -632,7 +632,7 @@ bool ElfView::Init()
 		}
 
 		// Add sections that aren't in the virtual address space only to the raw parent view
-		if (!(m_elfSections[i].flags & ELF_SHF_ALLOC))
+		if (!(m_elfSections[i].flags & ELF_SHF_ALLOC) || m_elfSections[i].type == ELF_SHT_NOTE)
 		{
 			if (m_elfSections[i].size != 0 && m_elfSections[i].type != ELF_SHT_NOBITS)
 				GetParentView()->AddAutoSection(sectionNames[i], m_elfSections[i].offset, m_elfSections[i].size, DefaultSectionSemantics,


### PR DESCRIPTION
NOTE sections were being treated as loadable segments when they should be metadata-only. The NOTE section had the allocatable flag set. The program correctly checked for SHF_ALLOC but didn't exclude NOTE sections explicitly. NOTE sections consumed 0x50 bytes at the base address