### PR TITLE
[WARP] Fix unused rerun matcher checkbox when loading file on disk

### DIFF
--- a/plugins/warp/src/plugin/load.rs
+++ b/plugins/warp/src/plugin/load.rs
@@ -49,7 +49,7 @@ impl RunMatcherField {
 
     pub fn from_form(form: &Form) -> Option<bool> {
         let field = form.get_field_with_name("Rerun Matcher")?;
-        let field_value = field.try_value_index()?;
+        let field_value = field.try_value_int()?;
         match field_value {
             1 => Some(true),
             _ => Some(false),


### PR DESCRIPTION
When running the command "WARP\\Load File" we had a checkbox that is used to prompt the matcher to run again after loading that was never properly checked, requiring users to manually go and run the matcher again