### PR TITLE
Add support for multiple single elements vld1 instructions

### DIFF
--- a/arch/armv7/armv7_disasm/armv7.h
+++ b/arch/armv7/armv7_disasm/armv7.h
@@ -910,15 +910,23 @@ typedef union _ieee754 {
 	float fvalue;
 }ieee754;
 
-typedef union _ieee754_double {
+typedef union _ieee754_double
+{
 	uint64_t value;
-	struct {
-		uint64_t fraction:52;
-		uint64_t exponent:11;
-		uint64_t sign:1;
+	struct
+	{
+		uint64_t fraction : 52;
+		uint64_t exponent : 11;
+		uint64_t sign : 1;
 	};
 	double fvalue;
-}ieee754_double;
+} ieee754_double;
+
+struct DoubleWordRegisterList
+{
+	uint8_t size;
+	uint8_t start;
+};
 
 #ifndef __cplusplus
 	typedef enum OperandClass OperandClass;

--- a/arch/armv7/il.cpp
+++ b/arch/armv7/il.cpp
@@ -123,6 +123,7 @@ static void ConditionExecute(LowLevelILFunction& il, Condition cond, ExprId true
 	il.AddInstruction(trueCase);
 	il.MarkLabel(falseCode);
 }
+// Returns an instructions datatype size in bits
 static size_t GetDataTypeSize(DataType dt)
 {
 	switch (dt)
@@ -183,6 +184,18 @@ static ExprId GetShifted(LowLevelILFunction& il, Register reg, uint32_t ShiftAmo
 			return 0;
 	}
 }
+static DoubleWordRegisterList ReadRegisterList(InstructionOperand instr) {
+	uint32_t val = instr.reg;
+	DoubleWordRegisterList dwrl;
+	#ifdef _MSC_VER
+	dwrl.size = __popcnt(val);
+	DWORD pos = 0;
+	_BitScanForward(&pos, val);
+	dwrl.start = pos;
+	
+	#else
+	dwrl.size = __builtin_popcount(val);
+	dwrl.start = __builtin_ctz(val);
 
 
 static ExprId GetShiftedOffset(LowLevelILFunction& il, InstructionOperand& op)

--- a/arch/armv7/il.cpp
+++ b/arch/armv7/il.cpp
@@ -197,6 +197,9 @@ static DoubleWordRegisterList ReadRegisterList(InstructionOperand instr) {
 	dwrl.size = __builtin_popcount(val);
 	dwrl.start = __builtin_ctz(val);
 
+	#endif
+	return dwrl;
+}
 
 static ExprId GetShiftedOffset(LowLevelILFunction& il, InstructionOperand& op)
 {

--- a/arch/armv7/il.cpp
+++ b/arch/armv7/il.cpp
@@ -180,7 +180,7 @@ static ExprId GetShifted(LowLevelILFunction& il, Register reg, uint32_t ShiftAmo
 			return 0;
 	}
 }
-static DoubleWordRegisterList ReadRegisterList(InstructionOperand instr) {
+static DoubleWordRegisterList ReadRegisterList(const InstructionOperand& instr) {
 	uint32_t val = instr.reg;
 	DoubleWordRegisterList dwrl;
 	#ifdef _MSC_VER

--- a/arch/armv7/il.cpp
+++ b/arch/armv7/il.cpp
@@ -144,7 +144,7 @@ static size_t GetDataTypeSize(DataType dt)
 	case DT_64:
 		return 64;
 	}
-};
+}
 
 static ExprId GetShifted(LowLevelILFunction& il, Register reg, uint32_t ShiftAmount, Shift shift)
 {

--- a/arch/armv7/il.cpp
+++ b/arch/armv7/il.cpp
@@ -131,22 +131,18 @@ static size_t GetDataTypeSize(DataType dt)
 	case DT_I8:
 	case DT_8:
 		return 8;
-		break;
 	case DT_F16:
 	case DT_I16:
 	case DT_16:
 		return 16;
-		break;
 	case DT_F32:
 	case DT_I32:
 	case DT_32:
 		return 32;
-		break;
 	case DT_F64:
 	case DT_I64:
 	case DT_64:
 		return 64;
-		break;
 	}
 };
 

--- a/arch/armv7/il.cpp
+++ b/arch/armv7/il.cpp
@@ -123,7 +123,31 @@ static void ConditionExecute(LowLevelILFunction& il, Condition cond, ExprId true
 	il.AddInstruction(trueCase);
 	il.MarkLabel(falseCode);
 }
-
+static size_t GetDataTypeSize(DataType dt)
+{
+	switch (dt)
+	{
+	case DT_I8:
+	case DT_8:
+		return 8;
+		break;
+	case DT_F16:
+	case DT_I16:
+	case DT_16:
+		return 16;
+		break;
+	case DT_F32:
+	case DT_I32:
+	case DT_32:
+		return 32;
+		break;
+	case DT_F64:
+	case DT_I64:
+	case DT_64:
+		return 64;
+		break;
+	}
+};
 
 static ExprId GetShifted(LowLevelILFunction& il, Register reg, uint32_t ShiftAmount, Shift shift)
 {

--- a/arch/armv7/il.cpp
+++ b/arch/armv7/il.cpp
@@ -5110,6 +5110,31 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 				)
 			);
 			break;
+		case ARMV7_VLD1:
+			ConditionExecute(addrSize, instr.cond, instr, il, [&](size_t addrSize, Instruction& instr, LowLevelILFunction& il) {
+				switch (op1.cls)
+					{
+					case OperandClass::REG_LIST_DOUBLE:
+						DoubleWordRegisterList reglist = ReadRegisterList(op1);
+						uint32_t dregsize = get_register_size(REG_D0);
+						uint32_t regsize = get_register_size(op2.reg);
+						uint32_t dataSizeInBytes = GetDataTypeSize(instr.dataType) / 8;
+						for (unsigned int i = 0; i < reglist.size; i++)
+						{
+							uint32_t curOffset = i * dataSizeInBytes;
+							uint32_t curregind = REG_D0 + reglist.start + i;
+
+							il.AddInstruction(il.SetRegister(dregsize, curregind,
+								il.Load(dataSizeInBytes, il.Add(regsize, ILREG(op2), il.Const(regsize, curOffset)))));
+						}
+						if (op2.flags.wb)
+						{
+							il.AddInstruction(il.SetRegister(
+								regsize, op2.reg, il.Add(regsize, ILREG(op2), il.Const(regsize, dataSizeInBytes * reglist.size))));
+						}
+					}
+				});
+			break;
 		default:
 			//printf("Instruction: %s\n", get_operation(instr.operation));
 			ConditionExecute(il, instr.cond, il.Unimplemented());

--- a/arch/armv7/il.cpp
+++ b/arch/armv7/il.cpp
@@ -128,21 +128,34 @@ static size_t GetDataTypeSize(DataType dt)
 {
 	switch (dt)
 	{
+	case DT_P8:
+	case DT_U8:
 	case DT_I8:
 	case DT_8:
 		return 8;
+	case DT_P16:
+	case DT_U16:
+	case DT_S16:
 	case DT_F16:
 	case DT_I16:
 	case DT_16:
 		return 16;
+	case DT_P32:
+	case DT_U32:
+	case DT_S32
 	case DT_F32:
 	case DT_I32:
 	case DT_32:
 		return 32;
+	case DT_P64:
+	case DT_U64:
+	case DT_S64:
 	case DT_F64:
 	case DT_I64:
 	case DT_64:
 		return 64;
+	default:
+		return 0;
 	}
 }
 
@@ -5144,6 +5157,9 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 							il.AddInstruction(il.SetRegister(
 								regsize, op2.reg, il.Add(regsize, ILREG(op2), il.Const(regsize, dataSizeInBytes * reglist.size))));
 						}
+					default:
+						il.AddInstruction(il.Unimplemented());
+						break;
 					}
 				});
 			break;


### PR DESCRIPTION
This pr adds support for the multiple single elements variant of the vld1 instruction.
A new struct `DoubleWordRegisterList` is added to represent register lists and a function `ReadRegisterList` to read it is added.
A utility function `GetDataTypeSize` is also added to return the size of a instruction datatype in bits.
A visual comparison of llil before and after.
# Before
<img width="683" height="52" alt="image" src="https://github.com/user-attachments/assets/56d26c4d-0f15-4574-bfdc-295d2a281b6b" />
# After
<img width="268" height="178" alt="image" src="https://github.com/user-attachments/assets/a44fa6b9-838e-47f3-8357-a698de650337" />
