### PR TITLE
[PPCVLE] Correct si_split16 immediate decoding for I16A-form instructions

### DIFF
--- a/arch/powerpc/decode/vle32.c
+++ b/arch/powerpc/decode/vle32.c
@@ -326,7 +326,7 @@ static uint32_t ComputeSCI8(uint32_t word32) {
 
 static void FillOperands32Vle(Instruction* instruction, uint32_t word32, uint64_t address, bool translate)
 {
-	uint16_t ui0_4 = (word32 >> 16) & 0x1f;
+	uint16_t ui0_4 = (word32 >> 21) & 0x1f;
 	uint16_t ui5_15 = word32 & 0x7ff;
 	uint32_t ui_split16 = (ui0_4 << 11) | ui5_15;
 	int32_t si_split16 = (int32_t)(int16_t)(uint16_t)(ui_split16);


### PR DESCRIPTION
### Description
This PR fixes a bug where the 16-bit signed immediate (si_split16) for VLE I16A-form instructions (e.g., e_add2i, e_add2is, e_mull2i, e_cmp16i, e_cmph16i, e_cmpl16i, e_cmphl16i) was decoded incorrectly.

### The Bug
The upper 5 bits of the immediate (ui0_4) were being extracted from the wrong field in the instruction word. The code was using (`word32 >> 16`), which reads from the rD register field, instead of the correct (`word32 >> 21`).
<img width="300" alt="image" src="https://github.com/user-attachments/assets/acf270bd-11ed-486d-acc5-7d71b9bcf239" />


### The Fix
Modified vle32.c in the FillOperands32Vle function:
Changed the bit shift for ui0_4 from `>>16` to `>>21`.
This ensures the si_split16 immediate value is now calculated correctly for all I16A-form instructions.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/9851bfa8-bcf4-4762-971b-2332c123a025" />
