### PR TITLE
Fix generating core API stubs on Windows

### DIFF
--- a/stubs/CMakeLists.txt
+++ b/stubs/CMakeLists.txt
@@ -1,18 +1,14 @@
 cmake_minimum_required(VERSION 3.19 FATAL_ERROR)
 project(binaryninjacore_stubs)
 
-if(WIN32)
-	set(PYTHON_COMMAND "py -3")
-else()
-	set(PYTHON_COMMAND "python3")
-endif()
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
 
 file(REAL_PATH "${PROJECT_SOURCE_DIR}/../" ABSOLUTE_API_PATH)
 
 # Generate stubs.cpp with implementations of all the BNAPI functions
 add_custom_command(
     OUTPUT ${PROJECT_BINARY_DIR}/stubs.cpp
-    COMMAND ${PYTHON_COMMAND} ${PROJECT_SOURCE_DIR}/generate_stubs.py ${ABSOLUTE_API_PATH}/binaryninjacore.h ${PROJECT_BINARY_DIR}
+    COMMAND ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/generate_stubs.py ${ABSOLUTE_API_PATH}/binaryninjacore.h ${PROJECT_BINARY_DIR}
     DEPENDS ${PROJECT_SOURCE_DIR}/generate_stubs.py ${ABSOLUTE_API_PATH}/binaryninjacore.h
     COMMENT "Generating stubs.cpp from binaryninjacore.h"
 )


### PR DESCRIPTION
"py -3" was being incorrectly quoted, preventing the stub generation script from running on Windows.

Instead of changing the quoting, I've opted to switch this to using `find_package(Python3)` to find the Python installation. This sets `Python3_EXECUTABLE` to point at the executable to run.