### PR TITLE
[aarch64] Enable Always and Never Branch patching for TBZ/TBNZ and CBZ/CBNZ

### DIFF
--- a/arch/arm64/arch_arm64.cpp
+++ b/arch/arm64/arch_arm64.cpp
@@ -1168,7 +1168,7 @@ class Arm64Architecture : public Architecture
 		Instruction instr;
 		if (!Disassemble(data, addr, len, instr))
 			return false;
-		return IsConditionalBranch(instr);
+		return IsConditionalJump(instr);
 	}
 
 
@@ -1177,7 +1177,7 @@ class Arm64Architecture : public Architecture
 		Instruction instr;
 		if (!Disassemble(data, addr, len, instr))
 			return false;
-		return IsConditionalBranch(instr);
+		return IsConditionalJump(instr);
 	}
 
 
@@ -1230,9 +1230,17 @@ class Arm64Architecture : public Architecture
 			return false;
 
 		uint32_t* value = (uint32_t*)data;
-		// Combine the immediate in the first operand with the unconditional branch opcode to form
-		// an unconditional branch instruction
-		*value = (5 << 26) | (((uint32_t)((instr.operands[0].immediate - addr) >> 2)) & 0x03ffffff);
+		if (IsConditionalBranch(instr))
+		{
+			// Combine the immediate in the first operand with the unconditional branch opcode to form
+			// an unconditional branch instruction
+			*value = (5 << 26) | (((uint32_t)((instr.operands[0].immediate - addr) >> 2)) & 0x03ffffff);
+		}
+		else
+		{
+			// Force to a *BZ, then change the register to zero register (WZR or XZR, determined by bit 31)
+			*value = (*value & ~(1 << 24)) | 0x0f;
+		}
 		return true;
 	}
 


### PR DESCRIPTION
Addresses https://github.com/Vector35/binaryninja-api/issues/7280

This PR implements the fix, but someone should sign off on this with respect to the following concern:

> while i can fix always branch (by forcing it to be a TBZ/CBZ and changing the tested register to the zero XZR/WZR so the branch always happens), its’s not clear to me that it’s “ok”, in the sense that it changes the data dependency of the instruction, from the tested register to the zero register.

