### PR TITLE
Fix the Triage Summary view's exports list to only update when visible

### DIFF
--- a/examples/triage/exports.cpp
+++ b/examples/triage/exports.cpp
@@ -25,13 +25,10 @@ GenericExportsModel::GenericExportsModel(QWidget* parent, BinaryViewRef data): Q
 	}
 
 	m_updateTimer = new QTimer(this);
-	m_updateTimer->setSingleShot(true);
 	m_updateTimer->setInterval(500);
 	connect(m_updateTimer, &QTimer::timeout, this, &GenericExportsModel::updateModel);
-	connect(this, &GenericExportsModel::modelUpdate, this, [=, this]() {
-		if (m_updateTimer->isActive())
-			return;
-		m_updateTimer->start();
+	connect(this, &GenericExportsModel::updateTimerOnUIThread, this, [=, this]() {
+		updateTimer(m_needsUpdate);
 	});
 
 	m_data->RegisterNotification(this);
@@ -49,6 +46,10 @@ GenericExportsModel::~GenericExportsModel()
 
 void GenericExportsModel::updateModel()
 {
+	if (!m_needsUpdate)
+		return;
+
+	setNeedsUpdate(false);
 	beginResetModel();
 	m_allEntries.clear();
 	for (auto& sym : m_data->GetSymbolsOfType(FunctionSymbol))
@@ -237,40 +238,64 @@ void GenericExportsModel::setFilter(const std::string& filterText)
 	endResetModel();
 }
 
-
-void GenericExportsModel::OnAnalysisFunctionAdded(BinaryNinja::BinaryView* view, BinaryNinja::Function* func)
+void GenericExportsModel::setNeedsUpdate(bool needed)
 {
-	emit modelUpdate();
+	if (m_needsUpdate.exchange(needed) == needed)
+		return;
+
+	updateTimer(needed);
 }
 
-
-void GenericExportsModel::OnAnalysisFunctionRemoved(BinaryNinja::BinaryView* view, BinaryNinja::Function* func)
+void GenericExportsModel::updateTimer(bool needsUpdate)
 {
-	emit modelUpdate();
+	if (needsUpdate && !m_updateTimer->isActive())
+		m_updateTimer->start();
+	if (!needsUpdate && m_updateTimer->isActive())
+		m_updateTimer->stop();
 }
 
-
-void GenericExportsModel::OnAnalysisFunctionUpdated(BinaryNinja::BinaryView* view, BinaryNinja::Function* func)
+void GenericExportsModel::pauseUpdates()
 {
-	emit modelUpdate();
+	m_updatesPaused = true;
+	setNeedsUpdate(false);
+}
+
+void GenericExportsModel::resumeUpdates()
+{
+	m_updatesPaused = false;
+	setNeedsUpdate(true);
+}
+
+void GenericExportsModel::onBinaryViewNotification()
+{
+	if (m_updatesPaused)
+		return;
+
+	// This can be called from any thread so we cannot directly
+	// update the timer. Emitting a signal is relatively expensive
+	// given how frequently we receive notifications, so we only
+	// emit a signal if we didn't already need an update.
+	if (!m_needsUpdate.exchange(true))
+		emit updateTimerOnUIThread();
 }
 
 
 void GenericExportsModel::OnSymbolAdded(BinaryNinja::BinaryView* view, BinaryNinja::Symbol* sym)
 {
-	emit modelUpdate();
+	if ((sym->GetBinding() == GlobalBinding) || (sym->GetBinding() == WeakBinding))
+		onBinaryViewNotification();
 }
 
 
 void GenericExportsModel::OnSymbolUpdated(BinaryNinja::BinaryView* view, BinaryNinja::Symbol* sym)
 {
-	emit modelUpdate();
+	onBinaryViewNotification();
 }
 
 
 void GenericExportsModel::OnSymbolRemoved(BinaryNinja::BinaryView* view, BinaryNinja::Symbol* sym)
 {
-	emit modelUpdate();
+	onBinaryViewNotification();
 }
 
 
@@ -401,6 +426,19 @@ void ExportsTreeView::keyPressEvent(QKeyEvent* event)
 			exportDoubleClicked(sel[0]);
 	}
 	QTreeView::keyPressEvent(event);
+}
+
+void ExportsTreeView::showEvent(QShowEvent* event)
+{
+	QTreeView::showEvent(event);
+	m_model->resumeUpdates();
+}
+
+
+void ExportsTreeView::hideEvent(QHideEvent* event)
+{
+	QTreeView::hideEvent(event);
+	m_model->pauseUpdates();
 }
 
 


### PR DESCRIPTION
The `ExportsTreeView` now asks the model to pause / resume updates when its visibility changes. When paused, all notifications from the view are ignored. When resumed, notifications set a flag to indicate that an update is needed and resume the update timer if it is not already active. The timer is stopped after an update is processed.

There's some extra complexity here to avoid emitting a signal for every `BinaryView` notification that is processed. These notifications are typically generated on background threads. The overhead of emitting a signal and it being routed to the main thread adds up given the number of notifications involved when loading a large binary. This manifests on macOS as time being spent inside `CFRunLoopWakeUp`.