### PR TITLE
Expose GetFilePathInProject API for context menu

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -3694,6 +3694,7 @@ namespace BinaryNinja {
 		std::string GetId() const;
 		bool IsOpen() const;
 		std::string GetPath() const;
+		std::string GetFilePathInProject(const Ref<ProjectFile>& file) const;
 		std::string GetName() const;
 		void SetName(const std::string& name);
 		std::string GetDescription() const;

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -37,7 +37,7 @@
 // Current ABI version for linking to the core. This is incremented any time
 // there are changes to the API that affect linking, including new functions,
 // new types, or modifications to existing functions or types.
-#define BN_CURRENT_CORE_ABI_VERSION 128
+#define BN_CURRENT_CORE_ABI_VERSION 129
 
 // Minimum ABI version that is supported for loading of plugins. Plugins that
 // are linked to an ABI version less than this will not be able to load and

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -4039,6 +4039,7 @@ extern "C"
 	BINARYNINJACOREAPI char* BNProjectGetId(BNProject* project);
 	BINARYNINJACOREAPI bool BNProjectIsOpen(BNProject* project);
 	BINARYNINJACOREAPI char* BNProjectGetPath(BNProject* project);
+	BINARYNINJACOREAPI char* BNProjectGetFilePathInProject(BNProject* project, BNProjectFile* file);
 	BINARYNINJACOREAPI char* BNProjectGetName(BNProject* project);
 	BINARYNINJACOREAPI void BNProjectSetName(BNProject* project, const char* name);
 	BINARYNINJACOREAPI char* BNProjectGetDescription(BNProject* project);

--- a/project.cpp
+++ b/project.cpp
@@ -285,6 +285,15 @@ std::string Project::GetPath() const
 	return result;
 }
 
+std::string Project::GetFilePathInProject(const Ref<ProjectFile>& file) const
+{
+	char* path = BNProjectGetFilePathInProject(m_object, file->m_object);
+	std::string result = path;
+	BNFreeString(path);
+	return result;
+}
+
+
 
 std::string Project::GetName() const
 {


### PR DESCRIPTION
Exposes the GetFilePathInProject API for use in a new right click context menu to copy file paths relative to a project. 

Linked with https://github.com/Vector35/binaryninja/pull/1190