### PR TITLE
Fix shared object start address without program header

### DIFF
--- a/view/elf/elfview.cpp
+++ b/view/elf/elfview.cpp
@@ -474,7 +474,7 @@ bool ElfView::Init()
 	{
 		if (settings->Contains("loader.imageBase"))
 			preferredImageBase = settings->Get<uint64_t>("loader.imageBase", this);
-
+			
 		if (settings->Contains("loader.platform"))
 		{
 			BNSettingsScope scope = SettingsAutoScope;
@@ -658,11 +658,10 @@ bool ElfView::Init()
 			semantics = ReadOnlyDataSectionSemantics;
 		else if ((m_elfSections[i].flags & ELF_SHF_WRITE) || In(sectionNames[i], readWriteDataSectionNames))
 			semantics = ReadWriteDataSectionSemantics;
-
 		if (m_elfSections[i].size != 0)
 		{
 			if (m_programHeaders.size() == 0)
-			{
+			{	
 				// We have an object file so we'll just create segments for the sections
 				uint32_t flags = 0;
 				if (semantics == ReadOnlyCodeSectionSemantics)
@@ -671,11 +670,22 @@ bool ElfView::Init()
 					flags = SegmentReadable | SegmentWritable;
 				else if (semantics == ReadOnlyDataSectionSemantics)
 					flags = SegmentReadable;
-				m_elfSections[i].address = segmentStart;
-				size_t size = m_elfSections[i].type == ELF_SHT_NOBITS ? 0 : m_elfSections[i].size;
-				uint64_t adjustedSectionAddr = m_elfSections[i].address + imageBaseAdjustment;
-				AddAutoSegment(adjustedSectionAddr, m_elfSections[i].size, m_elfSections[i].offset, size, flags);
-				segmentStart += ((m_elfSections[i].size + 15) & ~15);
+				if ((m_commonHeader.type == ET_DYN) && (!m_parseOnly))
+				{	
+					// We have a shared object file without program headers so we'll create segments for the sections
+					// based on the section address.
+					size_t size = m_elfSections[i].type == ELF_SHT_NOBITS ? 0 : m_elfSections[i].size;
+					uint64_t adjustedSectionAddr = m_elfSections[i].address + imageBaseAdjustment;
+					AddAutoSegment(adjustedSectionAddr, m_elfSections[i].size, m_elfSections[i].offset, size, flags);
+				}	
+				else 
+				{			
+					m_elfSections[i].address = segmentStart;
+					size_t size = m_elfSections[i].type == ELF_SHT_NOBITS ? 0 : m_elfSections[i].size;
+					uint64_t adjustedSectionAddr = m_elfSections[i].address + imageBaseAdjustment;
+					AddAutoSegment(adjustedSectionAddr, m_elfSections[i].size, m_elfSections[i].offset, size, flags);
+					segmentStart += ((m_elfSections[i].size + 15) & ~15);
+				}
 			}
 			else if ((m_elfSections[i].address + m_elfSections[i].size + imageBaseAdjustment) > GetEnd() || ((m_elfSections[i].address + imageBaseAdjustment) < GetStart()))
 			{
@@ -690,7 +700,6 @@ bool ElfView::Init()
 				GetParentView()->AddAutoSection(sectionNames[i], m_elfSections[i].offset, m_elfSections[i].size, DefaultSectionSemantics, type, m_elfSections[i].align, m_elfSections[i].entrySize, linkedSection, infoSection, m_elfSections[i].info);
 		}
 	}
-
 	// Apply architecture and platform
 	if (!m_arch)
 	{


### PR DESCRIPTION
This PR is for issue: https://github.com/Vector35/binaryninja-api/issues/6723

Symbols before fix:
<img width="630" alt="Screenshot 2025-07-07 at 2 16 22 PM" src="https://github.com/user-attachments/assets/52bba0a3-485f-472e-8793-984e7ef7cb83" />

Symbols after fix:
<img width="463" alt="Screenshot 2025-07-07 at 2 16 58 PM" src="https://github.com/user-attachments/assets/0155965f-d321-4d0f-ba83-15cf4f41691f" />

Memory map before fix:
<img width="650" alt="Screenshot 2025-07-07 at 2 17 15 PM" src="https://github.com/user-attachments/assets/38c5da7f-ed3f-40bd-a066-ddaa543a2f11" />

Memory map after fix:
<img width="464" alt="Screenshot 2025-07-07 at 2 17 48 PM" src="https://github.com/user-attachments/assets/f6c6827f-7fc6-4485-a30c-705ea7cbf3bb" />


The code before fix didn't include the situation for shared object file without program header case and section start address got overwritten by `segmentStart` which start with value 0.

Current fix creates segments based on sections start address.
