### PR TITLE
Fixed exportTriepresent with export offset and size check 

### DIFF
--- a/view/macho/machoview.cpp
+++ b/view/macho/machoview.cpp
@@ -696,14 +696,18 @@ MachOHeader MachoView::HeaderForAddress(BinaryView* data, uint64_t address, bool
 				header.dyldInfo.export_size = reader.Read32();
 				header.exportTrie.dataoff = header.dyldInfo.export_off;
 				header.exportTrie.datasize = header.dyldInfo.export_size;
-				header.exportTriePresent = true;
+				// Only mark export trie as present if there's actually data
+				if (header.dyldInfo.export_off != 0 && header.dyldInfo.export_size != 0)
+					header.exportTriePresent = true;
 				header.dyldInfoPresent = true;
 				break;
 			case LC_DYLD_EXPORTS_TRIE:
 				m_logger->LogDebug("LC_DYLD_EXPORTS_TRIE\n");
 				header.exportTrie.dataoff = reader.Read32();
 				header.exportTrie.datasize = reader.Read32();
-				header.exportTriePresent = true;
+				// Only mark export trie as present if there's actually data
+				if (header.exportTrie.dataoff != 0 && header.exportTrie.datasize != 0)
+					header.exportTriePresent = true;
 				break;
 			case LC_THREAD:
 			case LC_UNIXTHREAD:


### PR DESCRIPTION
This bug caused by incorrect header.exportTriePresent without checking export_off and export_size in MachOHeader MachoView::HeaderForAddress for case LC_DYLD_INFO_ONLY and case LC_DYLD_EXPORTS_TRIE. 

See issue: https://github.com/issues/assigned?issue=Vector35%7Cbinaryninja-api%7C6988