### PR TITLE
[MIPS] Mark `jalr[.hb] $zero, $ra` as a return instruction

### DIFF
--- a/arch/mips/arch_mips.cpp
+++ b/arch/mips/arch_mips.cpp
@@ -332,10 +332,12 @@ protected:
 			result.AddBranch(CallDestination, instr.operands[0].immediate, nullptr, hasBranchDelay);
 			break;
 
-		//Jmp to register register value is unknown
 		case MIPS_JALR:
 		case MIPS_JALR_HB:
-			result.delaySlots = 1;
+			if (instr.operands[0].reg == REG_ZERO && instr.operands[1].reg == REG_RA)
+				result.AddBranch(FunctionReturn, 0, nullptr, hasBranchDelay);
+			else
+				result.AddBranch(UnresolvedBranch, 0, nullptr, hasBranchDelay);
 			break;
 
 		case MIPS_BGEZAL:

--- a/arch/mips/il.cpp
+++ b/arch/mips/il.cpp
@@ -1430,7 +1430,10 @@ bool GetLowLevelILForInstruction(Architecture* arch, uint64_t addr, LowLevelILFu
 		{
 			operand = 2;
 		}
-		il.AddInstruction(il.Call(ReadILOperand(il, instr, operand, registerSize(instr.operands[operand]), addrSize, true)));
+		if (operand == 2 && op1.reg == REG_ZERO && op2.reg == REG_RA)
+			il.AddInstruction(il.Return(il.Register(addrSize, REG_RA)));
+		else
+			il.AddInstruction(il.Call(ReadILOperand(il, instr, operand, registerSize(instr.operands[operand]), addrSize, true)));
 	}
 		break;
 	case MIPS_JR:


### PR DESCRIPTION
This PR marks MIPS `jalr[.hb] $zero, $ra` as a return instruction.

Resolves #7355.

## Effects

Before:

<img width="1458" height="142" alt="before" src="https://github.com/user-attachments/assets/7f6b7f8b-e286-4e8a-93f2-46c13a48e8d3" />

After:

<img width="1257" height="89" alt="after" src="https://github.com/user-attachments/assets/339ff3bb-eab9-4b38-9077-0e6205ba0c49" />
