### PR TITLE
Add GetPathInProject() to core API

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -2878,6 +2878,7 @@ namespace BinaryNinja {
 
 		Ref<Project> GetProject() const;
 		std::string GetPathOnDisk() const;
+		std::string GetPathInProject() const;
 		bool ExistsOnDisk() const;
 		std::string GetName() const;
 		std::string GetDescription() const;

--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -2938,7 +2938,8 @@ namespace BinaryNinja {
 		Ref<ProjectFile> CreateFileUnsafe(const std::vector<uint8_t>& contents, Ref<ProjectFolder> folder, const std::string& name, const std::string& description, const std::string& id, int64_t creationTimestamp, const ProgressFunction& progressCallback = {});
 		std::vector<Ref<ProjectFile>> GetFiles() const;
 		Ref<ProjectFile> GetFileById(const std::string& id) const;
-		Ref<ProjectFile> GetFileByPathOnDisk(const std::string& path);
+		Ref<ProjectFile> GetFileByPathOnDisk(const std::string& path) const;
+		std::vector<Ref<ProjectFile>> GetFilesByPathInProject(const std::string& path) const;
 		void PushFile(Ref<ProjectFile> file);
 		bool DeleteFile_(Ref<ProjectFile> file);
 

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -4037,6 +4037,7 @@ extern "C"
 	BINARYNINJACOREAPI void BNFreeProjectFile(BNProjectFile* file);
 	BINARYNINJACOREAPI void BNFreeProjectFileList(BNProjectFile** files, size_t count);
 	BINARYNINJACOREAPI char* BNProjectFileGetPathOnDisk(BNProjectFile* file);
+	BINARYNINJACOREAPI char* BNProjectFileGetPathInProject(BNProjectFile* file);
 	BINARYNINJACOREAPI bool BNProjectFileExistsOnDisk(BNProjectFile* file);
 	BINARYNINJACOREAPI char* BNProjectFileGetName(BNProjectFile* file);
 	BINARYNINJACOREAPI bool BNProjectFileSetName(BNProjectFile* file, const char* name);

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -4013,6 +4013,7 @@ extern "C"
 	BINARYNINJACOREAPI BNProjectFile** BNProjectGetFiles(BNProject* project, size_t* count);
 	BINARYNINJACOREAPI BNProjectFile* BNProjectGetFileById(BNProject* project, const char* id);
 	BINARYNINJACOREAPI BNProjectFile* BNProjectGetFileByPathOnDisk(BNProject* project, const char* path);
+	BINARYNINJACOREAPI BNProjectFile** BNProjectGetFilesByPathInProject(BNProject* project, const char* path, size_t* count);
 
 	BINARYNINJACOREAPI void BNProjectPushFile(BNProject* project, BNProjectFile* file);
 	BINARYNINJACOREAPI bool BNProjectDeleteFile(BNProject* project, BNProjectFile* file);
@@ -4037,7 +4038,7 @@ extern "C"
 	BINARYNINJACOREAPI void BNFreeProjectFile(BNProjectFile* file);
 	BINARYNINJACOREAPI void BNFreeProjectFileList(BNProjectFile** files, size_t count);
 	BINARYNINJACOREAPI char* BNProjectFileGetPathOnDisk(BNProjectFile* file);
-	BINARYNINJACOREAPI char* BNProjectFileGetPathInProject(BNProjectFile* file);
+	BINARYNINJACOREAPI char* BNProjectFileGetPathInProject(const BNProjectFile* file);
 	BINARYNINJACOREAPI bool BNProjectFileExistsOnDisk(BNProjectFile* file);
 	BINARYNINJACOREAPI char* BNProjectFileGetName(BNProjectFile* file);
 	BINARYNINJACOREAPI bool BNProjectFileSetName(BNProjectFile* file, const char* name);

--- a/examples/triage/fileinfo.cpp
+++ b/examples/triage/fileinfo.cpp
@@ -72,8 +72,17 @@ FileInfoWidget::FileInfoWidget(QWidget* parent, BinaryViewRef bv)
 	this->m_layout->setVerticalSpacing(1);
 
 	const auto view = bv->GetParentView() ? bv->GetParentView() : bv;
-	const auto filePath = bv->GetFile()->GetOriginalFilename();
+
+	const auto file = bv->GetFile();
+	const auto filePath = file->GetOriginalFilename();
 	this->addCopyableField("Path: ", filePath.c_str());
+
+	// If triage view is opened from a project, show both actual filepath and path relative to project
+	if (const auto fileProjectRef = file->GetProjectFile())
+	{
+		const auto projectFilePath = file->GetProjectFile()->GetPathInProject();
+		this->addCopyableField("Path in project: ", projectFilePath.c_str());
+	}
 
 	const auto fileSize = QString::number(view->GetLength(), 16).prepend("0x");
 	this->addCopyableField("Size: ", fileSize);

--- a/examples/triage/fileinfo.cpp
+++ b/examples/triage/fileinfo.cpp
@@ -75,7 +75,7 @@ FileInfoWidget::FileInfoWidget(QWidget* parent, BinaryViewRef bv)
 
 	const auto file = bv->GetFile();
 	const auto filePath = file->GetOriginalFilename();
-	this->addCopyableField("Path: ", filePath.c_str());
+	this->addCopyableField("Path on disk: ", filePath.c_str());
 
 	// If triage view is opened from a project, show both actual filepath and path relative to project
 	if (const auto fileProjectRef = file->GetProjectFile())

--- a/project.cpp
+++ b/project.cpp
@@ -477,12 +477,31 @@ Ref<ProjectFile> Project::GetFileById(const std::string& id) const
 }
 
 
-Ref<ProjectFile> Project::GetFileByPathOnDisk(const std::string& path)
+Ref<ProjectFile> Project::GetFileByPathOnDisk(const std::string& path) const
 {
 	BNProjectFile* file = BNProjectGetFileByPathOnDisk(m_object, path.c_str());
 	if (file == nullptr)
 		return nullptr;
 	return new ProjectFile(file);
+}
+
+
+std::vector<Ref<ProjectFile>> Project::GetFilesByPathInProject(
+	const std::string& path
+) const
+{
+	size_t count;
+	BNProjectFile** files = BNProjectGetFilesByPathInProject(m_object, path.c_str(), &count);
+
+	std::vector<Ref<ProjectFile>> result;
+	result.reserve(count);
+	for (size_t i = 0; i < count; i++)
+	{
+		result.emplace_back(new ProjectFile(BNNewProjectFileReference(files[i])));
+	}
+
+	BNFreeProjectFileList(files, count);
+	return result;
 }
 
 

--- a/project.cpp
+++ b/project.cpp
@@ -552,6 +552,14 @@ std::string ProjectFile::GetPathOnDisk() const
 	return result;
 }
 
+std::string ProjectFile::GetPathInProject() const
+{
+	char* path = BNProjectFileGetPathInProject(m_object);
+	std::string result = path;
+	BNFreeString(path);
+	return result;
+}
+
 
 bool ProjectFile::ExistsOnDisk() const
 {

--- a/python/project.py
+++ b/python/project.py
@@ -190,6 +190,22 @@ class ProjectFile:
 		"""
 		return core.BNProjectFileExport(self._handle, str(dest))
 
+	def get_path_on_disk(self) -> Optional[str]:
+		"""
+		Get this file's path on disk
+		
+		:return: The path on disk of the file or None
+		"""
+		return core.BNProjectFileGetPathOnDisk(self._handle)
+
+	def get_path_in_project(self) -> Optional[str]:
+		"""
+		Get this file's path in its parent project
+
+		:return: The path on disk of the file or None
+		"""
+		return core.BNProjectFileGetPathInProject(self._handle)
+
 
 class ProjectFolder:
 	"""
@@ -649,6 +665,43 @@ class Project:
 			return None
 		file = ProjectFile(handle)
 		return file
+
+	def get_file_by_path_on_disk(self, path: str) -> Optional[ProjectFile]:
+		"""
+		Retrieve a file in the project by its path on disk
+
+		:param path: Path of the file on the disk
+		:return: File with the requested path or None
+		"""
+		handle = core.BNProjectGetFileByPathOnDisk(self._handle, path)
+		if handle is None:
+			return None
+		file = ProjectFile(handle)
+		return file
+
+	def get_files_by_path_in_project(self, path: str) -> List[ProjectFile]:
+		"""
+		Retrieve a file(s) by path in the project
+		Note that files in a project can share names and paths within the project
+		but are uniquely identified by a disk path or id.
+
+		:param path: Path of the file(s) in the project, separate from their path on disk.
+		:return: List of files with the requested path
+		"""
+		count = ctypes.c_size_t()
+		value = core.BNProjectGetFilesByPathInProject(self._handle, path, count)
+		if value is None:
+			raise ProjectException("Failed to get list of project files by path in project")
+		result = []
+		try:
+			for i in range(count.value):
+				file_handle = core.BNNewProjectFileReference(value[i])
+				if file_handle is None:
+					raise ProjectException("core.BNNewProjectFileReference returned None")
+				result.append(ProjectFile(file_handle))
+			return result
+		finally:
+			core.BNFreeProjectFileList(value, count.value)
 
 	def delete_file(self, file: ProjectFile) -> bool:
 		"""

--- a/rust/tests/binary_view.rs
+++ b/rust/tests/binary_view.rs
@@ -106,7 +106,8 @@ fn test_binary_tags() {
     let view = binaryninja::load(out_dir.join("atox.obj")).expect("Failed to create view");
     let tag_ty = view.create_tag_type("Test", "");
     view.add_tag(0x0, &tag_ty, "t", false);
-    view.tag_type_by_name("Test").expect("Failed to get tag type");
+    view.tag_type_by_name("Test")
+        .expect("Failed to get tag type");
 }
 
 // These are the target files present in OUT_DIR


### PR DESCRIPTION
Adds GetPathInProject() function to core API, returning the path of a file in a project relative to the project rather than the actual location on disk. 