### PR TITLE
Update support matrix for kernel/shared cache

### DIFF
--- a/docs/guide/kernelcache.md
+++ b/docs/guide/kernelcache.md
@@ -11,9 +11,9 @@ List of supported features for the given `kernelcache` targets:
 
 | Platform | Arch   | Versions | Features                    |
 |----------|--------|----------|-----------------------------|
-| macOS    | x86_64 | 11 - 15  | Core, Objective-C           |
-| macOS    | arm64  | 11 - 15  | Core, Objective-C           |
-| iOS      | arm64  | 14 - 18  | Core, Objective-C           |
+| macOS    | x86_64 | 11 - 26  | Core, Objective-C           |
+| macOS    | arm64  | 11 - 26  | Core, Objective-C           |
+| iOS      | arm64  | 14 - 26  | Core, Objective-C           |
 
 - **Core**: Core functionality, such as loading, navigating, and analyzing `kernelcache` files.
 - **Objective-C**: Support for analyzing Objective-C information and symbols within the `kernelcache`.

--- a/docs/guide/sharedcache.md
+++ b/docs/guide/sharedcache.md
@@ -11,9 +11,9 @@ List of supported features for the given shared cache targets:
 
 | Platform | Arch   | Versions | Features                          | Notes                          |
 |----------|--------|----------|-----------------------------------|--------------------------------|
-| macOS    | x86_64 | 11 - 15  | Core, Objective-C, Workflow       |                                |
-| macOS    | arm64  | 11 - 15  | Core, Objective-C, Workflow       |                                |
-| iOS      | arm64  | 11 - 18  | Core, Objective-C, Workflow       |                                |
+| macOS    | x86_64 | 11 - 26  | Core, Objective-C, Workflow       |                                |
+| macOS    | arm64  | 11 - 26  | Core, Objective-C, Workflow       |                                |
+| iOS      | arm64  | 11 - 26  | Core, Objective-C, Workflow       |                                |
 | iOS      | arm64  | 10       | Core, _~Objective-C_, Workflow    | Some objective-c parsing fails |
 | iOS      | arm64  | 7 - 9    | _~Core_, _~Objective-C_, Workflow | Missing slide info adjustments |
 


### PR DESCRIPTION
I believe we have previously tested both kernel cache and shared cache for both macOS and iOS beta builds, I figure it be good to update the support matrix.