### PR TITLE
[ELF] Fix a memory leak when parsing .gnu_debugdata

### DIFF
--- a/view/elf/elfview.cpp
+++ b/view/elf/elfview.cpp
@@ -2732,6 +2732,8 @@ void ElfView::ParseMiniDebugInfo()
 			symbol->GetBinding()
 		);
 	}
+
+	debugBv->GetFile()->Close();
 }
 
 


### PR DESCRIPTION
It is necessary to call `FileMetadata::Close` to break the reference cycle between the `BinaryView` and `FileMetadata`.

Fixes https://github.com/Vector35/binaryninja/issues/1060.