### PR TITLE
[ObjC] Support removing reference counting operations in more places in the shared cache

### DIFF
--- a/plugins/workflow_objc/src/activities/remove_memory_management.rs
+++ b/plugins/workflow_objc/src/activities/remove_memory_management.rs
@@ -11,6 +11,7 @@ use binaryninja::{
         lifting::LowLevelILLabel,
         LowLevelILRegisterKind,
     },
+    variable::PossibleValueSet,
     workflow::AnalysisContext,
 };
 
@@ -36,10 +37,12 @@ fn is_call_to_ignorable_memory_management_function<'func>(
 ) -> bool {
     let target = match instr.kind() {
         LowLevelILInstructionKind::Call(call) | LowLevelILInstructionKind::TailCall(call) => {
-            let LowLevelILExpressionKind::ConstPtr(address) = call.target().kind() else {
-                return false;
-            };
-            address.value()
+            match call.target().possible_values() {
+                PossibleValueSet::ConstantValue { value }
+                | PossibleValueSet::ConstantPointerValue { value }
+                | PossibleValueSet::ImportedAddressValue { value } => value as u64,
+                _ => return false,
+            }
         }
         LowLevelILInstructionKind::Goto(target) => target.address(),
         _ => return false,


### PR DESCRIPTION
Dataflow is now used to determine call targets when detecting calls to reference counting runtime functions. The previous approach of matching on specific instructions missed some patterns that are common in the shared cache.