### PR TITLE
[ObjC] Improve the parsing of message type encoding strings

### DIFF
--- a/objectivec/objc.cpp
+++ b/objectivec/objc.cpp
@@ -295,7 +295,7 @@ std::vector<QualifiedNameOrType> ObjCProcessor::ParseEncodedType(const std::stri
 			nameOrType.type = Type::IntegerType(2, true);
 			break;
 		case 'S':
-			nameOrType.type = Type::IntegerType(1, false);
+			nameOrType.type = Type::IntegerType(2, false);
 			break;
 		case 'i':
 			nameOrType.type = Type::IntegerType(4, true);
@@ -304,26 +304,26 @@ std::vector<QualifiedNameOrType> ObjCProcessor::ParseEncodedType(const std::stri
 			nameOrType.type = Type::IntegerType(4, false);
 			break;
 		case 'l':
-			nameOrType.type = Type::IntegerType(8, true);
+			nameOrType.type = Type::IntegerType(4, true);
 			break;
 		case 'L':
+			nameOrType.type = Type::IntegerType(4, false);
+			break;
+		case 'q':
 			nameOrType.type = Type::IntegerType(8, true);
 			break;
+		case 'Q':
+			nameOrType.type = Type::IntegerType(8, false);
+			break;
 		case 'f':
-			nameOrType.type = Type::IntegerType(4, true);
+			nameOrType.type = Type::FloatType(4);
+			break;
+		case 'd':
+			nameOrType.type = Type::FloatType(8);
 			break;
 		case 'b':
 		case 'B':
 			nameOrType.type = Type::BoolType();
-			break;
-		case 'q':
-			qualifiedName = "NSInteger";
-			break;
-		case 'Q':
-			qualifiedName = "NSUInteger";
-			break;
-		case 'd':
-			qualifiedName = "CGFloat";
 			break;
 		case '*':
 			nameOrType.type = Type::PointerType(m_data->GetAddressSize(), Type::IntegerType(1, true));

--- a/objectivec/objc.cpp
+++ b/objectivec/objc.cpp
@@ -340,6 +340,14 @@ std::vector<QualifiedNameOrType> ObjCProcessor::ParseEncodedType(const std::stri
 			qualifiedName = "objc_class_t";
 			break;
 		case '?':
+			if (last == '@')
+			{
+				// A pointer to a Clang block is encoded as `@?`. For now we continue to represent this
+				// as `id` as we cannot represent block types.
+				last = c;
+				continue;
+			}
+			[[fallthrough]];
 		case 'T':
 			nameOrType.type = Type::PointerType(8, Type::VoidType());
 			break;


### PR DESCRIPTION
This does two main things:
1. Fixes the parsing of `@?` which is used to represent a block argument. Since we do not have type system support for blocks and blocks can be treated as Objective-C objects, they are mapped to `id`.
2. Fixes some incorrect handling of integer and floating point types, particularly on 32-bit platforms.

   `q`, `Q` and `d` were being mapped to `NSInteger`, `NSUInteger` and  `CGFloat` respectively. While this works for 64-bit platforms, the type aliases refer to 32-bit types on 32-bit platforms.  These type encodings are explicitly for 64-bit types. To address this `q`, `Q` and `d` are now mapped to `int64_t`, `uint64_t` and `double` respectively.
 
   `l` and `L` were incorrectly being interpreted as `int64_t` and `uint64_t`. While `long` is a 64-bit type on 64-bit Apple platforms, the `l` / `L` type encodings always refer to a 32-bit type.
 
   `S` was mistakenly being mapped to `uint8_t`. It is now `uint16_t` as intended.