### PR TITLE
[DWARF] Prevent extra slashes in generated debuginfod urls

### DIFF
--- a/plugins/dwarf/dwarf_import/src/helpers.rs
+++ b/plugins/dwarf/dwarf_import/src/helpers.rs
@@ -453,7 +453,11 @@ pub(crate) fn download_debug_info(
         settings.get_string_list_with_opts("network.debuginfodServers", &mut settings_query_opts);
 
     for debug_server_url in debug_server_urls.iter() {
-        let artifact_url = format!("{}/buildid/{}/debuginfo", debug_server_url, build_id);
+        let artifact_url = format!(
+            "{}/buildid/{}/debuginfo",
+            debug_server_url.trim_end_matches("/"),
+            build_id
+        );
 
         // Download from remote
         let (tx, rx) = mpsc::channel();


### PR DESCRIPTION
debuginfod.elfutils.org recently changed behavior and now they don't handle extra slashes in URLs gracefully. This fixes loading of DWARF info from debuginfod servers when the configured URLs end with a slash

To test:
1. Enable `network.enableDebuginfod`
2. Set `network.debuginfodServers` to `["https://debuginfod.elfutils.org/"]`
3. Open [true.txt](https://github.com/user-attachments/files/23485656/true.txt)
4. You should see debug info being applied in the log
