### PR TITLE
Fix calculation of mask for constant values

### DIFF
--- a/rust/src/low_level_il/operation.rs
+++ b/rust/src/low_level_il/operation.rs
@@ -1754,12 +1754,14 @@ where
             }
         }
 
-        let mut mask = -1i64 as u64;
-
-        if self.op.size < mem::size_of::<u64>() {
-            mask <<= self.op.size * 8;
-            mask = !mask;
-        }
+        let mask: u64 = if self.op.size == 0 {
+            1
+        } else if self.op.size < mem::size_of::<u64>() {
+            let m = -1i64 << (self.op.size * 8);
+            !m as u64
+        } else {
+            (-1i64) as u64
+        };
 
         self.op.operands[0] & mask
     }


### PR DESCRIPTION
This fixes an error when a constant is being loaded into a flag. The constants associated with a flag value have their size set to zero. That causes the mask for the constant value to be all zeros. Due to that, getting the value of a zero sized constant will always return 0 even if it should be 1.

This commit special cases the size of zero to create a mask of 1 which will correctly mask off the lowest bit and return that as the constant.