### PR TITLE
[ObjC] Fix handling of relative method selectors with MSVC

### DIFF
--- a/objectivec/objc.cpp
+++ b/objectivec/objc.cpp
@@ -838,9 +838,14 @@ void ObjCProcessor::LoadProtocols(ObjCReader* reader, Ref<Section> listSection)
 
 void ObjCProcessor::GetRelativeMethod(ObjCReader* reader, method_t& meth)
 {
-	meth.name = reader->GetOffset() + reader->ReadS32();
-	meth.types = reader->GetOffset() + reader->ReadS32();
-	meth.imp = reader->GetOffset() + reader->ReadS32();
+	uint64_t offset = reader->GetOffset();
+	meth.name = offset + reader->ReadS32();
+
+	offset += sizeof(int32_t);
+	meth.types = offset + reader->ReadS32();
+
+	offset += sizeof(int32_t);
+	meth.imp = offset + reader->ReadS32();
 }
 
 void ObjCProcessor::ReadListOfMethodLists(ObjCReader* reader, ClassBase& cls, std::string_view name, view_ptr_t start)

--- a/view/sharedcache/core/ObjC.cpp
+++ b/view/sharedcache/core/ObjC.cpp
@@ -97,8 +97,12 @@ void SharedCacheObjCProcessor::GetRelativeMethod(ObjCReader* reader, method_t& m
 	if (m_customRelativeMethodSelectorBase.has_value())
 	{
 		meth.name = m_customRelativeMethodSelectorBase.value() + reader->ReadS32();
-		meth.types = reader->GetOffset() + reader->ReadS32();
-		meth.imp = reader->GetOffset() + reader->ReadS32();
+
+		uint64_t offset = reader->GetOffset();
+		meth.types = offset + reader->ReadS32();
+
+		offset += sizeof(int32_t);
+		meth.imp = offset + reader->ReadS32();
 	}
 	else
 	{


### PR DESCRIPTION
The order that the operands to `+` are evaluated in is unspecified. Clang happens to evaluate them left to right and gives the expected answer. MSVC picks the opposite order and so the value it computes is off by 4.

This was resulting in missing method names when arm64 binaries containing Objective-C are analyzed on Windows.