### PR TITLE
Fix disallowBranchToString in default abb.

### DIFF
--- a/defaultabb.cpp
+++ b/defaultabb.cpp
@@ -462,7 +462,7 @@ void Architecture::DefaultAnalyzeBasicBlocks(Function* function, BasicBlockAnaly
 									break;
 								}
 							}
-							else if (disallowBranchToString && data->GetStringAtAddress(location.address, strRef) && targetExceedsByteLimit(strRef))
+							else if (disallowBranchToString && data->GetStringAtAddress(target.address, strRef) && targetExceedsByteLimit(strRef))
 							{
 								BNLogInfo("Not adding branch target from 0x%" PRIx64 " to string at 0x%" PRIx64
 									" length:%zu",


### PR DESCRIPTION
The setting should halt analysis of branch targets that fall within string references. Previous implementation looked up string references at branch source.