### PR TITLE
[PPC-VLE] Fix(ppc/il): Treat r0 as a register in e_addi/e_add16i IL

### DIFF
--- a/arch/powerpc/il.cpp
+++ b/arch/powerpc/il.cpp
@@ -611,7 +611,7 @@ bool GetLowLevelILForPPCInstruction(Architecture *arch, LowLevelILFunction &il,
 				ei0 = il.Const(addressSize_l, oper2->simm);
 			ei0 = il.Add(
 				addressSize_l,
-				operToIL(il, oper1, OTI_GPR0_ZERO, PPC_IL_EXTRA_DEFAULT, addressSize_l),
+				operToIL(il, oper1),
 				ei0
 			);
 			ei0 = il.SetRegister(addressSize_l, oper0->reg, ei0);


### PR DESCRIPTION
### Description
This PR updates the Intermediate Language (IL) generation for the e_addi and e_add16i instructions on the PowerPC VLE architecture to ensure correct data-flow analysis.

### Motivation and Context
For `e_addi` and `e_add16i` instructions, the IL was incorrectly interpreting the `r0` register as a constant `0` instead of a register source. This was caused by the `OTI_GPR0_ZERO` flag.

### Changes Made
The `OTI_GPR0_ZERO` flag has been removed.
As a result, `r0` is now correctly treated as a general-purpose register in the IL, enabling accurate data-flow analysis.
- Before: `operToIL(il, oper1, OTI_GPR0_ZERO, ...)`
- After: `operToIL(il, oper1)`

This ensures that r0 is consistently treated as a register operand in the IL for these instruction.

### Visual Comparison
- Before
<img width="500" alt="image" src="https://github.com/user-attachments/assets/d29a6c48-3504-4f6a-9d9c-a327ea0960d5" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/f2ebd8f5-c88b-4b00-a6ef-a018dbb0206f" />

- After
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8771dc54-4708-41de-a3b1-da9bdaf30d07" />
