### PR TITLE
[ObjC] Avoid leaking SymbolQueue and MachoObjCProcessor

### DIFF
--- a/objectivec/objc.cpp
+++ b/objectivec/objc.cpp
@@ -2,9 +2,59 @@
 #include "inttypes.h"
 #include <optional>
 
+#define RELEASE_ASSERT(condition) ((condition) ? (void)0 : (std::abort(), (void)0))
+
 using namespace BinaryNinja;
 
 namespace {
+
+	// ScopedSingleton is a thread-local singleton that allows for scoped
+	// instantiation and destruction of an object. It is useful for managing
+	// resources that should only exist during a specific scope, but where it
+	// would be inconvenient to pass the object around explicitly.
+	//
+	// Calling `Make` initializes the thread-local singleton and returns a `Guard`
+	// object. When the `Guard` object goes out of scope, the singleton is destroyed.
+	template <typename T>
+	class ScopedSingleton
+	{
+		static thread_local T* current;
+
+	public:
+		class Guard
+		{
+			friend class ScopedSingleton;
+			Guard() = default;
+
+		public:
+			~Guard()
+			{
+				delete current;
+				current = nullptr;
+			}
+			Guard(Guard&&) = default;
+			Guard(const Guard&) = delete;
+			Guard& operator=(const Guard&) = delete;
+		};
+
+		static T& Get()
+		{
+			RELEASE_ASSERT(current);
+			return *current;
+		}
+
+		static Guard Make()
+		{
+			RELEASE_ASSERT(!current);
+			current = new T();
+			return Guard {};
+		}
+	};
+
+	template <typename T>
+	thread_local T* ScopedSingleton<T>::current = nullptr;
+
+	using ScopedSymbolQueue = ScopedSingleton<SymbolQueue>;
 
 	// Attempt to recover an Objective-C class name from the symbol's name.
 	// Note: classes defined in the current image should be looked up in m_classes
@@ -56,7 +106,7 @@ namespace {
 		return component;
 	}
 
-}
+}  // namespace
 
 Ref<Metadata> ObjCProcessor::SerializeMethod(uint64_t loc, const Method& method)
 {
@@ -369,7 +419,7 @@ void ObjCProcessor::DefineObjCSymbol(
 
 	if (!deferred)
 	{
-		m_symbolQueue->Append(process, defineSymbol);
+		ScopedSymbolQueue::Get().Append(process, defineSymbol);
 	}
 	else
 	{
@@ -1331,7 +1381,8 @@ Ref<Symbol> ObjCProcessor::GetSymbol(uint64_t address)
 
 void ObjCProcessor::ProcessObjCData()
 {
-	m_symbolQueue = new SymbolQueue();
+	auto guard = ScopedSymbolQueue::Make();
+
 	auto addrSize = m_data->GetAddressSize();
 
 	m_typeNames.id = defineTypedef(m_data, {"id"}, Type::PointerType(addrSize, Type::VoidType()));
@@ -1525,9 +1576,8 @@ void ObjCProcessor::ProcessObjCData()
 
 	PostProcessObjCSections(reader.get());
 
-	m_symbolQueue->Process();
+	ScopedSymbolQueue::Get().Process();
 	m_data->EndBulkModifySymbols();
-	delete m_symbolQueue;
 
 	auto meta = SerializeMetadata();
 	m_data->StoreMetadata("Objective-C", meta, true);
@@ -1547,7 +1597,8 @@ void ObjCProcessor::ProcessObjCLiterals()
 
 void ObjCProcessor::ProcessCFStrings()
 {
-	m_symbolQueue = new SymbolQueue();
+	auto guard = ScopedSymbolQueue::Make();
+
 	uint64_t ptrSize = m_data->GetAddressSize();
 	// https://github.com/apple/llvm-project/blob/next/clang/lib/CodeGen/CodeGenModule.cpp#L6129
 	// See also ASTContext.cpp ctrl+f __NSConstantString_tag
@@ -1654,9 +1705,9 @@ void ObjCProcessor::ProcessCFStrings()
 				DefineObjCSymbol(DataSymbol, Type::NamedType(m_data, m_typeNames.cfString), "cfstr_" + str, i, true);
 			}
 		}
-		m_symbolQueue->Process();
+
+		ScopedSymbolQueue::Get().Process();
 		m_data->EndBulkModifySymbols();
-		delete m_symbolQueue;
 	}
 }
 

--- a/objectivec/objc.cpp
+++ b/objectivec/objc.cpp
@@ -1713,7 +1713,7 @@ void ObjCProcessor::ProcessCFStrings()
 
 void ObjCProcessor::ProcessNSConstantArrays()
 {
-	m_symbolQueue = new SymbolQueue();
+	auto guard = ScopedSymbolQueue::Make();
 	uint64_t ptrSize = m_data->GetAddressSize();
 
 	auto idType = Type::NamedType(m_data, m_typeNames.id);
@@ -1742,16 +1742,16 @@ void ObjCProcessor::ProcessNSConstantArrays()
 				fmt::format("nsarray_{:x}", i), i, true);
 		}
 		auto id = m_data->BeginUndoActions();
-		m_symbolQueue->Process();
+		ScopedSymbolQueue::Get().Process();
 		m_data->EndBulkModifySymbols();
 		m_data->ForgetUndoActions(id);
 	}
-	delete m_symbolQueue;
+	
 }
 
 void ObjCProcessor::ProcessNSConstantDictionaries()
 {
-	m_symbolQueue = new SymbolQueue();
+	auto guard = ScopedSymbolQueue::Make();
 	uint64_t ptrSize = m_data->GetAddressSize();
 
 	auto idType = Type::NamedType(m_data, m_typeNames.id);
@@ -1786,16 +1786,15 @@ void ObjCProcessor::ProcessNSConstantDictionaries()
 				fmt::format("nsdict_{:x}", i), i, true);
 		}
 		auto id = m_data->BeginUndoActions();
-		m_symbolQueue->Process();
+		ScopedSymbolQueue::Get().Process();
 		m_data->EndBulkModifySymbols();
 		m_data->ForgetUndoActions(id);
 	}
-	delete m_symbolQueue;
 }
 
 void ObjCProcessor::ProcessNSConstantIntegerNumbers()
 {
-	m_symbolQueue = new SymbolQueue();
+	auto guard = ScopedSymbolQueue::Make();
 	uint64_t ptrSize = m_data->GetAddressSize();
 
 	StructureBuilder nsConstantIntegerNumberBuilder;
@@ -1844,11 +1843,10 @@ void ObjCProcessor::ProcessNSConstantIntegerNumbers()
 			}
 		}
 		auto id = m_data->BeginUndoActions();
-		m_symbolQueue->Process();
+		ScopedSymbolQueue::Get().Process();
 		m_data->EndBulkModifySymbols();
 		m_data->ForgetUndoActions(id);
 	}
-	delete m_symbolQueue;
 }
 
 void ObjCProcessor::ProcessNSConstantFloatingPointNumbers()
@@ -1893,7 +1891,7 @@ void ObjCProcessor::ProcessNSConstantFloatingPointNumbers()
 		if (!numbers)
 			continue;
 
-		m_symbolQueue = new SymbolQueue();
+		auto guard = ScopedSymbolQueue::Make();
 		auto start = numbers->GetStart();
 		auto end = numbers->GetEnd();
 		auto typeWidth = Type::NamedType(m_data, m_typeNames.nsConstantDoubleNumber)->GetWidth();
@@ -1935,16 +1933,15 @@ void ObjCProcessor::ProcessNSConstantFloatingPointNumbers()
 			DefineObjCSymbol(DataSymbol, Type::NamedType(m_data, *typeName), name, i, true);
 		}
 		auto id = m_data->BeginUndoActions();
-		m_symbolQueue->Process();
+		ScopedSymbolQueue::Get().Process();
 		m_data->EndBulkModifySymbols();
 		m_data->ForgetUndoActions(id);
-		delete m_symbolQueue;
 	}
 }
 
 void ObjCProcessor::ProcessNSConstantDatas()
 {
-	m_symbolQueue = new SymbolQueue();
+	auto guard = ScopedSymbolQueue::Make();
 	uint64_t ptrSize = m_data->GetAddressSize();
 
 	StructureBuilder nsConstantDataBuilder;
@@ -1972,11 +1969,10 @@ void ObjCProcessor::ProcessNSConstantDatas()
 				DataSymbol, Type::NamedType(m_data, m_typeNames.nsConstantData), fmt::format("nsdata_{:x}", i), i, true);
 		}
 		auto id = m_data->BeginUndoActions();
-		m_symbolQueue->Process();
+		ScopedSymbolQueue::Get().Process();
 		m_data->EndBulkModifySymbols();
 		m_data->ForgetUndoActions(id);
 	}
-	delete m_symbolQueue;
 }
 
 void ObjCProcessor::AddRelocatedPointer(uint64_t location, uint64_t rewrite)

--- a/objectivec/objc.h
+++ b/objectivec/objc.h
@@ -286,7 +286,6 @@ namespace BinaryNinja {
 		// TODO(WeiN76LQh): this is to avoid a bug with defining a classes protocol list in the DSC plugin. Remove once fixed
 		bool m_skipClassBaseProtocols;
 
-		SymbolQueue* m_symbolQueue;
 		std::map<uint64_t, Class> m_classes;
 		std::map<uint64_t, Class> m_categories;
 		std::map<uint64_t, Protocol> m_protocols;

--- a/view/macho/machoview.cpp
+++ b/view/macho/machoview.cpp
@@ -1856,9 +1856,11 @@ bool MachoView::InitializeHeader(MachOHeader& header, bool isMainHeader, uint64_
 		parseObjCStructs = false;
 	if (!GetSectionByName("__cfstring"))
 		parseCFStrings = false;
+
+	std::unique_ptr<MachoObjCProcessor> objcProcessor;
 	if (parseObjCStructs || parseCFStrings)
 	{
-		m_objcProcessor = new MachoObjCProcessor(this);
+		objcProcessor = std::make_unique<MachoObjCProcessor>(this);
 	}
 	if (parseObjCStructs)
 	{
@@ -2067,7 +2069,7 @@ bool MachoView::InitializeHeader(MachOHeader& header, bool isMainHeader, uint64_
 	{
 		// Add functions for all function symbols
 		m_logger->LogDebug("Parsing symbol table\n");
-		ParseSymbolTable(reader, header, header.symtab, indirectSymbols);
+		ParseSymbolTable(reader, header, header.symtab, indirectSymbols, objcProcessor.get());
 	}
 	catch (std::exception&)
 	{
@@ -2088,8 +2090,8 @@ bool MachoView::InitializeHeader(MachOHeader& header, bool isMainHeader, uint64_
 		uint64_t slidTarget = target + m_imageBaseAdjustment;
 		relocation.address = slidTarget;
 		DefineRelocation(m_arch, relocation, slidTarget, relocationLocation);
-		if (m_objcProcessor)
-			m_objcProcessor->AddRelocatedPointer(relocationLocation, slidTarget);
+		if (objcProcessor)
+			objcProcessor->AddRelocatedPointer(relocationLocation, slidTarget);
 	}
 	for (auto& [relocation, name] : header.externalRelocations)
 	{
@@ -2369,7 +2371,7 @@ bool MachoView::InitializeHeader(MachOHeader& header, bool isMainHeader, uint64_
 	if (parseCFStrings)
 	{
 		try {
-			m_objcProcessor->ProcessObjCLiterals();
+			objcProcessor->ProcessObjCLiterals();
 		}
 		catch (std::exception& ex)
 		{
@@ -2381,14 +2383,13 @@ bool MachoView::InitializeHeader(MachOHeader& header, bool isMainHeader, uint64_
 	if (parseObjCStructs)
 	{
 		try {
-			m_objcProcessor->ProcessObjCData();
+			objcProcessor->ProcessObjCData();
 		}
 		catch (std::exception& ex)
 		{
 			m_logger->LogError("Failed to process Objective-C Metadata. Binary may be malformed");
 			m_logger->LogError("Error: %s", ex.what());
 		}
-		delete m_objcProcessor;
 	}
 
 
@@ -2976,7 +2977,8 @@ void MachoView::ParseDynamicTable(BinaryReader& reader, MachOHeader& header, BNS
 }
 
 
-void MachoView::ParseSymbolTable(BinaryReader& reader, MachOHeader& header, const symtab_command& symtab, const vector<uint32_t>& indirectSymbols)
+void MachoView::ParseSymbolTable(BinaryReader& reader, MachOHeader& header, const symtab_command& symtab,
+	const vector<uint32_t>& indirectSymbols, MachoObjCProcessor* objcProcessor)
 {
 	if (header.ident.filetype == MH_DSYM)
 	{
@@ -3004,12 +3006,12 @@ void MachoView::ParseSymbolTable(BinaryReader& reader, MachOHeader& header, cons
 		if (header.chainedFixupsPresent)
 		{
 			m_logger->LogDebug("Chained Fixups");
-			ParseChainedFixups(header, header.chainedFixups);
+			ParseChainedFixups(header, header.chainedFixups, objcProcessor);
 		}
 		else if (header.chainStartsPresent)
 		{
 			m_logger->LogDebug("Chained Starts");
-			ParseChainedStarts(header, header.chainStarts);
+			ParseChainedStarts(header, header.chainStarts, objcProcessor);
 		}
 		if (header.exportTriePresent && header.isMainHeader)
 			ParseExportTrie(reader, header.exportTrie);
@@ -3197,7 +3199,8 @@ void MachoView::ParseSymbolTable(BinaryReader& reader, MachOHeader& header, cons
 }
 
 
-void MachoView::ParseChainedFixups(MachOHeader& header, linkedit_data_command chainedFixups)
+void MachoView::ParseChainedFixups(
+	MachOHeader& header, linkedit_data_command chainedFixups, MachoObjCProcessor* objcProcessor)
 {
 	if (!chainedFixups.dataoff)
 		return;
@@ -3596,9 +3599,9 @@ void MachoView::ParseChainedFixups(MachOHeader& header, linkedit_data_command ch
 							reloc.address = GetStart() + (chainEntryAddress - m_universalImageOffset);
 							DefineRelocation(m_arch, reloc, entryOffset, reloc.address);
 
-							if (m_objcProcessor)
+							if (objcProcessor)
 							{
-								m_objcProcessor->AddRelocatedPointer(reloc.address, entryOffset);
+								objcProcessor->AddRelocatedPointer(reloc.address, entryOffset);
 							}
 						}
 
@@ -3627,7 +3630,7 @@ void MachoView::ParseChainedFixups(MachOHeader& header, linkedit_data_command ch
 }
 
 
-void MachoView::ParseChainedStarts(MachOHeader& header, section_64 chainedStarts)
+void MachoView::ParseChainedStarts(MachOHeader& header, section_64 chainedStarts, MachoObjCProcessor* objcProcessor)
 {
 	if (!chainedStarts.offset)
 		return;
@@ -3799,9 +3802,9 @@ void MachoView::ParseChainedStarts(MachOHeader& header, section_64 chainedStarts
 					DefineRelocation(m_arch, reloc, entryOffset, reloc.address);
 					m_logger->LogDebug("Chained Starts: Adding relocated pointer %llx -> %llx", reloc.address, entryOffset);
 
-					if (m_objcProcessor)
+					if (objcProcessor)
 					{
-						m_objcProcessor->AddRelocatedPointer(reloc.address, entryOffset);
+						objcProcessor->AddRelocatedPointer(reloc.address, entryOffset);
 					}
 				}
 

--- a/view/macho/machoview.h
+++ b/view/macho/machoview.h
@@ -1456,8 +1456,6 @@ namespace BinaryNinja
 			QualifiedName filesetEntryCommandQualName;
 		} m_typeNames;
 
-		MachoObjCProcessor* m_objcProcessor = nullptr;
-
 		uint64_t m_universalImageOffset;
 		bool m_parseOnly, m_backedByDatabase;
 		int64_t m_imageBaseAdjustment;
@@ -1488,7 +1486,7 @@ namespace BinaryNinja
 		void RebaseThreadStarts(BinaryReader& virtualReader, std::vector<uint32_t>& threadStarts, uint64_t stepMultiplier);
 		Ref<Symbol> DefineMachoSymbol(
 			BNSymbolType type, const std::string& name, uint64_t addr, BNSymbolBinding binding, bool deferred);
-		void ParseSymbolTable(BinaryReader& reader, MachOHeader& header, const symtab_command& symtab, const std::vector<uint32_t>& symbolStubsList);
+		void ParseSymbolTable(BinaryReader& reader, MachOHeader& header, const symtab_command& symtab, const std::vector<uint32_t>& symbolStubsList, MachoObjCProcessor*);
 		bool IsValidFunctionStart(uint64_t addr);
 		void ParseFunctionStarts(Platform* platform, uint64_t textBase, function_starts_command functionStarts);
 		bool ParseRelocationEntry(const relocation_info& info, uint64_t start, BNRelocationInfo& result);
@@ -1503,8 +1501,8 @@ namespace BinaryNinja
 			BNSymbolBinding binding);
 		bool GetSectionPermissions(MachOHeader& header, uint64_t address, uint32_t &flags);
 		bool GetSegmentPermissions(MachOHeader& header, uint64_t address, uint32_t &flags);
-		void ParseChainedFixups(MachOHeader& header, linkedit_data_command chainedFixups);
-		void ParseChainedStarts(MachOHeader& header, section_64 chainedStarts);
+		void ParseChainedFixups(MachOHeader& header, linkedit_data_command chainedFixups, MachoObjCProcessor*);
+		void ParseChainedStarts(MachOHeader& header, section_64 chainedStarts, MachoObjCProcessor*);
 
 		virtual uint64_t PerformGetEntryPoint() const override;
 


### PR DESCRIPTION
`SymbolQueue`'s lifetime was being managed via `new` / `delete`. This was error-prone in the face of code that can a) throw exceptions, or b) return early. Typically the solution would be to move to `std::unique_ptr` and call it a day, but nothing is ever easy.

The `SymbolQueue`s created by `ObjCProcessor` are intended to live for the duration of `ProcessObjCData` and `ProcessCFStrings` methods. Since they are used multiple levels down the call tree, the active `SymbolQueue` is stored as a member variable on `ObjCProcessor`. Switching to `std::unique_ptr` would ensure that the `SymbolQueue` is destroyed, but would leave a dangling pointer in the member variable.

To address this I'm introducing a `ScopedSingleton` class that provides a thread-local singleton whose lifetime is controlled by a guard object. `ProcessObjCData` / `ProcessCFStrings` call `ScopedSymbolQueue::Make` and store the returned guard object in a local. Code that accesses the symbol queue uses `ScopedSymbolQueue::Get` to retrieve the current instance. The guard object ensures the `SymbolQueue` is deleted and the `current` pointer is cleared no matter how the scope is exited.

A better longer-term design is to introduce a class for processing the Objective-C runtime metadata and a class for processing constants such as `CFString`s. These could directly own the symbol queue so it would be accessible to any member functions that define symbols, while inherently having the correct lifetime. This is a more involved refactoring than I have time for right now.


---


I'm not in love with this approach, but it was cleaner than the alternatives I experimented with:

1. Remove `m_symbolQueue` in favor of local `SymbolQueue` variables in `ProcessObjCData` / `ProcessCFStrings`. This works, but requires threading the object through virtually every function in the class so is quite unpleasant.
2. Make `m_symbolQueue` a `std::unique_ptr` and use a `scope_exit` type within `ProcessObjCData` / `ProcessCFStrings`. This works but it feels odd to have it be a member that's only set for the duration of a single method , which is how I ended up at `ScopedSymbolQueue`.

I'd probably have gone with 2 if there was an existing `scope_exit` type to use, but if I'm adding my own type for this purpose then it's nice to avoid the weirdness.