### PR TITLE
Add on_action_executed_immutable to python API

### DIFF
--- a/python/examples/ui_notifications.py
+++ b/python/examples/ui_notifications.py
@@ -98,6 +98,8 @@ class UINotification(UIContextNotification):
 		# This function only works in C++: Name is an out param (cpp: &name), and not modifiable by python.
 		print(f"py OnContextMenuCreated {context} {view} {menu}")
 
+	def OnActionExecutedImmutable(self, context, handler, name, ctx):
+		print(f"py OnActionExecutedImmutable {context} {handler} {name} {ctx}")
 
 # Register as a global so it doesn't get destructed
 notif = UINotification()

--- a/ui/uicontext.h
+++ b/ui/uicontext.h
@@ -340,6 +340,24 @@ class BINARYNINJAUIAPI UIContextNotification
 		(void)action;
 	}
 
+
+	/*!
+	 * Callback when an action is executed. Unlike OnActionExecuted, plugins cannot
+	 * modify the behavior of the action.
+	 *
+	 * \param context
+	 * \param handler
+	 * \param name
+	 * \param ctx
+	 */
+	virtual void OnActionExecutedImmutable(UIContext* context, UIActionHandler* handler, const QString& name, const UIActionContext& ctx)
+	{
+		(void)context;
+		(void)handler;
+		(void)name;
+		(void)ctx;
+	}
+
 	/*!
 	    Callback when a context menu is created, allowing plugins to modify the menu,
 	    e.g., registering and adding new actions into it. This allow plugins to add
@@ -570,6 +588,7 @@ public:
 	void NotifyOnILViewTypeChange(ViewFrame* frame, View* view, const BinaryNinja::FunctionViewType& viewType);
 	void updateCrossReferences(ViewFrame* frame, View* view, const SelectionInfoForXref& selection);
 	void NotifyOnActionExecuted(UIActionHandler* handler, const QString& name, const UIActionContext& ctx, std::function<void(const UIActionContext&)>& action);
+	void NotifyOnActionExecutedImmutable(UIActionHandler* handler, const QString& name, const UIActionContext& ctx);
 	void NotifyOnContextMenuCreated(View* view, Menu& menu);
 
 	virtual void findAll(const BinaryNinja::FindParameters& params);


### PR DESCRIPTION
Adds on_action_executed_immutable, for a python-based version of OnActionExecuted that omits the problematic std::function& parameter.