### PR TITLE
Added search placeholder for DSCView and KCView.

### DIFF
--- a/view/kernelcache/ui/kctriage.cpp
+++ b/view/kernelcache/ui/kctriage.cpp
@@ -264,6 +264,7 @@ QWidget* KCTriageView::initImageTable()
 	} // refreshDataButton
 
 	auto loadImageFilterEdit = new FilterEdit(m_imageTable);
+	loadImageFilterEdit->setPlaceholderText("Filter images");
 	connect(loadImageFilterEdit, &FilterEdit::textChanged, [this](const QString& filter) {
 		m_imageTable->setFilter(filter.toStdString());
 	});
@@ -316,6 +317,7 @@ void KCTriageView::initSymbolTable()
 	m_symbolTable->setItemDelegateForColumn(0, new AddressColorDelegate(m_symbolTable));
 
 	auto symbolFilterEdit = new FilterEdit(m_symbolTable);
+	symbolFilterEdit->setPlaceholderText("Filter symbols");
 	connect(symbolFilterEdit, &FilterEdit::textChanged, [this](const QString& filter) {
 		m_symbolTable->setFilter(filter.toStdString());
 	});

--- a/view/sharedcache/ui/dsctriage.cpp
+++ b/view/sharedcache/ui/dsctriage.cpp
@@ -266,6 +266,7 @@ QWidget* DSCTriageView::initImageTable()
 	} // refreshDataButton
 
 	auto loadImageFilterEdit = new FilterEdit(m_imageTable);
+	loadImageFilterEdit->setPlaceholderText("Filter images");
 	connect(loadImageFilterEdit, &FilterEdit::textChanged, [this](const QString& filter) {
 		m_imageTable->setFilter(filter.toStdString());
 	});
@@ -318,6 +319,7 @@ void DSCTriageView::initSymbolTable()
 	m_symbolTable->setItemDelegateForColumn(0, new AddressColorDelegate(m_symbolTable));
 
 	auto symbolFilterEdit = new FilterEdit(m_symbolTable);
+	symbolFilterEdit->setPlaceholderText("Filter symbols");
 	connect(symbolFilterEdit, &FilterEdit::textChanged, [this](const QString& filter) {
 		m_symbolTable->setFilter(filter.toStdString());
 	});
@@ -448,6 +450,7 @@ void DSCTriageView::initCacheInfoTables()
 
 	auto mappingLabel = new QLabel("Mappings");
 	auto mappingFilterEdit = new FilterEdit(m_mappingTable);
+	mappingFilterEdit->setPlaceholderText("Filter mappings");
 	connect(mappingFilterEdit, &FilterEdit::textChanged, [this](const QString& filter) {
 		m_mappingTable->setFilter(filter.toStdString());
 	});
@@ -460,6 +463,7 @@ void DSCTriageView::initCacheInfoTables()
 
 	auto regionLabel = new QLabel("Regions");
 	auto regionFilterEdit = new FilterEdit(regionTable);
+	regionFilterEdit->setPlaceholderText("Filter regions");
 	connect(regionFilterEdit, &FilterEdit::textChanged, [regionTable](const QString& filter) {
 		regionTable->setFilter(filter.toStdString());
 	});


### PR DESCRIPTION
This fix is for issue: https://github.com/Vector35/binaryninja-api/issues/6975 

Before fix:
<img width="422" height="130" alt="Screenshot 2025-07-15 at 12 27 31 PM" src="https://github.com/user-attachments/assets/dd33d6ae-cc87-46e5-bdf6-03649b0530ca" />

After fix:
<img width="456" height="103" alt="Screenshot 2025-07-15 at 12 33 45 PM" src="https://github.com/user-attachments/assets/3e6b8f62-dee5-4274-8a81-3aba625aa182" />

This change also applies to 
<img width="407" height="106" alt="Screenshot 2025-07-15 at 12 33 50 PM" src="https://github.com/user-attachments/assets/0220d8a2-c9a1-42c9-b289-b61b07ef9212" />

<img width="403" height="99" alt="Screenshot 2025-07-15 at 12 33 55 PM" src="https://github.com/user-attachments/assets/c4e96796-de13-403a-8720-fd1e254c7425" />

<img width="372" height="65" alt="Screenshot 2025-07-15 at 12 33 59 PM" src="https://github.com/user-attachments/assets/1852bec6-6918-4a2b-a6a7-43f8a032ae6e" />




