### PR TITLE
Miscellaneous leak fixes in MachoView and ObjCProcessor

### DIFF
--- a/objectivec/objc.cpp
+++ b/objectivec/objc.cpp
@@ -1352,9 +1352,9 @@ void ObjCProcessor::PostProcessObjCSections(ObjCReader* reader)
 		// The ivar section contains entries of type `long` for for all architectures
 		// except arm64, which uses `int` for the ivar offset.
 		size_t ivarOffsetSize = m_data->GetDefaultArchitecture()->GetName() == "aarch64" ? 4 : ptrSize;
-		auto ivarSectionEntryTypeBuilder = new TypeBuilder(Type::IntegerType(ivarOffsetSize, false));
-		ivarSectionEntryTypeBuilder->SetConst(true);
-		auto type = ivarSectionEntryTypeBuilder->Finalize();
+		TypeBuilder ivarSectionEntryTypeBuilder(Type::IntegerType(ivarOffsetSize, false));
+		ivarSectionEntryTypeBuilder.SetConst(true);
+		auto type = ivarSectionEntryTypeBuilder.Finalize();
 		for (view_ptr_t i = start; i < end; i += ivarOffsetSize)
 		{
 			m_data->DefineDataVariable(i, type);

--- a/view/macho/machoview.cpp
+++ b/view/macho/machoview.cpp
@@ -264,7 +264,6 @@ MachOHeader MachoView::HeaderForAddress(BinaryView* data, uint64_t address, bool
 	header.isMainHeader = isMainHeader;
 
 	header.identifierPrefix = identifierPrefix;
-	header.stringList = new DataBuffer();
 
 	std::string errorMsg;
 	if (isMainHeader) {
@@ -608,7 +607,7 @@ MachOHeader MachoView::HeaderForAddress(BinaryView* data, uint64_t address, bool
 				header.symtab.stroff  = reader.Read32();
 				header.symtab.strsize = reader.Read32();
 				reader.Seek(header.symtab.stroff);
-				header.stringList->Append(reader.Read(header.symtab.strsize));
+				header.stringList.Append(reader.Read(header.symtab.strsize));
 				header.stringListSize = header.symtab.strsize;
 				m_logger->LogDebug("\tstrsize: %08x\n" \
 					"\tstroff: %08x\n" \
@@ -3131,7 +3130,7 @@ void MachoView::ParseSymbolTable(BinaryReader& reader, MachOHeader& header, cons
 			if (sym.n_strx >= symtab.strsize || ((sym.n_type & N_TYPE) == N_INDR))
 				continue;
 
-			string symbol((char*)header.stringList->GetDataAt(sym.n_strx));
+			string symbol((char*)header.stringList.GetDataAt(sym.n_strx));
 			m_symbols.push_back(symbol);
 			//otool ignores symbols that end with ".o", startwith "ltmp" or are "gcc_compiled." so do we
 			if (symbol == "gcc_compiled." ||

--- a/view/macho/machoview.h
+++ b/view/macho/machoview.h
@@ -1413,7 +1413,7 @@ namespace BinaryNinja
 		linkedit_data_command chainedFixups {};
 		section_64 chainStarts {};
 
-		DataBuffer* stringList;
+		DataBuffer stringList;
 		size_t stringListSize = 0;
 
 		uint64_t relocationBase = 0;


### PR DESCRIPTION
If we don't allocate these on the heap then we don't have to free them later.