### PR TITLE
Fix: Incorrect GPR Encoding for PPCVLE Architecture (issue #7510)

### DIFF
--- a/arch/powerpc/decode/vle16.c
+++ b/arch/powerpc/decode/vle16.c
@@ -335,17 +335,20 @@ static InstructionId Decode16Vle(uint16_t word16, uint32_t decodeFlags)
 }
 static uint16_t Get16Rx(uint16_t word16)
 {
-	return word16 & 0xf;
+	uint16_t rx = word16 & 0xf;
+	return rx + ((rx & 0x8) >> 3) * 16;
 }
 
 static uint16_t Get16Ry(uint16_t word16)
 {
-	return (word16 >> 4) & 0xf;
+	uint16_t ry = (word16 >> 4) & 0xf;
+	return ry + ((ry & 0x8) >> 3) * 16;
 }
 
 static uint16_t Get16Rz(uint16_t word16)
 {
-	return (word16 >> 4) & 0xf;
+	uint16_t rz = (word16 >> 4) & 0xf;
+	return rz + ((rz & 0x8) >> 3) * 16;
 }
 
 static void FillOperands16Vle(Instruction* instruction, uint16_t word16, uint64_t address, bool translate)


### PR DESCRIPTION
### Description
This PR fixes an issue in the PowerPC VLE instruction decoder where 4-bit General Purpose Register (GPR) fields were not being decoded correctly.

### Motivation and Context
According to the PowerISA v2.03 specification (page 644), 4-bit GPR fields in VLE instructions utilize a split-range encoding. This field designates registers in the range R0-R7 or R24-R31.

The previous implementation only masked the 4-bit value, correctly handling the R0-R7 range but failing to map values to the upper R24-R31 range. This occurred when the Most Significant Bit (MSB) of the 4-bit field was set, leading to incorrect disassembly and flawed control-flow analysis. For example, a register field of 1000b (8) was incorrectly decoded as r8 instead of the correct r24.

### Changes
The Get16Rx, Get16Ry, and Get16Rz (if applicable) helper functions have been updated to align with the specification. The new logic checks the MSB of the 4-bit register field (& 0x8). If the bit is set, an offset of 16 (0x10) is added to the value. This correctly maps the register indices 8-15 to the GPRs R24-R31.

### Visual Comparison

To clearly demonstrate the impact of this fix, here is a side-by-side comparison of the disassembly before and after the changes.

- Before (Incorrect Disassembly)
As shown below, the instruction `se_lbz r6, 2(r31)` was incorrectly disassembled as `se_lbz r6, 2(r15)`.
<img width="600" alt="image" src="https://github.com/user-attachments/assets/2ad42ed1-00a2-4afb-86e8-929bdf84b98a" />

-  After (Correct Disassembly)
With the updated logic, the 4-bit register field is now correctly interpreted.
<img width="600" alt="image" src="https://github.com/user-attachments/assets/cc145419-5797-4628-b897-32fb9e2afd55" />
