### PR TITLE
[ObjC] Handle tail calls to objc_msgSend when applying call type adjustments

### DIFF
--- a/plugins/workflow_objc/Workflow.cpp
+++ b/plugins/workflow_objc/Workflow.cpp
@@ -225,7 +225,7 @@ void Workflow::inlineMethodCalls(AnalysisContextRef ac)
 
     if (auto info = GlobalState::analysisInfo(bv))
     {
-        if (info->hasObjcStubs && func->GetStart() > info->objcStubsStartEnd.first && func->GetStart() < info->objcStubsStartEnd.second)
+        if (info->hasObjcStubs && func->GetStart() >= info->objcStubsStartEnd.first && func->GetStart() < info->objcStubsStartEnd.second)
         {
             func->SetAutoInlinedDuringAnalysis({true, BN_FULL_CONFIDENCE});
             // Do no further cleanup, this is a stub and it will be cleaned up after inlining

--- a/plugins/workflow_objc/Workflow.cpp
+++ b/plugins/workflow_objc/Workflow.cpp
@@ -86,7 +86,7 @@ bool Workflow::rewriteMethodCall(LLILFunctionRef ssa, size_t insnIndex)
     const auto bv = function->GetView();
     const auto llil = ssa->GetNonSSAForm();
     const auto insn = ssa->GetInstruction(insnIndex);
-    const auto params = insn.GetParameterExprs<LLIL_CALL_SSA>();
+    const auto params = insn.GetParameterExprs();
 
     // The second parameter passed to the objc_msgSend call is the address of
     // either the selector reference or the method's name, which in both cases
@@ -254,12 +254,13 @@ void Workflow::inlineMethodCalls(AnalysisContextRef ac)
     const auto rewriteIfEligible = [bv, messageHandler, ssa](size_t insnIndex) {
         auto insn = ssa->GetInstruction(insnIndex);
 
-        if (insn.operation == LLIL_CALL_SSA)
+        if (insn.operation == LLIL_CALL_SSA || insn.operation == LLIL_TAILCALL_SSA)
         {
             // Filter out calls that aren't to `objc_msgSend`.
-            auto callExpr = insn.GetDestExpr<LLIL_CALL_SSA>();
-            bool isMessageSend = messageHandler->isMessageSend(callExpr.GetValue().value);
-            if (auto symbol = bv->GetSymbolByAddress(callExpr.GetValue().value))
+            auto callExpr = insn.GetDestExpr();
+            auto callTarget = callExpr.GetValue().value;
+            bool isMessageSend = messageHandler->isMessageSend(callTarget);
+            if (auto symbol = bv->GetSymbolByAddress(callTarget))
                 isMessageSend = isMessageSend || symbol->GetRawName() == "_objc_msgSend";
             if (!isMessageSend)
                 return false;
@@ -294,7 +295,7 @@ void Workflow::registerActivities()
     const auto wf = BinaryNinja::Workflow::Instance("core.function.baseAnalysis")->Clone("core.function.objectiveC");
     wf->RegisterActivity(new BinaryNinja::Activity(
         ActivityID::ResolveMethodCalls, &Workflow::inlineMethodCalls));
-    wf->Insert("core.function.translateTailCalls", ActivityID::ResolveMethodCalls);
+    wf->InsertAfter("core.function.translateTailCalls", ActivityID::ResolveMethodCalls);
 
     BinaryNinja::Workflow::RegisterWorkflow(wf, WorkflowInfo);
 }


### PR DESCRIPTION
Moves the `ResolveMethodCalls` activity after `core.function.translateTailCalls` so tail calls are represented explicitly in LLIL, then updates `inlineMethodCalls` to process them.

While looking at this I spotted and fixed an off-by-one error that was causing the first stub function in `__objc_stubs` to be skipped.

Fixes #7060.