### PR TITLE
[Rust] Fix clippy + rustfmt complaints

### DIFF
--- a/rust/src/function.rs
+++ b/rust/src/function.rs
@@ -2371,8 +2371,8 @@ impl Function {
         unsafe { BNHasUnresolvedIndirectBranches(self.handle) }
     }
 
-    /// List of address of unresolved indirect branches
     /*
+    /// List of address of unresolved indirect branches
     pub fn unresolved_indirect_branches(&self) -> Array<Arch> {
         let mut count = 0;
         let result = unsafe { BNGetUnresolvedIndirectBranches(self.handle, &mut count) };


### PR DESCRIPTION
The clippy complaint was a real issue: the doc comment intended for the commented-out `unresolved_indirect_branches` was being interpreted as the start of the doc comment for the following function.