### PR TITLE
[KernelCache] Remove 'Load Selected Image and Dependencies'

### DIFF
--- a/view/kernelcache/ui/kctriage.cpp
+++ b/view/kernelcache/ui/kctriage.cpp
@@ -208,7 +208,6 @@ QWidget* KCTriageView::initImageTable()
 
 		QAction noSelectionAction("No Images Selected", m_imageTable);
 		QAction loadImagesAction("", m_imageTable);
-		QAction loadImagesWithDepsAction("", m_imageTable);
 		if (selectedCount == 0)
 		{
 			noSelectionAction.setEnabled(false);
@@ -223,14 +222,6 @@ QWidget* KCTriageView::initImageTable()
 				loadImagesWithAddr(addresses, false);
 			});
 			contextMenu.addAction(&loadImagesAction);
-
-			// Format action text for loading selected images with dependencies
-			QString loadWithDepsActionText = (selectedCount == 1) ? "Load Selected Image and Dependencies" : QString("Load %1 Selected Images and Dependencies").arg(selectedCount);
-			loadImagesWithDepsAction.setText(loadWithDepsActionText);
-			connect(&loadImagesWithDepsAction, &QAction::triggered, [this, addresses]() {
-				this->loadImagesWithAddr(addresses, true);
-			});
-			contextMenu.addAction(&loadImagesWithDepsAction);
 		}
 
 		contextMenu.exec(m_imageTable->viewport()->mapToGlobal(pos));


### PR DESCRIPTION
Fixes https://github.com/Vector35/binaryninja-api/issues/7615.

The dependency loading for kernel cache images was copied from the shared cache code, and looks for `LC_LOAD_DYLIB` load commands to determine the direct dependencies of an image. Images in kernel caches don't use `LC_LOAD_DYLIB` load commands so no dependencies were ever loaded. It could, however, result in a crash.