### PR TITLE
[ObjC] Use the appropriate integer size for entries in __objc_ivar

### DIFF
--- a/objectivec/objc.cpp
+++ b/objectivec/objc.cpp
@@ -1342,10 +1342,13 @@ void ObjCProcessor::PostProcessObjCSections(ObjCReader* reader)
 	{
 		auto start = ivars->GetStart();
 		auto end = ivars->GetEnd();
-		auto ivarSectionEntryTypeBuilder = new TypeBuilder(Type::IntegerType(8, false));
+		// The ivar section contains entries of type `long` for for all architectures
+		// except arm64, which uses `int` for the ivar offset.
+		size_t ivarOffsetSize = m_data->GetDefaultArchitecture()->GetName() == "aarch64" ? 4 : ptrSize;
+		auto ivarSectionEntryTypeBuilder = new TypeBuilder(Type::IntegerType(ivarOffsetSize, false));
 		ivarSectionEntryTypeBuilder->SetConst(true);
 		auto type = ivarSectionEntryTypeBuilder->Finalize();
-		for (view_ptr_t i = start; i < end; i += ptrSize)
+		for (view_ptr_t i = start; i < end; i += ivarOffsetSize)
 		{
 			m_data->DefineDataVariable(i, type);
 		}


### PR DESCRIPTION
The `__objc_ivar` section contains [values of type `long` for all architectures except arm64, where it contains `int`][1].

This fixes problems with resolving non-fragile ivar accesses to struct field accesses on arm64 and 32-bit architectures.

[1]: https://github.com/llvm/llvm-project/blob/535d6917ec3308ade866f205644b740666312342/clang/lib/CodeGen/CGObjCMac.cpp#L5628-L5629