### PR TITLE
[PPCVLE] Fix I16L-form immediate decoding: use 5-bit mask for ui0_4

### DIFF
--- a/arch/powerpc/decode/vle32.c
+++ b/arch/powerpc/decode/vle32.c
@@ -383,9 +383,10 @@ static void FillOperands32Vle(Instruction* instruction, uint32_t word32, uint64_
 		case PPC_ID_VLE_E_AND2IS:
 		case PPC_ID_VLE_E_OR2I:
 		case PPC_ID_VLE_E_OR2IS:
+		case PPC_ID_VLE_E_LIS:
 		{
 			uint32_t ui5_15 = word32 & 0x7ff;
-			uint32_t ui0_4 = (word32 >> 16) & 0xf;
+			uint32_t ui0_4 = (word32 >> 16) & 0x1f;
 			uint32_t ui = (ui0_4 << 11) | ui5_15;
 
 			PushRA(instruction, word32);
@@ -621,11 +622,6 @@ static void FillOperands32Vle(Instruction* instruction, uint32_t word32, uint64_
 			PushSIMMValue(instruction, signed_li20);
 			break;
 		}
-
-		case PPC_ID_VLE_E_LIS:
-			PushRD(instruction, word32);
-			PushUIMMValue(instruction, ui_split16);
-			break;
 
 		case PPC_ID_VLE_E_MCRF:
 			PushCRFD(instruction, word32);


### PR DESCRIPTION
### Issue
VLE I16L-form instructions (`e_and2i`, `e_and2is`, `e_or2i`, `e_or2is`, `e_lis`) 
decoded incorrect immediate values due to wrong bit mask.
<img width="450" alt="image" src="https://github.com/user-attachments/assets/624e1399-f810-4b3a-a622-230f032a0b01" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/8a2a17a0-2771-4e37-b596-cc4e458e7dc9" />

### Fix
Changed `ui0_4` mask from `0xf` (4-bit) to `0x1f` (5-bit) to match PowerPC VLE 
I16L-form specification where UI = ui[0-4] || ui[5-15].
<img width="450" alt="image" src="https://github.com/user-attachments/assets/b30571a5-4240-4e71-ac84-e985bfabc9bf" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/be4fe20b-4a37-4fc2-962d-b9953190bd10" />

### Impact
Immediate values are now correctly parsed for all I16L-form instructions.