### PR TITLE
[Rust] Don't leak the callbacks within DownloadInstance::perform_custom_request

### DIFF
--- a/rust/src/download_provider.rs
+++ b/rust/src/download_provider.rs
@@ -253,6 +253,7 @@ impl DownloadInstance {
             )
         };
 
+        unsafe { drop(Box::from_raw(callbacks)) };
         if result < 0 {
             unsafe { BNFreeDownloadInstanceResponse(response) };
             return Err(self.get_error());


### PR DESCRIPTION
I'm not entirely clear why this function copies the callbacks to the heap given that `BNPerformCustomRequest` is synchronous. Rather than changing that, I added an explicit `Box::from_raw` to ensure it is deallocated. This matches what is done within `perform_request`.