### PR TITLE
[PPCVLE] Fix VLE I16L-form instruction register operand decoding

### DIFF
--- a/arch/powerpc/decode/vle32.c
+++ b/arch/powerpc/decode/vle32.c
@@ -389,10 +389,7 @@ static void FillOperands32Vle(Instruction* instruction, uint32_t word32, uint64_
 			uint32_t ui0_4 = (word32 >> 16) & 0x1f;
 			uint32_t ui = (ui0_4 << 11) | ui5_15;
 
-			PushRA(instruction, word32);
-			if (translate)
-				PushRS(instruction, word32);
-
+			PushRD(instruction, word32);
 			PushUIMMValue(instruction, ui);
 			if ((instruction->id == PPC_ID_VLE_E_AND2I) || (instruction->id == PPC_ID_VLE_E_AND2IS))
 				instruction->flags.rc = true;

--- a/arch/powerpc/decode/vle32.c
+++ b/arch/powerpc/decode/vle32.c
@@ -383,7 +383,7 @@ static void FillOperands32Vle(Instruction* instruction, uint32_t word32, uint64_
 		case PPC_ID_VLE_E_AND2IS:
 		case PPC_ID_VLE_E_OR2I:
 		case PPC_ID_VLE_E_OR2IS:
-		case PPC_ID_VLE_E_LIS:
+		{
 			uint32_t ui5_15 = word32 & 0x7ff;
 			uint32_t ui0_4 = (word32 >> 16) & 0x1f;
 			uint32_t ui = (ui0_4 << 11) | ui5_15;
@@ -396,6 +396,17 @@ static void FillOperands32Vle(Instruction* instruction, uint32_t word32, uint64_
 			if ((instruction->id == PPC_ID_VLE_E_AND2I) || (instruction->id == PPC_ID_VLE_E_AND2IS))
 				instruction->flags.rc = true;
 			break;
+		}
+
+		case PPC_ID_VLE_E_LIS:
+		{
+			uint32_t ui5_15 = word32 & 0x7ff;
+			uint32_t ui0_4 = (word32 >> 16) & 0x1f;
+			uint32_t ui = (ui0_4 << 11) | ui5_15;
+			PushRD(instruction, word32);
+			PushUIMMValue(instruction, ui);
+			break;
+		}
 
 		// <op>[.] rA, rS, SH
 		case PPC_ID_VLE_E_RLWIx:

--- a/arch/powerpc/decode/vle32.c
+++ b/arch/powerpc/decode/vle32.c
@@ -384,17 +384,18 @@ static void FillOperands32Vle(Instruction* instruction, uint32_t word32, uint64_
 		case PPC_ID_VLE_E_OR2I:
 		case PPC_ID_VLE_E_OR2IS:
 		case PPC_ID_VLE_E_LIS:
-		{
 			uint32_t ui5_15 = word32 & 0x7ff;
 			uint32_t ui0_4 = (word32 >> 16) & 0x1f;
 			uint32_t ui = (ui0_4 << 11) | ui5_15;
 
 			PushRD(instruction, word32);
+			if (translate)
+				PushRS(instruction, word32);
+				
 			PushUIMMValue(instruction, ui);
 			if ((instruction->id == PPC_ID_VLE_E_AND2I) || (instruction->id == PPC_ID_VLE_E_AND2IS))
 				instruction->flags.rc = true;
 			break;
-		}
 
 		// <op>[.] rA, rS, SH
 		case PPC_ID_VLE_E_RLWIx:


### PR DESCRIPTION
### Issue
VLE I16L-form instructions (`e_and2i`, `e_and2is`, `e_or2i`, `e_or2is`, `e_lis`) 
used `PushRA` instead of `PushRD`, causing incorrect register operand decoding.

### Changes
- Changed `PushRA` to `PushRD` for all I16L-form instructions per VLE specification
- Separated `e_lis` case to remove unnecessary `PushRS` call in translate mode

### Impact
I16L-form instructions now correctly decode the destination register as rD.