### PR TITLE
Generate WARP function guids for mach-o objective-c binaries

### DIFF
--- a/plugins/warp/src/plugin.rs
+++ b/plugins/warp/src/plugin.rs
@@ -12,9 +12,9 @@ use binaryninja::background_task::BackgroundTask;
 use binaryninja::command::{
     register_command, register_command_for_function, register_command_for_project,
 };
-use binaryninja::is_ui_enabled;
 use binaryninja::logger::Logger;
 use binaryninja::settings::Settings;
+use binaryninja::{add_optional_plugin_dependency, is_ui_enabled};
 use log::LevelFilter;
 use reqwest::StatusCode;
 
@@ -196,4 +196,10 @@ pub extern "C" fn CorePluginInit() -> bool {
     );
 
     true
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn CorePluginDependencies() {
+    // TODO: Remove this once the objectivec workflow is registered on the meta workflow.
+    add_optional_plugin_dependency("workflow_objc");
 }

--- a/plugins/warp/src/plugin/workflow.rs
+++ b/plugins/warp/src/plugin/workflow.rs
@@ -108,8 +108,21 @@ pub fn run_matcher(view: &BinaryView) {
     if functions_by_target_and_guid.is_empty() && !view.functions().is_empty() {
         // The user is likely trying to run the matcher on a database before guids were automatically
         // generated, we should alert them and ask if they would like to reanalyze.
-        // TODO: Call reanalyze for them?
-        log::error!("Trying to match with an older database, please reanalyze the database.");
+        // NOTE: We only alert if we actually have the GUID activity enabled.
+        if let Some(sample_function) = view.functions().iter().next() {
+            let function_workflow = sample_function
+                .workflow()
+                .expect("Function has no workflow");
+            if function_workflow.contains(GUID_ACTIVITY_NAME) {
+                log::error!("No function guids in database, please reanalyze the database.");
+            } else {
+                log::error!(
+                    "Activity '{}' is not in workflow '{}', create function guids manually to run matcher...",
+                    GUID_ACTIVITY_NAME,
+                    function_workflow.name()
+                )
+            }
+        }
         background_task.finish();
         return;
     }
@@ -245,22 +258,21 @@ pub fn insert_workflow() {
         }
     };
 
-    let old_function_meta_workflow = Workflow::instance("core.function.metaAnalysis");
-    let function_meta_workflow = old_function_meta_workflow.clone_to("core.function.metaAnalysis");
     let guid_activity = Activity::new_with_action(GUID_ACTIVITY_CONFIG, guid_activity);
     let apply_activity = Activity::new_with_action(APPLY_ACTIVITY_CONFIG, apply_activity);
-    function_meta_workflow
-        .register_activity(&guid_activity)
-        .unwrap();
-    // Because we are going to impact analysis with application we must make sure the function update is triggered to continue to update analysis.
-    function_meta_workflow
-        .register_activity(&apply_activity)
-        .unwrap();
-    function_meta_workflow
-        .insert_after("core.function.runFunctionRecognizers", [GUID_ACTIVITY_NAME]);
-    function_meta_workflow
-        .insert_after("core.function.generateMediumLevelIL", [APPLY_ACTIVITY_NAME]);
-    function_meta_workflow.register().unwrap();
+
+    let add_function_activities = |workflow: &Workflow| {
+        let new_workflow = workflow.clone_to(&workflow.name());
+        new_workflow.register_activity(&guid_activity).unwrap();
+        new_workflow.register_activity(&apply_activity).unwrap();
+        new_workflow.insert_after("core.function.runFunctionRecognizers", [GUID_ACTIVITY_NAME]);
+        new_workflow.insert_after("core.function.generateMediumLevelIL", [APPLY_ACTIVITY_NAME]);
+        new_workflow.register().unwrap();
+    };
+
+    add_function_activities(&Workflow::instance("core.function.metaAnalysis"));
+    // TODO: Remove this once the objectivec workflow is registered on the meta workflow.
+    add_function_activities(&Workflow::instance("core.function.objectiveC"));
 
     let old_module_meta_workflow = Workflow::instance("core.module.metaAnalysis");
     let module_meta_workflow = old_module_meta_workflow.clone_to("core.module.metaAnalysis");


### PR DESCRIPTION
Previously we only added the warp function activities to the meta workflow, however objective-c plugin currently registers its own workflow that we must add the activities to as well.

Fixes https://github.com/Vector35/binaryninja-api/issues/7172