### PR TITLE
[Arm64, Apple] Apple arm64 syscall calling convention

### DIFF
--- a/arch/arm64/arch_arm64.cpp
+++ b/arch/arm64/arch_arm64.cpp
@@ -2692,15 +2692,15 @@ class WindowsArm64SystemCallConvention : public CallingConvention
 	virtual bool IsEligibleForHeuristics() override { return false; }
 };
 
-class MacosArm64SystemCallConvention : public CallingConvention
+class AppleArm64SystemCallConvention : public CallingConvention
 {
  public:
-	MacosArm64SystemCallConvention(Architecture* arch) : CallingConvention(arch, "macos-syscall") {}
+	AppleArm64SystemCallConvention(Architecture* arch) : CallingConvention(arch, "apple-syscall") {}
 
 
 	virtual vector<uint32_t> GetIntegerArgumentRegisters() override
 	{
-		return vector<uint32_t> {REG_X16, REG_X0, REG_X1, REG_X2, REG_X3, REG_X4, REG_X5};
+		return vector<uint32_t> {REG_X16, REG_X0, REG_X1, REG_X2, REG_X3, REG_X4, REG_X5, REG_X6, REG_X7, REG_X8};
 	}
 
 
@@ -3498,6 +3498,9 @@ extern "C"
 		arm64->RegisterCallingConvention(conv);
 
 		conv = new WindowsArm64SystemCallConvention(arm64);
+		arm64->RegisterCallingConvention(conv);
+
+		conv = new AppleArm64SystemCallConvention(arm64);
 		arm64->RegisterCallingConvention(conv);
 
 		conv = new AppleArm64CallingConvention(arm64);

--- a/platform/mac/platform_mac.cpp
+++ b/platform/mac/platform_mac.cpp
@@ -143,6 +143,10 @@ public:
 			RegisterFastcallCallingConvention(cc);
 			RegisterStdcallCallingConvention(cc);
 		}
+
+		cc = arch->GetCallingConventionByName("apple-syscall");
+		if (cc)
+			SetSystemCallConvention(cc);
 	}
 
 	virtual bool GetFallbackEnabled() override
@@ -232,6 +236,11 @@ public:
 			RegisterFastcallCallingConvention(cc);
 			RegisterStdcallCallingConvention(cc);
 		}
+
+		cc = arch->GetCallingConventionByName("apple-syscall");
+		if (cc)
+			SetSystemCallConvention(cc);
+
 	}
 
 	virtual bool GetFallbackEnabled() override


### PR DESCRIPTION
This MR addressing #7311. A bit confused why hasn't it been done earlier.

As "macos-syscall" was never registered and used by any of platform types, it is safe to rename it to "apple-syscall" (as it applied to both macos and ios).

Also changed arguments for this cc from X0-X5 to X0-X8 as syscalls on ios/macos can handle up to 9 arguments