### PR TITLE
[ARM64] Fix lifting of mrs xzr, ... to not reference the xzr register

### DIFF
--- a/arch/arm64/il.cpp
+++ b/arch/arm64/il.cpp
@@ -2803,8 +2803,13 @@ bool GetLowLevelILForInstruction(
 				operand2.implspec[3], operand2.implspec[4]);
 		}
 
-		il.AddInstruction(
-		    il.Intrinsic({RegisterOrFlag::Register(REG_O(operand1))}, ARM64_INTRIN_MRS, {il.Const(4, reg)}));
+		if (IS_ZERO_REG(REG_O(operand1))) {
+			il.AddInstruction(
+			    il.Intrinsic({}, ARM64_INTRIN_MRS, {il.Const(4, reg)}));
+		} else {
+			il.AddInstruction(
+			    il.Intrinsic({RegisterOrFlag::Register(REG_O(operand1))}, ARM64_INTRIN_MRS, {il.Const(4, reg)}));
+		}
 		break;
 	}
 	case ARM64_MSUB:


### PR DESCRIPTION
ARM64 lifting replaces references to the zero register with constant zeroes. The zero register is not intended to appear in any lifted IL.

In the case of the `mrs` instruction, the destination being a zero register means the system register is accessed only for a side-effect, and is not stored anywhere. The lifting is updated to specify no output registers for the intrinsic in that case.