### PR TITLE
[PPC] Make assembler.cpp compile over 30 times faster

### DIFF
--- a/arch/powerpc/assembler.cpp
+++ b/arch/powerpc/assembler.cpp
@@ -43,7 +43,7 @@ struct info {
 	uint32_t mask; /* which bits to mutate */
 };
 
-map<string, info> lookup = {
+static const map<string_view, info> lookup = {
 {               "tdi NUM , GPR , NUM",{0x0800000A,0x03FFFFFF}}, // 000010xxxxxxxxxxxxxxxxxxxxxxxxxx  tdi 0, r0, 0xa
 {                  "tdlgti GPR , NUM",{0x08200000,0x001FFFFF}}, // 00001000001xxxxxxxxxxxxxxxxxxxxx  tdlgti r0, 0
 {                  "tdllti GPR , NUM",{0x08400000,0x001FFFFF}}, // 00001000010xxxxxxxxxxxxxxxxxxxxx  tdllti r0, 0
@@ -2932,12 +2932,13 @@ int assemble_single(string src, uint32_t addr, uint8_t *result, string& err,
 
 	MYLOG("src:%s has signature:%s\n", src.c_str(), sig_src.c_str());
 
-	if(lookup.find(sig_src) == lookup.end()) {
+	auto it = lookup.find(sig_src);
+	if(it == lookup.end()) {
 		err = "invalid syntax in " + sig_src;
 		return -1;
 	}
 
-	auto info = lookup[sig_src];
+	auto info = it->second;
 	uint32_t vary_mask = info.mask;
 
 	/* for relative branches, shift the target address to 0 */


### PR DESCRIPTION
Clang was taking around 30 seconds to compile assembler.cpp on my machine, with most of its time spent in code generation for the global initializer for `lookup`.

Changing the map key from `std::string` to `std::string_view` drops compile time to under a second. This is because the compiler no longer has to code gen the allocation, initialization, and moves of 2,100 `std::string`s. `std::string_view` is effectively free to initialize in comparison.

While I was here I made the map `static const`. It's not required for the build time improvement, but it is more correct and helped me check that no-one is mutating the map.