### PR TITLE
Reserve vector capacity when populating vectors in conversion operators

### DIFF
--- a/highlevelilinstruction.cpp
+++ b/highlevelilinstruction.cpp
@@ -321,6 +321,7 @@ uint64_t HighLevelILIntegerList::operator[](size_t i) const
 HighLevelILIntegerList::operator vector<uint64_t>() const
 {
 	vector<uint64_t> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -375,6 +376,7 @@ size_t HighLevelILIndexList::operator[](size_t i) const
 HighLevelILIndexList::operator vector<size_t>() const
 {
 	vector<size_t> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -440,6 +442,7 @@ const HighLevelILInstruction HighLevelILInstructionList::operator[](size_t i) co
 HighLevelILInstructionList::operator vector<HighLevelILInstruction>() const
 {
 	vector<HighLevelILInstruction> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -498,6 +501,7 @@ const SSAVariable HighLevelILSSAVariableList::operator[](size_t i) const
 HighLevelILSSAVariableList::operator vector<SSAVariable>() const
 {
 	vector<SSAVariable> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -651,6 +655,7 @@ const HighLevelILOperand HighLevelILOperandList::operator[](size_t i) const
 HighLevelILOperandList::operator vector<HighLevelILOperand>() const
 {
 	vector<HighLevelILOperand> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;

--- a/lowlevelilinstruction.cpp
+++ b/lowlevelilinstruction.cpp
@@ -644,6 +644,7 @@ uint64_t LowLevelILIntegerList::operator[](size_t i) const
 LowLevelILIntegerList::operator vector<uint64_t>() const
 {
 	vector<uint64_t> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -697,6 +698,7 @@ size_t LowLevelILIndexList::operator[](size_t i) const
 LowLevelILIndexList::operator vector<size_t>() const
 {
 	vector<size_t> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -812,6 +814,7 @@ const LowLevelILInstruction LowLevelILInstructionList::operator[](size_t i) cons
 LowLevelILInstructionList::operator vector<LowLevelILInstruction>() const
 {
 	vector<LowLevelILInstruction> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -866,6 +869,7 @@ const RegisterOrFlag LowLevelILRegisterOrFlagList::operator[](size_t i) const
 LowLevelILRegisterOrFlagList::operator vector<RegisterOrFlag>() const
 {
 	vector<RegisterOrFlag> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -924,6 +928,7 @@ const SSARegister LowLevelILSSARegisterList::operator[](size_t i) const
 LowLevelILSSARegisterList::operator vector<SSARegister>() const
 {
 	vector<SSARegister> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -982,6 +987,7 @@ const SSARegisterStack LowLevelILSSARegisterStackList::operator[](size_t i) cons
 LowLevelILSSARegisterStackList::operator vector<SSARegisterStack>() const
 {
 	vector<SSARegisterStack> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -1040,6 +1046,7 @@ const SSAFlag LowLevelILSSAFlagList::operator[](size_t i) const
 LowLevelILSSAFlagList::operator vector<SSAFlag>() const
 {
 	vector<SSAFlag> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -1098,6 +1105,7 @@ const SSARegisterOrFlag LowLevelILSSARegisterOrFlagList::operator[](size_t i) co
 LowLevelILSSARegisterOrFlagList::operator vector<SSARegisterOrFlag>() const
 {
 	vector<SSARegisterOrFlag> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -1360,6 +1368,7 @@ const LowLevelILOperand LowLevelILOperandList::operator[](size_t i) const
 LowLevelILOperandList::operator vector<LowLevelILOperand>() const
 {
 	vector<LowLevelILOperand> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -3357,6 +3366,7 @@ ExprId LowLevelILFunction::CallStackAdjust(
     ExprId dest, int64_t adjust, const map<uint32_t, int32_t>& regStackAdjust, const ILSourceLocation& loc)
 {
 	vector<size_t> list;
+	list.reserve(regStackAdjust.size() * 2);
 	for (auto& i : regStackAdjust)
 	{
 		list.push_back(i.first);

--- a/mediumlevelilinstruction.cpp
+++ b/mediumlevelilinstruction.cpp
@@ -434,6 +434,7 @@ uint64_t MediumLevelILIntegerList::operator[](size_t i) const
 MediumLevelILIntegerList::operator vector<uint64_t>() const
 {
 	vector<uint64_t> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -488,6 +489,7 @@ size_t MediumLevelILIndexList::operator[](size_t i) const
 MediumLevelILIndexList::operator vector<size_t>() const
 {
 	vector<size_t> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -600,6 +602,7 @@ const Variable MediumLevelILVariableList::operator[](size_t i) const
 MediumLevelILVariableList::operator vector<Variable>() const
 {
 	vector<Variable> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -658,6 +661,7 @@ const SSAVariable MediumLevelILSSAVariableList::operator[](size_t i) const
 MediumLevelILSSAVariableList::operator vector<SSAVariable>() const
 {
 	vector<SSAVariable> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -716,6 +720,7 @@ const MediumLevelILInstruction MediumLevelILInstructionList::operator[](size_t i
 MediumLevelILInstructionList::operator vector<MediumLevelILInstruction>() const
 {
 	vector<MediumLevelILInstruction> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;
@@ -898,6 +903,7 @@ const MediumLevelILOperand MediumLevelILOperandList::operator[](size_t i) const
 MediumLevelILOperandList::operator vector<MediumLevelILOperand>() const
 {
 	vector<MediumLevelILOperand> result;
+	result.reserve(size());
 	for (auto i : *this)
 		result.push_back(i);
 	return result;


### PR DESCRIPTION
I noticed while looking at some performance profiles today that some of these conversion operators are used on relatively hot codepaths. Reserving capacity before populating them avoids reallocations as they grow and is free performance.