### PR TITLE
[PPC_SPE] Fix incorrect operand decoding for EVX conversion instructions

### DIFF
--- a/arch/powerpc/decode/operands.c
+++ b/arch/powerpc/decode/operands.c
@@ -2868,7 +2868,7 @@ void FillOperands32(Instruction* instruction, uint32_t word32, uint64_t address)
 		case PPC_ID_SPE_EVFSCTUI:
 		case PPC_ID_SPE_EVFSCTUIZ:
 			PushRD(instruction, word32);
-			PushRA(instruction, word32);
+			PushRB(instruction, word32);
 			break;
 
 		// crfD//, rA, rB


### PR DESCRIPTION
### Description
Fixes incorrect operand decoding for PowerPC SPE EVX instructions like efdcfs.

### The Bug
Instructions like `efsctuiz rD, rB` mistakenly used `PushRA` instead of `PushRB` when parsing the source operand (`rB`).
This occurred despite correct comments, likely due to a typo or copy-paste error during implementation.

### The Fix
Changed the incorrect `PushRA` call to the correct `PushRB` call for the source operand (`rB`).

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5120f2fa-ee59-40c7-90ee-a8c6a662d405" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/f7412da9-8f12-414b-b61a-ed1fca7c9f4a" />
