### PR TITLE
Fix leaks from the Workflow constructor

### DIFF
--- a/workflow.cpp
+++ b/workflow.cpp
@@ -392,20 +392,20 @@ Workflow::Workflow(const string& name)
 
 Workflow::Workflow(BNWorkflow* workflow)
 {
-	m_object = BNNewWorkflowReference(workflow);
+	m_object = workflow;
 }
 
 
 Workflow::Workflow(BNWorkflow* workflow, Ref<BinaryView> view)
 {
-	m_object = BNNewWorkflowReference(workflow);
+	m_object = workflow;
 	m_machine = make_unique<WorkflowMachine>(view);
 }
 
 
 Workflow::Workflow(BNWorkflow* workflow, Ref<Function> function)
 {
-	m_object = BNNewWorkflowReference(workflow);
+	m_object = workflow;
 	m_machine = make_unique<WorkflowMachine>(function);
 }
 


### PR DESCRIPTION
Don't add an additional reference to the wrapped object in the constructor.

API wrapper objects are passed a +1 object and do not need to add an additional reference. All clients of the Workflow constructors are doing this already which was resulting in leaks.

Fixes https://github.com/Vector35/binaryninja-api/issues/7059.