### PR TITLE
[MachO] Tweak handling of LC_FUNCTION_STARTS

### DIFF
--- a/view/macho/machoview.cpp
+++ b/view/macho/machoview.cpp
@@ -959,6 +959,8 @@ bool MachoView::IsValidFunctionStart(uint64_t addr)
 		const auto& instr = ilFunc->GetInstruction(i);
 		if (instr.operation == LLIL_UNDEF)
 			return false;
+		if (i == 0 && instr.operation == LLIL_TRAP)
+			return false;
 	}
 
 	return true;
@@ -993,12 +995,12 @@ void MachoView::ParseFunctionStarts(Platform* platform, uint64_t textBase, funct
 			uint64_t target = curfunc;
 			if (!IsValidFunctionStart(target))
 			{
-				m_logger->LogWarn("Possible error processing LC_FUNCTION_STARTS! Not adding function at: 0x%" PRIx64 "\n", target);
+				m_logger->LogInfoF("Address {:#x} referenced from LC_FUNCTION_STARTS does not appear to be a function", target);
 				continue;
 			}
 			Ref<Platform> targetPlatform = platform->GetAssociatedPlatformByAddress(target);
 			AddFunctionForAnalysis(targetPlatform, target);
-			m_logger->LogDebug("Adding function start: %#" PRIx64 "\n", curfunc);
+			m_logger->LogDebugF("Adding function start: {:#x}", curfunc);
 		}
 	}
 	catch (ReadException&)


### PR DESCRIPTION
`LC_FUNCTION_STARTS` includes both functions and jump tables. We want to avoid calling `AddFunctionForAnalysis` on jump tables since it can result in a function being created at the jump table's location with a bogus body.

We already skip adding functions for entries in `LC_FUNCTION_STARTS` if the lifting of their first few bytes end up including `LLIL_UNDEF`. However, arm64 intentionally lifts `udf` instructions (i.e., opcodes in the Permanently Undefined range) to `LLIL_TRAP` in order to preserve the immediate portion of the instruction.

To address this, `MachoView::IsValidFunctionStart` now returns false if the first lifted instruction is `LLIL_TRAP` in addition to when the lifting contains `LLIL_UNDEF`.