### PR TITLE
[MachO] Treat a binary as containing Objective-C metadata if it has __objc_stubs

### DIFF
--- a/view/macho/objc.cpp
+++ b/view/macho/objc.cpp
@@ -83,8 +83,8 @@ std::shared_ptr<ObjCReader> MachoObjCProcessor::GetReader()
 
 bool MachoObjCProcessor::ViewHasObjCMetadata(BinaryView* data)
 {
-	return (data->GetSectionByName("__objc_classlist") || data->GetSectionByName("__objc_catlist")
-		|| data->GetSectionByName("__objc_protolist"));
+	return data->GetSectionByName("__objc_classlist") || data->GetSectionByName("__objc_catlist")
+		|| data->GetSectionByName("__objc_protolist") || data->GetSectionByName("__objc_stubs");
 }
 
 MachoObjCProcessor::MachoObjCProcessor(BinaryView* data) :


### PR DESCRIPTION
If it only has `__objc_stubs` it may not have any actual Objective-C type metadata, but `MachoView` currently only enables the Objective-C workflow if it think there is type metadata. Additionally, `MachoView` only has `MachoObjCProcessor` load Objective-C information if the binary is reported as having Objective-C type metadata, and the workflow won't try to inline stubs if it doesn't see the metadata created by `MachoObjCProcessor`.

This all needs to be rethought.