### PR TITLE
STABLE: [WARP] Fix processor leaking "empty" binary views

### DIFF
--- a/plugins/warp/src/processor.rs
+++ b/plugins/warp/src/processor.rs
@@ -772,6 +772,10 @@ impl WarpFileProcessor {
             })
             .filter_map(|res| match res {
                 Ok(result) => Some(Ok(result)),
+                Err(ProcessingError::SkippedFile(path)) => {
+                    log::debug!("Skipping archive file: {:?}", path);
+                    None
+                }
                 Err(ProcessingError::Cancelled) => Some(Err(ProcessingError::Cancelled)),
                 Err(e) => {
                     log::error!("Archive file processing error: {:?}", e);

--- a/plugins/warp/src/processor.rs
+++ b/plugins/warp/src/processor.rs
@@ -664,6 +664,8 @@ impl WarpFileProcessor {
         if view.functions().is_empty() {
             self.state
                 .set_file_state(path.clone(), ProcessingFileState::Processed);
+            // Close the view manually, see comment in [`BinaryView`].
+            view.file().close();
             return Err(ProcessingError::SkippedFile(path));
         }
 


### PR DESCRIPTION
0. Can only be done on commercial
1. Create a new empty project
2. Add [nofunctions.dll.zip](https://github.com/user-attachments/files/23887710/nofunctions.dll.zip) to the project
3. Right click in the file browser and run "WARP" -> "Create" -> "From Project" with default settings
4. Run `get_memory_usage_info()` and verify no binary view objects.
