### PR TITLE
[ARM64] Fix lifting of tbz / tbnz for bits >= 32

### DIFF
--- a/arch/arm64/il.cpp
+++ b/arch/arm64/il.cpp
@@ -1159,13 +1159,13 @@ static ExprId ExtractBits(
     LowLevelILFunction& il, InstructionOperand& reg, size_t nbits, size_t rightMostBit)
 {
 // Get N set bits at offset O
-#define BITMASK(N, O) (((1LL << nbits) - 1) << O)
+#define BITMASK(N, O) (((UINT64_C(1) << nbits) - 1) << O)
 	return il.And(REGSZ_O(reg), ILREG_O(reg), il.Const(REGSZ_O(reg), BITMASK(nbits, rightMostBit)));
 }
 
 static ExprId ExtractBit(LowLevelILFunction& il, InstructionOperand& reg, size_t bit)
 {
-	return il.And(REGSZ_O(reg), ILREG_O(reg), il.Const(REGSZ_O(reg), (1 << bit)));
+	return il.And(REGSZ_O(reg), ILREG_O(reg), il.Const(REGSZ_O(reg), (UINT64_C(1) << bit)));
 }
 
 static void ConditionalJump(Architecture* arch, LowLevelILFunction& il, size_t cond,


### PR DESCRIPTION
Fixes https://github.com/Vector35/binaryninja-api/issues/7205.

Since the integer literal `1` fits in an int, that is its type. Shifting it by values larger than 31 give unexpected behavior in this context. I'm not entirely sure how we get `0xffffffff80000000` as the result. That doesn't match my reading of https://en.cppreference.com/w/cpp/language/operator_arithmetic.html#Built-in_bitwise_shift_operators. Prior to C++20 this was undefined behavior territory, but with C++20 it should be well defined.

The fix is to ensure that the value we are shifting is a `uint64_t`.
