### PR TITLE
Add GetSystemCache function to C++ API

### DIFF
--- a/binaryninjaapi.cpp
+++ b/binaryninjaapi.cpp
@@ -95,6 +95,17 @@ string BinaryNinja::GetUserDirectory(void)
 }
 
 
+string BinaryNinja::GetSystemCacheDirectory()
+{
+	char* dir = BNGetSystemCacheDirectory();
+	if (!dir)
+		return string();
+	std::string result(dir);
+	BNFreeString(dir);
+	return result;
+}
+
+
 string BinaryNinja::GetSettingsFileName()
 {
 	char* dir = BNGetSettingsFileName();

--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -1241,6 +1241,8 @@ namespace BinaryNinja {
 	void SetBundledPluginDirectory(const std::string& path);
 	std::string GetUserDirectory();
 
+	std::string GetSystemCacheDirectory();
+
 	std::string GetSettingsFileName();
 	std::string GetRepositoriesDirectory();
 	std::string GetInstallDirectory();

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -7530,6 +7530,7 @@ extern "C"
 	BINARYNINJACOREAPI char** BNGetFilePathsInDirectory(const char* path, size_t* count);
 	BINARYNINJACOREAPI char* BNAppendPath(const char* path, const char* part);
 	BINARYNINJACOREAPI void BNFreePath(char* path);
+	BINARYNINJACOREAPI char* BNGetSystemCacheDirectory();
 
 	// Settings APIs
 	BINARYNINJACOREAPI BNSettings* BNCreateSettings(const char* schemaId);

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -462,6 +462,19 @@ def connect_vscode_debugger(port=5678):
 	debugpy.wait_for_client()
 	execute_on_main_thread(lambda: debugpy.debug_this_thread())
 
+def get_system_cache_directory() -> Optional[str]:
+	"""
+	Returns Binary Ninja's system cache directory on the system.
+
+	Supported default locations:
+		- macOS: ~/Library/Caches/Binary Ninja
+		- Linux: $XDG_CACHE_HOME/Binary Ninja or ~/.cache/Binary Ninja
+		- Windows: %LOCALAPPDATA%/Binary Ninja/cache
+
+	:return: Returns a string containing the system cache directory, or None on failure.
+	"""
+	return core.BNGetSystemCacheDirectory()
+
 
 class UIPluginInHeadlessError(Exception):
 	"""


### PR DESCRIPTION
Adds the `GetSystemCacheDirectory` function to the C++ API, a function that returns Binary Ninja's default system cache directory as a string dependent on the user's OS. 