### PR TITLE
handle None cases when empty strings are returned from the core

### DIFF
--- a/python/__init__.py
+++ b/python/__init__.py
@@ -164,7 +164,7 @@ class CoreVersionInfo:
 			self.major = core_version_info.major
 			self.minor = core_version_info.minor
 			self.build = core_version_info.build
-			if core_version_info._channel is not None:
+			if core_version_info.channel is not None:
 				self.channel = core_version_info.channel
 		else:
 			self.major = major

--- a/python/compatibility.py
+++ b/python/compatibility.py
@@ -22,7 +22,7 @@ import sys
 
 
 def pyNativeStr(arg):
-	if isinstance(arg, str):
+	if arg is None or isinstance(arg, str):
 		return arg
 	else:
 		try:

--- a/python/generator.cpp
+++ b/python/generator.cpp
@@ -284,7 +284,7 @@ int main(int argc, char* argv[])
 	fprintf(out, "	return var.encode(\"utf-8\")\n\n\n");
 
 	fprintf(out, "def pyNativeStr(arg: AnyStr) -> str:\n");
-	fprintf(out, "	if isinstance(arg, str):\n");
+	fprintf(out, "	if arg is None or isinstance(arg, str):\n");
 	fprintf(out, "		return arg\n");
 	fprintf(out, "	else:\n");
 	fprintf(out, "		try:\n");

--- a/python/generator.cpp
+++ b/python/generator.cpp
@@ -283,7 +283,7 @@ int main(int argc, char* argv[])
 	fprintf(out, "		return var\n");
 	fprintf(out, "	return var.encode(\"utf-8\")\n\n\n");
 
-	fprintf(out, "def pyNativeStr(arg: AnyStr) -> str:\n");
+	fprintf(out, "def pyNativeStr(arg: Optional[AnyStr]) -> Optional[str]:\n");
 	fprintf(out, "	if arg is None or isinstance(arg, str):\n");
 	fprintf(out, "		return arg\n");
 	fprintf(out, "	else:\n");

--- a/python/typeparser.py
+++ b/python/typeparser.py
@@ -324,7 +324,7 @@ class TypeParser(metaclass=_TypeParserMetaclass):
 			for i in range(includeDirCount):
 				include_dirs_py.append(core.pyNativeStr(includeDirs[i]))
 
-			auto_type_source = core.pyNativeStr(autoTypeSource)
+			auto_type_source = core.pyNativeStr(autoTypeSource) or ""
 
 			(result_py, errors_py) = self.parse_types_from_source(
 				source_py, file_name_py, platform_py, existing_types_py, options_py,


### PR DESCRIPTION
Prior to this commit (and the broken "fix" before it in [ac909374541f32697a065c43e7e12c5d6916f937](https://github.com/Vector35/binaryninja-api/commit/ac909374541f32697a065c43e7e12c5d6916f937#diff-6782036b11fde2c417fa4d886777898de32ff7edff2d3d0e6171614516127f3aR167-R168)), the following API failed:

`CoreVersionInfo("4.2.0")` 

This resolves the issue by checking if a string is empty before trying to decode it and failing. 