### PR TITLE
[PPCVLE] Fix VLE ANDIx translation to always store result in destination register

### DIFF
--- a/arch/powerpc/il.cpp
+++ b/arch/powerpc/il.cpp
@@ -660,8 +660,9 @@ bool GetLowLevelILForPPCInstruction(Architecture *arch, LowLevelILFunction &il,
 
 			// VLE instructions that get translated to ANDIx may
 			// not have the rc bit set
-			if (instruction->flags.rc)
-				ei0 = il.SetRegister(addressSize_l, oper0->reg, ei0, IL_FLAGWRITE_CR0_S);
+			ei0 = il.SetRegister(addressSize_l, oper0->reg, ei0,
+				instruction->flags.rc ? IL_FLAGWRITE_CR0_S : 0
+			);
 			il.AddInstruction(ei0);
 			break;
 


### PR DESCRIPTION
### Issue
VLE instructions translated to ANDIx (e.g., `e_andi`, `e_and2i`) did not store 
results in the destination register when the rc flag was not set.

### Fix
Changed `SetRegister` to always store the result, with conditional flag writing 
based on `instruction->flags.rc`.

### Impact
VLE ANDIx-family instructions now correctly store computation results regardless 
of rc flag state.