### PR TITLE
Avoid leaking Relocation instances

### DIFF
--- a/relocationhandler.cpp
+++ b/relocationhandler.cpp
@@ -102,7 +102,7 @@ bool RelocationHandler::ApplyRelocation(
     Ref<BinaryView> view, Ref<Architecture> arch, Ref<Relocation> reloc, uint8_t* dest, size_t len)
 {
 	return BNRelocationHandlerDefaultApplyRelocation(
-	    m_object, view->GetObject(), arch->GetObject(), BNNewRelocationReference(reloc->GetObject()), dest, len);
+	    m_object, view->GetObject(), arch->GetObject(), reloc->GetObject(), dest, len);
 }
 
 
@@ -125,7 +125,7 @@ bool CoreRelocationHandler::ApplyRelocation(
     Ref<BinaryView> view, Ref<Architecture> arch, Ref<Relocation> reloc, uint8_t* dest, size_t len)
 {
 	return BNRelocationHandlerApplyRelocation(
-	    m_object, view->GetObject(), arch->GetObject(), BNNewRelocationReference(reloc->GetObject()), dest, len);
+	    m_object, view->GetObject(), arch->GetObject(), reloc->GetObject(), dest, len);
 }
 
 
@@ -148,5 +148,5 @@ size_t CoreRelocationHandler::GetOperandForExternalRelocation(
     const uint8_t* data, uint64_t addr, size_t length, Ref<LowLevelILFunction> il, Ref<Relocation> relocation)
 {
 	return BNRelocationHandlerGetOperandForExternalRelocation(
-	    m_object, data, addr, length, il->GetObject(), BNNewRelocationReference(relocation->GetObject()));
+	    m_object, data, addr, length, il->GetObject(), relocation->GetObject());
 }


### PR DESCRIPTION
`BNRelocationHandlerDefaultApplyRelocation` / `BNRelocationHandlerApplyRelocation` / `BNRelocationHandlerGetOperandForExternalRelocation` do not take ownership of the reference that is passed to them. Instead they take their own reference to the object. As a result, `Relocation` objects passed into `RelocationHandler::ApplyRelocation` / `CoreRelocationHandler::ApplyRelocation` / `CoreRelocationHandler::GetOperandForExternalRelocation` were being leaked.