### PR TITLE
Allow overriding the IL source location that is used by *ILInstruction::CopyTo

### DIFF
--- a/highlevelilinstruction.cpp
+++ b/highlevelilinstruction.cpp
@@ -1370,162 +1370,165 @@ void HighLevelILInstruction::VisitExprs(const std::function<bool(const HighLevel
 }
 
 
-ExprId HighLevelILInstruction::CopyTo(HighLevelILFunction* dest) const
+ExprId HighLevelILInstruction::CopyTo(HighLevelILFunction* dest, const ILSourceLocation& sourceLocation) const
 {
-	return CopyTo(dest, [&](const HighLevelILInstruction& subExpr) { return subExpr.CopyTo(dest); });
+	return CopyTo(dest, [&](const HighLevelILInstruction& subExpr) { return subExpr.CopyTo(dest, sourceLocation); }, sourceLocation);
 }
 
 
 ExprId HighLevelILInstruction::CopyTo(
-    HighLevelILFunction* dest, const std::function<ExprId(const HighLevelILInstruction& subExpr)>& subExprHandler) const
+    HighLevelILFunction* dest, const std::function<ExprId(const HighLevelILInstruction& subExpr)>& subExprHandler, const ILSourceLocation& sourceLocation) const
 {
 	vector<ExprId> output, params;
+
+	const auto& loc = sourceLocation.valid ? sourceLocation : ILSourceLocation{*this};
+
 	switch (operation)
 	{
 	case HLIL_NOP:
-		return dest->Nop(*this);
+		return dest->Nop(loc);
 	case HLIL_BLOCK:
 		for (auto i : GetBlockExprs<HLIL_BLOCK>())
 			params.push_back(subExprHandler(i));
-		return dest->Block(params, *this);
+		return dest->Block(params, loc);
 	case HLIL_IF:
 		return dest->If(subExprHandler(GetConditionExpr<HLIL_IF>()), subExprHandler(GetTrueExpr<HLIL_IF>()),
-		    subExprHandler(GetFalseExpr<HLIL_IF>()), *this);
+		    subExprHandler(GetFalseExpr<HLIL_IF>()), loc);
 	case HLIL_WHILE:
 		return dest->While(
-		    subExprHandler(GetConditionExpr<HLIL_WHILE>()), subExprHandler(GetLoopExpr<HLIL_WHILE>()), *this);
+		    subExprHandler(GetConditionExpr<HLIL_WHILE>()), subExprHandler(GetLoopExpr<HLIL_WHILE>()), loc);
 	case HLIL_WHILE_SSA:
 		return dest->WhileSSA(subExprHandler(GetConditionPhiExpr<HLIL_WHILE_SSA>()),
-		    subExprHandler(GetConditionExpr<HLIL_WHILE_SSA>()), subExprHandler(GetLoopExpr<HLIL_WHILE_SSA>()), *this);
+		    subExprHandler(GetConditionExpr<HLIL_WHILE_SSA>()), subExprHandler(GetLoopExpr<HLIL_WHILE_SSA>()), loc);
 	case HLIL_DO_WHILE:
 		return dest->DoWhile(
-		    subExprHandler(GetLoopExpr<HLIL_DO_WHILE>()), subExprHandler(GetConditionExpr<HLIL_DO_WHILE>()), *this);
+		    subExprHandler(GetLoopExpr<HLIL_DO_WHILE>()), subExprHandler(GetConditionExpr<HLIL_DO_WHILE>()), loc);
 	case HLIL_DO_WHILE_SSA:
 		return dest->DoWhileSSA(subExprHandler(GetLoopExpr<HLIL_DO_WHILE_SSA>()),
 		    subExprHandler(GetConditionPhiExpr<HLIL_DO_WHILE_SSA>()),
-		    subExprHandler(GetConditionExpr<HLIL_DO_WHILE_SSA>()), *this);
+		    subExprHandler(GetConditionExpr<HLIL_DO_WHILE_SSA>()), loc);
 	case HLIL_FOR:
 		return dest->For(subExprHandler(GetInitExpr<HLIL_FOR>()), subExprHandler(GetConditionExpr<HLIL_FOR>()),
-		    subExprHandler(GetUpdateExpr<HLIL_FOR>()), subExprHandler(GetLoopExpr<HLIL_FOR>()), *this);
+		    subExprHandler(GetUpdateExpr<HLIL_FOR>()), subExprHandler(GetLoopExpr<HLIL_FOR>()), loc);
 	case HLIL_FOR_SSA:
 		return dest->ForSSA(subExprHandler(GetInitExpr<HLIL_FOR_SSA>()),
 		    subExprHandler(GetConditionPhiExpr<HLIL_FOR_SSA>()), subExprHandler(GetConditionExpr<HLIL_FOR_SSA>()),
-		    subExprHandler(GetUpdateExpr<HLIL_FOR_SSA>()), subExprHandler(GetLoopExpr<HLIL_FOR_SSA>()), *this);
+		    subExprHandler(GetUpdateExpr<HLIL_FOR_SSA>()), subExprHandler(GetLoopExpr<HLIL_FOR_SSA>()), loc);
 	case HLIL_SWITCH:
 		for (auto i : GetCases<HLIL_SWITCH>())
 			params.push_back(subExprHandler(i));
 		return dest->Switch(subExprHandler(GetConditionExpr<HLIL_SWITCH>()),
-		    subExprHandler(GetDefaultExpr<HLIL_SWITCH>()), params, *this);
+		    subExprHandler(GetDefaultExpr<HLIL_SWITCH>()), params, loc);
 	case HLIL_CASE:
 		for (auto i : GetValueExprs<HLIL_CASE>())
 			params.push_back(subExprHandler(i));
-		return dest->Case(params, subExprHandler(GetTrueExpr<HLIL_CASE>()), *this);
+		return dest->Case(params, subExprHandler(GetTrueExpr<HLIL_CASE>()), loc);
 	case HLIL_BREAK:
-		return dest->Break(*this);
+		return dest->Break(loc);
 	case HLIL_CONTINUE:
-		return dest->Continue(*this);
+		return dest->Continue(loc);
 	case HLIL_GOTO:
-		return dest->Goto(GetTarget<HLIL_GOTO>(), *this);
+		return dest->Goto(GetTarget<HLIL_GOTO>(), loc);
 	case HLIL_LABEL:
-		return dest->Label(GetTarget<HLIL_LABEL>(), *this);
+		return dest->Label(GetTarget<HLIL_LABEL>(), loc);
 	case HLIL_VAR_DECLARE:
-		return dest->VarDeclare(GetVariable<HLIL_VAR_DECLARE>(), *this);
+		return dest->VarDeclare(GetVariable<HLIL_VAR_DECLARE>(), loc);
 	case HLIL_VAR_INIT:
 		return dest->VarInit(
-		    size, GetDestVariable<HLIL_VAR_INIT>(), subExprHandler(GetSourceExpr<HLIL_VAR_INIT>()), *this);
+		    size, GetDestVariable<HLIL_VAR_INIT>(), subExprHandler(GetSourceExpr<HLIL_VAR_INIT>()), loc);
 	case HLIL_VAR_INIT_SSA:
 		return dest->VarInitSSA(
-		    size, GetDestSSAVariable<HLIL_VAR_INIT_SSA>(), subExprHandler(GetSourceExpr<HLIL_VAR_INIT_SSA>()), *this);
+		    size, GetDestSSAVariable<HLIL_VAR_INIT_SSA>(), subExprHandler(GetSourceExpr<HLIL_VAR_INIT_SSA>()), loc);
 	case HLIL_ASSIGN:
 		return dest->Assign(
-		    size, subExprHandler(GetDestExpr<HLIL_ASSIGN>()), subExprHandler(GetSourceExpr<HLIL_ASSIGN>()), *this);
+		    size, subExprHandler(GetDestExpr<HLIL_ASSIGN>()), subExprHandler(GetSourceExpr<HLIL_ASSIGN>()), loc);
 	case HLIL_ASSIGN_UNPACK:
 		for (auto i : GetDestExprs<HLIL_ASSIGN_UNPACK>())
 			output.push_back(subExprHandler(i));
-		return dest->AssignUnpack(output, subExprHandler(GetSourceExpr<HLIL_ASSIGN_UNPACK>()), *this);
+		return dest->AssignUnpack(output, subExprHandler(GetSourceExpr<HLIL_ASSIGN_UNPACK>()), loc);
 	case HLIL_ASSIGN_MEM_SSA:
 		return dest->AssignMemSSA(size, subExprHandler(GetDestExpr<HLIL_ASSIGN_MEM_SSA>()),
 		    GetDestMemoryVersion<HLIL_ASSIGN_MEM_SSA>(), subExprHandler(GetSourceExpr<HLIL_ASSIGN_MEM_SSA>()),
-		    GetSourceMemoryVersion<HLIL_ASSIGN_MEM_SSA>(), *this);
+		    GetSourceMemoryVersion<HLIL_ASSIGN_MEM_SSA>(), loc);
 	case HLIL_ASSIGN_UNPACK_MEM_SSA:
 		for (auto i : GetDestExprs<HLIL_ASSIGN_UNPACK_MEM_SSA>())
 			output.push_back(subExprHandler(i));
 		return dest->AssignUnpackMemSSA(output, GetDestMemoryVersion<HLIL_ASSIGN_UNPACK_MEM_SSA>(),
 		    subExprHandler(GetSourceExpr<HLIL_ASSIGN_UNPACK_MEM_SSA>()),
-		    GetSourceMemoryVersion<HLIL_ASSIGN_UNPACK_MEM_SSA>(), *this);
+		    GetSourceMemoryVersion<HLIL_ASSIGN_UNPACK_MEM_SSA>(), loc);
 	case HLIL_FORCE_VER:
-		return dest->ForceVer(size, GetDestVariable<HLIL_FORCE_VER>(), GetVariable<HLIL_FORCE_VER>(), *this);
+		return dest->ForceVer(size, GetDestVariable<HLIL_FORCE_VER>(), GetVariable<HLIL_FORCE_VER>(), loc);
 	case HLIL_FORCE_VER_SSA:
-		return dest->ForceVerSSA(size, GetDestSSAVariable<HLIL_FORCE_VER_SSA>(), GetSSAVariable<HLIL_FORCE_VER_SSA>(), *this);
+		return dest->ForceVerSSA(size, GetDestSSAVariable<HLIL_FORCE_VER_SSA>(), GetSSAVariable<HLIL_FORCE_VER_SSA>(), loc);
 	case HLIL_ASSERT:
-		return dest->Assert(size, GetVariable<HLIL_ASSERT>(), GetConstraint<HLIL_ASSERT>(), *this);
+		return dest->Assert(size, GetVariable<HLIL_ASSERT>(), GetConstraint<HLIL_ASSERT>(), loc);
 	case HLIL_ASSERT_SSA:
-		return dest->AssertSSA(size, GetSSAVariable<HLIL_ASSERT_SSA>(), GetConstraint<HLIL_ASSERT_SSA>(), *this);
+		return dest->AssertSSA(size, GetSSAVariable<HLIL_ASSERT_SSA>(), GetConstraint<HLIL_ASSERT_SSA>(), loc);
 	case HLIL_VAR:
-		return dest->Var(size, GetVariable<HLIL_VAR>(), *this);
+		return dest->Var(size, GetVariable<HLIL_VAR>(), loc);
 	case HLIL_VAR_SSA:
-		return dest->VarSSA(size, GetSSAVariable<HLIL_VAR_SSA>(), *this);
+		return dest->VarSSA(size, GetSSAVariable<HLIL_VAR_SSA>(), loc);
 	case HLIL_VAR_PHI:
-		return dest->VarPhi(GetDestSSAVariable<HLIL_VAR_PHI>(), GetSourceSSAVariables<HLIL_VAR_PHI>(), *this);
+		return dest->VarPhi(GetDestSSAVariable<HLIL_VAR_PHI>(), GetSourceSSAVariables<HLIL_VAR_PHI>(), loc);
 	case HLIL_MEM_PHI:
-		return dest->MemPhi(GetDestMemoryVersion<HLIL_MEM_PHI>(), GetSourceMemoryVersions<HLIL_MEM_PHI>(), *this);
+		return dest->MemPhi(GetDestMemoryVersion<HLIL_MEM_PHI>(), GetSourceMemoryVersions<HLIL_MEM_PHI>(), loc);
 	case HLIL_STRUCT_FIELD:
 		return dest->StructField(size, subExprHandler(GetSourceExpr<HLIL_STRUCT_FIELD>()),
-		    GetOffset<HLIL_STRUCT_FIELD>(), GetMemberIndex<HLIL_STRUCT_FIELD>(), *this);
+		    GetOffset<HLIL_STRUCT_FIELD>(), GetMemberIndex<HLIL_STRUCT_FIELD>(), loc);
 	case HLIL_ARRAY_INDEX:
 		return dest->ArrayIndex(size, subExprHandler(GetSourceExpr<HLIL_ARRAY_INDEX>()),
-		    subExprHandler(GetIndexExpr<HLIL_ARRAY_INDEX>()), *this);
+		    subExprHandler(GetIndexExpr<HLIL_ARRAY_INDEX>()), loc);
 	case HLIL_ARRAY_INDEX_SSA:
 		return dest->ArrayIndexSSA(size, subExprHandler(GetSourceExpr<HLIL_ARRAY_INDEX_SSA>()),
 		    GetSourceMemoryVersion<HLIL_ARRAY_INDEX_SSA>(), subExprHandler(GetIndexExpr<HLIL_ARRAY_INDEX_SSA>()),
-		    *this);
+		    loc);
 	case HLIL_SPLIT:
 		return dest->Split(
-		    size, subExprHandler(GetHighExpr<HLIL_SPLIT>()), subExprHandler(GetLowExpr<HLIL_SPLIT>()), *this);
+		    size, subExprHandler(GetHighExpr<HLIL_SPLIT>()), subExprHandler(GetLowExpr<HLIL_SPLIT>()), loc);
 	case HLIL_DEREF:
-		return dest->Deref(size, subExprHandler(GetSourceExpr<HLIL_DEREF>()), *this);
+		return dest->Deref(size, subExprHandler(GetSourceExpr<HLIL_DEREF>()), loc);
 	case HLIL_DEREF_FIELD:
 		return dest->DerefField(size, subExprHandler(GetSourceExpr<HLIL_DEREF_FIELD>()), GetOffset<HLIL_DEREF_FIELD>(),
-		    GetMemberIndex<HLIL_DEREF_FIELD>(), *this);
+		    GetMemberIndex<HLIL_DEREF_FIELD>(), loc);
 	case HLIL_DEREF_SSA:
 		return dest->DerefSSA(
-		    size, subExprHandler(GetSourceExpr<HLIL_DEREF_SSA>()), GetSourceMemoryVersion<HLIL_DEREF_SSA>(), *this);
+		    size, subExprHandler(GetSourceExpr<HLIL_DEREF_SSA>()), GetSourceMemoryVersion<HLIL_DEREF_SSA>(), loc);
 	case HLIL_DEREF_FIELD_SSA:
 		return dest->DerefFieldSSA(size, subExprHandler(GetSourceExpr<HLIL_DEREF_FIELD_SSA>()),
 		    GetSourceMemoryVersion<HLIL_DEREF_FIELD_SSA>(), GetOffset<HLIL_DEREF_FIELD_SSA>(),
-		    GetMemberIndex<HLIL_DEREF_FIELD_SSA>(), *this);
+		    GetMemberIndex<HLIL_DEREF_FIELD_SSA>(), loc);
 	case HLIL_ADDRESS_OF:
-		return dest->AddressOf(subExprHandler(GetSourceExpr<HLIL_ADDRESS_OF>()), *this);
+		return dest->AddressOf(subExprHandler(GetSourceExpr<HLIL_ADDRESS_OF>()), loc);
 	case HLIL_CALL:
 		for (auto i : GetParameterExprs<HLIL_CALL>())
 			params.push_back(subExprHandler(i));
-		return dest->Call(subExprHandler(GetDestExpr<HLIL_CALL>()), params, *this);
+		return dest->Call(subExprHandler(GetDestExpr<HLIL_CALL>()), params, loc);
 	case HLIL_SYSCALL:
 		for (auto i : GetParameterExprs<HLIL_SYSCALL>())
 			params.push_back(subExprHandler(i));
-		return dest->Syscall(params, *this);
+		return dest->Syscall(params, loc);
 	case HLIL_TAILCALL:
 		for (auto i : GetParameterExprs<HLIL_TAILCALL>())
 			params.push_back(subExprHandler(i));
-		return dest->TailCall(subExprHandler(GetDestExpr<HLIL_TAILCALL>()), params, *this);
+		return dest->TailCall(subExprHandler(GetDestExpr<HLIL_TAILCALL>()), params, loc);
 	case HLIL_CALL_SSA:
 		for (auto i : GetParameterExprs<HLIL_CALL_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->CallSSA(subExprHandler(GetDestExpr<HLIL_CALL_SSA>()), params,
-		    GetDestMemoryVersion<HLIL_CALL_SSA>(), GetSourceMemoryVersion<HLIL_CALL_SSA>(), *this);
+		    GetDestMemoryVersion<HLIL_CALL_SSA>(), GetSourceMemoryVersion<HLIL_CALL_SSA>(), loc);
 	case HLIL_SYSCALL_SSA:
 		for (auto i : GetParameterExprs<HLIL_SYSCALL_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->SyscallSSA(
-		    params, GetDestMemoryVersion<HLIL_SYSCALL_SSA>(), GetSourceMemoryVersion<HLIL_SYSCALL_SSA>(), *this);
+		    params, GetDestMemoryVersion<HLIL_SYSCALL_SSA>(), GetSourceMemoryVersion<HLIL_SYSCALL_SSA>(), loc);
 	case HLIL_RET:
 		for (auto i : GetSourceExprs<HLIL_RET>())
 			params.push_back(subExprHandler(i));
-		return dest->Return(params, *this);
+		return dest->Return(params, loc);
 	case HLIL_NORET:
-		return dest->NoReturn(*this);
+		return dest->NoReturn(loc);
 	case HLIL_UNREACHABLE:
-		return dest->Unreachable(*this);
+		return dest->Unreachable(loc);
 	case HLIL_NEG:
 	case HLIL_NOT:
 	case HLIL_SX:
@@ -1544,7 +1547,7 @@ ExprId HighLevelILInstruction::CopyTo(
 	case HLIL_FLOOR:
 	case HLIL_CEIL:
 	case HLIL_FTRUNC:
-		return dest->AddExprWithLocation(operation, *this, size, subExprHandler(AsOneOperand().GetSourceExpr()));
+		return dest->AddExprWithLocation(operation, loc, size, subExprHandler(AsOneOperand().GetSourceExpr()));
 	case HLIL_ADD:
 	case HLIL_SUB:
 	case HLIL_AND:
@@ -1590,44 +1593,44 @@ ExprId HighLevelILInstruction::CopyTo(
 	case HLIL_FCMP_GT:
 	case HLIL_FCMP_O:
 	case HLIL_FCMP_UO:
-		return dest->AddExprWithLocation(operation, *this, size, subExprHandler(AsTwoOperand().GetLeftExpr()),
+		return dest->AddExprWithLocation(operation, loc, size, subExprHandler(AsTwoOperand().GetLeftExpr()),
 		    subExprHandler(AsTwoOperand().GetRightExpr()));
 	case HLIL_ADC:
 	case HLIL_SBB:
 	case HLIL_RLC:
 	case HLIL_RRC:
-		return dest->AddExprWithLocation(operation, *this, size, subExprHandler(AsTwoOperandWithCarry().GetLeftExpr()),
+		return dest->AddExprWithLocation(operation, loc, size, subExprHandler(AsTwoOperandWithCarry().GetLeftExpr()),
 		    subExprHandler(AsTwoOperandWithCarry().GetRightExpr()),
 		    subExprHandler(AsTwoOperandWithCarry().GetCarryExpr()));
 	case HLIL_CONST:
-		return dest->Const(size, GetConstant<HLIL_CONST>(), *this);
+		return dest->Const(size, GetConstant<HLIL_CONST>(), loc);
 	case HLIL_CONST_PTR:
-		return dest->ConstPointer(size, GetConstant<HLIL_CONST_PTR>(), *this);
+		return dest->ConstPointer(size, GetConstant<HLIL_CONST_PTR>(), loc);
 	case HLIL_EXTERN_PTR:
-		return dest->ExternPointer(size, GetConstant<HLIL_EXTERN_PTR>(), GetOffset<HLIL_EXTERN_PTR>(), *this);
+		return dest->ExternPointer(size, GetConstant<HLIL_EXTERN_PTR>(), GetOffset<HLIL_EXTERN_PTR>(), loc);
 	case HLIL_FLOAT_CONST:
-		return dest->FloatConstRaw(size, GetConstant<HLIL_FLOAT_CONST>(), *this);
+		return dest->FloatConstRaw(size, GetConstant<HLIL_FLOAT_CONST>(), loc);
 	case HLIL_IMPORT:
-		return dest->ImportedAddress(size, GetConstant<HLIL_IMPORT>(), *this);
+		return dest->ImportedAddress(size, GetConstant<HLIL_IMPORT>(), loc);
 	case HLIL_CONST_DATA:
-		return dest->ConstData(size, GetConstantData<HLIL_CONST_DATA>(), *this);
+		return dest->ConstData(size, GetConstantData<HLIL_CONST_DATA>(), loc);
 	case HLIL_BP:
-		return dest->Breakpoint(*this);
+		return dest->Breakpoint(loc);
 	case HLIL_TRAP:
-		return dest->Trap(GetVector<HLIL_TRAP>(), *this);
+		return dest->Trap(GetVector<HLIL_TRAP>(), loc);
 	case HLIL_INTRINSIC:
 		for (auto i : GetParameterExprs<HLIL_INTRINSIC>())
 			params.push_back(subExprHandler(i));
-		return dest->Intrinsic(GetIntrinsic<HLIL_INTRINSIC>(), params, *this);
+		return dest->Intrinsic(GetIntrinsic<HLIL_INTRINSIC>(), params, loc);
 	case HLIL_INTRINSIC_SSA:
 		for (auto i : GetParameterExprs<HLIL_INTRINSIC_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->IntrinsicSSA(GetIntrinsic<HLIL_INTRINSIC_SSA>(), params,
-		    GetDestMemoryVersion<HLIL_INTRINSIC_SSA>(), GetSourceMemoryVersion<HLIL_INTRINSIC_SSA>(), *this);
+		    GetDestMemoryVersion<HLIL_INTRINSIC_SSA>(), GetSourceMemoryVersion<HLIL_INTRINSIC_SSA>(), loc);
 	case HLIL_UNDEF:
-		return dest->Undefined(*this);
+		return dest->Undefined(loc);
 	case HLIL_UNIMPL:
-		return dest->Unimplemented(*this);
+		return dest->Unimplemented(loc);
 	default:
 		throw HighLevelILInstructionAccessException();
 	}

--- a/highlevelilinstruction.h
+++ b/highlevelilinstruction.h
@@ -25,6 +25,7 @@
 #include <vector>
 #ifdef BINARYNINJACORE_LIBRARY
 	#include "variable.h"
+	#include "ilsourcelocation.h"
 #else
 	#include "binaryninjaapi.h"
 #endif
@@ -487,9 +488,10 @@ namespace BinaryNinja
 		void VisitExprs(const std::function<bool(const HighLevelILInstruction& expr)>& preFunc,
 			const std::function<void(const HighLevelILInstruction& expr)>& postFunc) const;
 
-		ExprId CopyTo(HighLevelILFunction* dest) const;
+		ExprId CopyTo(HighLevelILFunction* dest, const ILSourceLocation& sourceLocation = {}) const;
 		ExprId CopyTo(HighLevelILFunction* dest,
-		    const std::function<ExprId(const HighLevelILInstruction& subExpr)>& subExprHandler) const;
+		    const std::function<ExprId(const HighLevelILInstruction& subExpr)>& subExprHandler,
+			const ILSourceLocation& sourceLocation = {}) const;
 
 		bool operator<(const HighLevelILInstruction& other) const;
 		bool operator==(const HighLevelILInstruction& other) const;

--- a/lowlevelilinstruction.cpp
+++ b/lowlevelilinstruction.cpp
@@ -2064,143 +2064,146 @@ void LowLevelILInstruction::VisitExprs(const std::function<bool(const LowLevelIL
 }
 
 
-ExprId LowLevelILInstruction::CopyTo(LowLevelILFunction* dest) const
+ExprId LowLevelILInstruction::CopyTo(LowLevelILFunction* dest, const ILSourceLocation& sourceLocation) const
 {
-	return CopyTo(dest, [&](const LowLevelILInstruction& subExpr) { return subExpr.CopyTo(dest); });
+	return CopyTo(dest, [&](const LowLevelILInstruction& subExpr) { return subExpr.CopyTo(dest, sourceLocation); }, sourceLocation);
 }
 
 
 ExprId LowLevelILInstruction::CopyTo(
-    LowLevelILFunction* dest, const std::function<ExprId(const LowLevelILInstruction& subExpr)>& subExprHandler) const
+    LowLevelILFunction* dest, const std::function<ExprId(const LowLevelILInstruction& subExpr)>& subExprHandler, const ILSourceLocation& sourceLocation) const
 {
 	vector<ExprId> params;
 	BNLowLevelILLabel* labelA;
 	BNLowLevelILLabel* labelB;
+
+	const auto& loc = sourceLocation.valid ? sourceLocation : ILSourceLocation{*this};
+
 	switch (operation)
 	{
 	case LLIL_NOP:
-		return dest->Nop();
+		return dest->Nop(loc);
 	case LLIL_SET_REG:
 		return dest->SetRegister(
-		    size, GetDestRegister<LLIL_SET_REG>(), subExprHandler(GetSourceExpr<LLIL_SET_REG>()), flags, *this);
+		    size, GetDestRegister<LLIL_SET_REG>(), subExprHandler(GetSourceExpr<LLIL_SET_REG>()), flags, loc);
 	case LLIL_SET_REG_SPLIT:
 		return dest->SetRegisterSplit(size, GetHighRegister<LLIL_SET_REG_SPLIT>(), GetLowRegister<LLIL_SET_REG_SPLIT>(),
-		    subExprHandler(GetSourceExpr<LLIL_SET_REG_SPLIT>()), flags, *this);
+		    subExprHandler(GetSourceExpr<LLIL_SET_REG_SPLIT>()), flags, loc);
 	case LLIL_SET_REG_SSA:
 		return dest->SetRegisterSSA(
-		    size, GetDestSSARegister<LLIL_SET_REG_SSA>(), subExprHandler(GetSourceExpr<LLIL_SET_REG_SSA>()), *this);
+		    size, GetDestSSARegister<LLIL_SET_REG_SSA>(), subExprHandler(GetSourceExpr<LLIL_SET_REG_SSA>()), loc);
 	case LLIL_SET_REG_SSA_PARTIAL:
 		return dest->SetRegisterSSAPartial(size, GetDestSSARegister<LLIL_SET_REG_SSA_PARTIAL>(),
 		    GetPartialRegister<LLIL_SET_REG_SSA_PARTIAL>(), subExprHandler(GetSourceExpr<LLIL_SET_REG_SSA_PARTIAL>()),
-		    *this);
+		    loc);
 	case LLIL_SET_REG_SPLIT_SSA:
 		return dest->SetRegisterSplitSSA(size, GetHighSSARegister<LLIL_SET_REG_SPLIT_SSA>(),
 		    GetLowSSARegister<LLIL_SET_REG_SPLIT_SSA>(), subExprHandler(GetSourceExpr<LLIL_SET_REG_SPLIT_SSA>()),
-		    *this);
+		    loc);
 	case LLIL_SET_REG_STACK_REL:
 		return dest->SetRegisterStackTopRelative(size, GetDestRegisterStack<LLIL_SET_REG_STACK_REL>(),
 		    subExprHandler(GetDestExpr<LLIL_SET_REG_STACK_REL>()),
-		    subExprHandler(GetSourceExpr<LLIL_SET_REG_STACK_REL>()), flags, *this);
+		    subExprHandler(GetSourceExpr<LLIL_SET_REG_STACK_REL>()), flags, loc);
 	case LLIL_REG_STACK_PUSH:
 		return dest->RegisterStackPush(size, GetDestRegisterStack<LLIL_REG_STACK_PUSH>(),
-		    subExprHandler(GetSourceExpr<LLIL_REG_STACK_PUSH>()), flags, *this);
+		    subExprHandler(GetSourceExpr<LLIL_REG_STACK_PUSH>()), flags, loc);
 	case LLIL_SET_REG_STACK_REL_SSA:
 		return dest->SetRegisterStackTopRelativeSSA(size,
 		    GetDestSSARegisterStack<LLIL_SET_REG_STACK_REL_SSA>().regStack,
 		    GetDestSSARegisterStack<LLIL_SET_REG_STACK_REL_SSA>().version,
 		    GetSourceSSARegisterStack<LLIL_SET_REG_STACK_REL_SSA>().version,
 		    subExprHandler(GetDestExpr<LLIL_SET_REG_STACK_REL_SSA>()), GetTopSSARegister<LLIL_SET_REG_STACK_REL_SSA>(),
-		    subExprHandler(GetSourceExpr<LLIL_SET_REG_STACK_REL_SSA>()), *this);
+		    subExprHandler(GetSourceExpr<LLIL_SET_REG_STACK_REL_SSA>()), loc);
 	case LLIL_SET_REG_STACK_ABS_SSA:
 		return dest->SetRegisterStackAbsoluteSSA(size, GetDestSSARegisterStack<LLIL_SET_REG_STACK_ABS_SSA>().regStack,
 		    GetDestSSARegisterStack<LLIL_SET_REG_STACK_ABS_SSA>().version,
 		    GetSourceSSARegisterStack<LLIL_SET_REG_STACK_ABS_SSA>().version,
 		    GetDestRegister<LLIL_SET_REG_STACK_ABS_SSA>(), subExprHandler(GetSourceExpr<LLIL_SET_REG_STACK_ABS_SSA>()),
-		    *this);
+		    loc);
 	case LLIL_SET_FLAG:
-		return dest->SetFlag(GetDestFlag<LLIL_SET_FLAG>(), subExprHandler(GetSourceExpr<LLIL_SET_FLAG>()), *this);
+		return dest->SetFlag(GetDestFlag<LLIL_SET_FLAG>(), subExprHandler(GetSourceExpr<LLIL_SET_FLAG>()), loc);
 	case LLIL_SET_FLAG_SSA:
 		return dest->SetFlagSSA(
-		    GetDestSSAFlag<LLIL_SET_FLAG_SSA>(), subExprHandler(GetSourceExpr<LLIL_SET_FLAG_SSA>()), *this);
+		    GetDestSSAFlag<LLIL_SET_FLAG_SSA>(), subExprHandler(GetSourceExpr<LLIL_SET_FLAG_SSA>()), loc);
 	case LLIL_FORCE_VER:
-		return dest->ForceVer(size, GetDestRegister<LLIL_FORCE_VER>(), *this);
+		return dest->ForceVer(size, GetDestRegister<LLIL_FORCE_VER>(), loc);
 	case LLIL_FORCE_VER_SSA:
-		return dest->ForceVerSSA(size, GetDestSSARegister<LLIL_FORCE_VER_SSA>(), GetSourceSSARegister<LLIL_FORCE_VER_SSA>(), *this);
+		return dest->ForceVerSSA(size, GetDestSSARegister<LLIL_FORCE_VER_SSA>(), GetSourceSSARegister<LLIL_FORCE_VER_SSA>(), loc);
 	case LLIL_ASSERT:
-		return dest->Assert(size, GetSourceRegister<LLIL_ASSERT>(), GetConstraint<LLIL_ASSERT>(), *this);
+		return dest->Assert(size, GetSourceRegister<LLIL_ASSERT>(), GetConstraint<LLIL_ASSERT>(), loc);
 	case LLIL_ASSERT_SSA:
-		return dest->AssertSSA(size, GetSourceSSARegister<LLIL_ASSERT_SSA>(), GetConstraint<LLIL_ASSERT_SSA>(), *this);
+		return dest->AssertSSA(size, GetSourceSSARegister<LLIL_ASSERT_SSA>(), GetConstraint<LLIL_ASSERT_SSA>(), loc);
 	case LLIL_LOAD:
-		return dest->Load(size, subExprHandler(GetSourceExpr<LLIL_LOAD>()), flags, *this);
+		return dest->Load(size, subExprHandler(GetSourceExpr<LLIL_LOAD>()), flags, loc);
 	case LLIL_LOAD_SSA:
 		return dest->LoadSSA(
-		    size, subExprHandler(GetSourceExpr<LLIL_LOAD_SSA>()), GetSourceMemoryVersion<LLIL_LOAD_SSA>(), *this);
+		    size, subExprHandler(GetSourceExpr<LLIL_LOAD_SSA>()), GetSourceMemoryVersion<LLIL_LOAD_SSA>(), loc);
 	case LLIL_STORE:
 		return dest->Store(
-		    size, subExprHandler(GetDestExpr<LLIL_STORE>()), subExprHandler(GetSourceExpr<LLIL_STORE>()), flags, *this);
+		    size, subExprHandler(GetDestExpr<LLIL_STORE>()), subExprHandler(GetSourceExpr<LLIL_STORE>()), flags, loc);
 	case LLIL_STORE_SSA:
 		return dest->StoreSSA(size, subExprHandler(GetDestExpr<LLIL_STORE_SSA>()),
 		    subExprHandler(GetSourceExpr<LLIL_STORE_SSA>()), GetDestMemoryVersion<LLIL_STORE_SSA>(),
-		    GetSourceMemoryVersion<LLIL_STORE_SSA>(), *this);
+		    GetSourceMemoryVersion<LLIL_STORE_SSA>(), loc);
 	case LLIL_REG:
-		return dest->Register(size, GetSourceRegister<LLIL_REG>(), *this);
+		return dest->Register(size, GetSourceRegister<LLIL_REG>(), loc);
 	case LLIL_REG_SSA:
-		return dest->RegisterSSA(size, GetSourceSSARegister<LLIL_REG_SSA>(), *this);
+		return dest->RegisterSSA(size, GetSourceSSARegister<LLIL_REG_SSA>(), loc);
 	case LLIL_REG_SSA_PARTIAL:
 		return dest->RegisterSSAPartial(
-		    size, GetSourceSSARegister<LLIL_REG_SSA_PARTIAL>(), GetPartialRegister<LLIL_REG_SSA_PARTIAL>(), *this);
+		    size, GetSourceSSARegister<LLIL_REG_SSA_PARTIAL>(), GetPartialRegister<LLIL_REG_SSA_PARTIAL>(), loc);
 	case LLIL_REG_SPLIT:
-		return dest->RegisterSplit(size, GetHighRegister<LLIL_REG_SPLIT>(), GetLowRegister<LLIL_REG_SPLIT>(), *this);
+		return dest->RegisterSplit(size, GetHighRegister<LLIL_REG_SPLIT>(), GetLowRegister<LLIL_REG_SPLIT>(), loc);
 	case LLIL_REG_SPLIT_SSA:
 		return dest->RegisterSplitSSA(
-		    size, GetHighSSARegister<LLIL_REG_SPLIT_SSA>(), GetLowSSARegister<LLIL_REG_SPLIT_SSA>(), *this);
+		    size, GetHighSSARegister<LLIL_REG_SPLIT_SSA>(), GetLowSSARegister<LLIL_REG_SPLIT_SSA>(), loc);
 	case LLIL_REG_STACK_REL:
 		return dest->RegisterStackTopRelative(size, GetSourceRegisterStack<LLIL_REG_STACK_REL>(),
-		    subExprHandler(GetSourceExpr<LLIL_REG_STACK_REL>()), *this);
+		    subExprHandler(GetSourceExpr<LLIL_REG_STACK_REL>()), loc);
 	case LLIL_REG_STACK_POP:
-		return dest->RegisterStackPop(size, GetSourceRegisterStack<LLIL_REG_STACK_POP>(), flags, *this);
+		return dest->RegisterStackPop(size, GetSourceRegisterStack<LLIL_REG_STACK_POP>(), flags, loc);
 	case LLIL_REG_STACK_FREE_REG:
-		return dest->RegisterStackFreeReg(GetDestRegister<LLIL_REG_STACK_FREE_REG>(), *this);
+		return dest->RegisterStackFreeReg(GetDestRegister<LLIL_REG_STACK_FREE_REG>(), loc);
 	case LLIL_REG_STACK_FREE_REL:
 		return dest->RegisterStackFreeTopRelative(GetDestRegisterStack<LLIL_REG_STACK_FREE_REL>(),
-		    subExprHandler(GetDestExpr<LLIL_REG_STACK_FREE_REL>()), *this);
+		    subExprHandler(GetDestExpr<LLIL_REG_STACK_FREE_REL>()), loc);
 	case LLIL_REG_STACK_REL_SSA:
 		return dest->RegisterStackTopRelativeSSA(size, GetSourceSSARegisterStack<LLIL_REG_STACK_REL_SSA>(),
 		    subExprHandler(GetSourceExpr<LLIL_REG_STACK_REL_SSA>()), GetTopSSARegister<LLIL_REG_STACK_REL_SSA>(),
-		    *this);
+		    loc);
 	case LLIL_REG_STACK_ABS_SSA:
 		return dest->RegisterStackAbsoluteSSA(size, GetSourceSSARegisterStack<LLIL_REG_STACK_ABS_SSA>(),
-		    GetSourceRegister<LLIL_REG_STACK_ABS_SSA>(), *this);
+		    GetSourceRegister<LLIL_REG_STACK_ABS_SSA>(), loc);
 	case LLIL_REG_STACK_FREE_REL_SSA:
 		return dest->RegisterStackFreeTopRelativeSSA(GetDestSSARegisterStack<LLIL_REG_STACK_FREE_REL_SSA>().regStack,
 		    GetDestSSARegisterStack<LLIL_REG_STACK_FREE_REL_SSA>().version,
 		    GetSourceSSARegisterStack<LLIL_REG_STACK_FREE_REL_SSA>().version,
 		    subExprHandler(GetDestExpr<LLIL_REG_STACK_FREE_REL_SSA>()),
-		    GetTopSSARegister<LLIL_REG_STACK_FREE_REL_SSA>(), *this);
+		    GetTopSSARegister<LLIL_REG_STACK_FREE_REL_SSA>(), loc);
 	case LLIL_REG_STACK_FREE_ABS_SSA:
 		return dest->RegisterStackFreeAbsoluteSSA(GetDestSSARegisterStack<LLIL_REG_STACK_FREE_ABS_SSA>().regStack,
 		    GetDestSSARegisterStack<LLIL_REG_STACK_FREE_ABS_SSA>().version,
 		    GetSourceSSARegisterStack<LLIL_REG_STACK_FREE_ABS_SSA>().version,
-		    GetDestRegister<LLIL_REG_STACK_FREE_ABS_SSA>(), *this);
+		    GetDestRegister<LLIL_REG_STACK_FREE_ABS_SSA>(), loc);
 	case LLIL_FLAG:
-		return dest->Flag(GetSourceFlag<LLIL_FLAG>(), *this);
+		return dest->Flag(GetSourceFlag<LLIL_FLAG>(), loc);
 	case LLIL_FLAG_SSA:
-		return dest->FlagSSA(GetSourceSSAFlag<LLIL_FLAG_SSA>(), *this);
+		return dest->FlagSSA(GetSourceSSAFlag<LLIL_FLAG_SSA>(), loc);
 	case LLIL_FLAG_BIT:
-		return dest->FlagBit(size, GetSourceFlag<LLIL_FLAG_BIT>(), GetBitIndex<LLIL_FLAG_BIT>(), *this);
+		return dest->FlagBit(size, GetSourceFlag<LLIL_FLAG_BIT>(), GetBitIndex<LLIL_FLAG_BIT>(), loc);
 	case LLIL_FLAG_BIT_SSA:
-		return dest->FlagBitSSA(size, GetSourceSSAFlag<LLIL_FLAG_BIT_SSA>(), GetBitIndex<LLIL_FLAG_BIT_SSA>(), *this);
+		return dest->FlagBitSSA(size, GetSourceSSAFlag<LLIL_FLAG_BIT_SSA>(), GetBitIndex<LLIL_FLAG_BIT_SSA>(), loc);
 	case LLIL_JUMP:
-		return dest->Jump(subExprHandler(GetDestExpr<LLIL_JUMP>()), *this);
+		return dest->Jump(subExprHandler(GetDestExpr<LLIL_JUMP>()), loc);
 	case LLIL_CALL:
-		return dest->Call(subExprHandler(GetDestExpr<LLIL_CALL>()), *this);
+		return dest->Call(subExprHandler(GetDestExpr<LLIL_CALL>()), loc);
 	case LLIL_CALL_STACK_ADJUST:
 		return dest->CallStackAdjust(subExprHandler(GetDestExpr<LLIL_CALL_STACK_ADJUST>()),
-		    GetStackAdjustment<LLIL_CALL_STACK_ADJUST>(), GetRegisterStackAdjustments<LLIL_CALL_STACK_ADJUST>(), *this);
+		    GetStackAdjustment<LLIL_CALL_STACK_ADJUST>(), GetRegisterStackAdjustments<LLIL_CALL_STACK_ADJUST>(), loc);
 	case LLIL_TAILCALL:
-		return dest->TailCall(subExprHandler(GetDestExpr<LLIL_TAILCALL>()), *this);
+		return dest->TailCall(subExprHandler(GetDestExpr<LLIL_TAILCALL>()), loc);
 	case LLIL_RET:
-		return dest->Return(subExprHandler(GetDestExpr<LLIL_RET>()), *this);
+		return dest->Return(subExprHandler(GetDestExpr<LLIL_RET>()), loc);
 	case LLIL_JUMP_TO:
 	{
 		map<uint64_t, BNLowLevelILLabel*> labelList;
@@ -2208,10 +2211,10 @@ ExprId LowLevelILInstruction::CopyTo(
 		{
 			labelA = dest->GetLabelForSourceInstruction(target.second);
 			if (!labelA)
-				return dest->Jump(subExprHandler(GetDestExpr<LLIL_JUMP_TO>()), *this);
+				return dest->Jump(subExprHandler(GetDestExpr<LLIL_JUMP_TO>()), loc);
 			labelList[target.first] = labelA;
 		}
-		return dest->JumpTo(subExprHandler(GetDestExpr<LLIL_JUMP_TO>()), labelList, *this);
+		return dest->JumpTo(subExprHandler(GetDestExpr<LLIL_JUMP_TO>()), labelList, loc);
 	}
 	case LLIL_GOTO:
 		labelA = dest->GetLabelForSourceInstruction(GetTarget<LLIL_GOTO>());
@@ -2219,63 +2222,63 @@ ExprId LowLevelILInstruction::CopyTo(
 		{
 			return dest->Jump(dest->ConstPointer(function->GetArchitecture()->GetAddressSize(),
 			                      function->GetInstruction(GetTarget<LLIL_GOTO>()).address),
-			    *this);
+			    loc);
 		}
-		return dest->Goto(*labelA, *this);
+		return dest->Goto(*labelA, loc);
 	case LLIL_IF:
 		labelA = dest->GetLabelForSourceInstruction(GetTrueTarget<LLIL_IF>());
 		labelB = dest->GetLabelForSourceInstruction(GetFalseTarget<LLIL_IF>());
 		if ((!labelA) || (!labelB))
-			return dest->Undefined(*this);
-		return dest->If(subExprHandler(GetConditionExpr<LLIL_IF>()), *labelA, *labelB, *this);
+			return dest->Undefined(loc);
+		return dest->If(subExprHandler(GetConditionExpr<LLIL_IF>()), *labelA, *labelB, loc);
 	case LLIL_FLAG_COND:
-		return dest->FlagCondition(GetFlagCondition<LLIL_FLAG_COND>(), GetSemanticFlagClass<LLIL_FLAG_COND>(), *this);
+		return dest->FlagCondition(GetFlagCondition<LLIL_FLAG_COND>(), GetSemanticFlagClass<LLIL_FLAG_COND>(), loc);
 	case LLIL_FLAG_GROUP:
-		return dest->FlagGroup(GetSemanticFlagGroup<LLIL_FLAG_GROUP>(), *this);
+		return dest->FlagGroup(GetSemanticFlagGroup<LLIL_FLAG_GROUP>(), loc);
 	case LLIL_TRAP:
-		return dest->Trap(GetVector<LLIL_TRAP>(), *this);
+		return dest->Trap(GetVector<LLIL_TRAP>(), loc);
 	case LLIL_CALL_SSA:
 		for (auto i : GetParameterExprs<LLIL_CALL_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->CallSSA(GetOutputSSARegisters<LLIL_CALL_SSA>(), subExprHandler(GetDestExpr<LLIL_CALL_SSA>()),
 		    params, GetStackSSARegister<LLIL_CALL_SSA>(), GetDestMemoryVersion<LLIL_CALL_SSA>(),
-		    GetSourceMemoryVersion<LLIL_CALL_SSA>(), *this);
+		    GetSourceMemoryVersion<LLIL_CALL_SSA>(), loc);
 	case LLIL_SYSCALL_SSA:
 		for (auto i : GetParameterExprs<LLIL_SYSCALL_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->SystemCallSSA(GetOutputSSARegisters<LLIL_SYSCALL_SSA>(), params,
 		    GetStackSSARegister<LLIL_SYSCALL_SSA>(), GetDestMemoryVersion<LLIL_SYSCALL_SSA>(),
-		    GetSourceMemoryVersion<LLIL_SYSCALL_SSA>(), *this);
+		    GetSourceMemoryVersion<LLIL_SYSCALL_SSA>(), loc);
 	case LLIL_TAILCALL_SSA:
 		for (auto i : GetParameterExprs<LLIL_TAILCALL_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->TailCallSSA(GetOutputSSARegisters<LLIL_TAILCALL_SSA>(),
 		    subExprHandler(GetDestExpr<LLIL_TAILCALL_SSA>()), params, GetStackSSARegister<LLIL_TAILCALL_SSA>(),
-		    GetDestMemoryVersion<LLIL_TAILCALL_SSA>(), GetSourceMemoryVersion<LLIL_TAILCALL_SSA>(), *this);
+		    GetDestMemoryVersion<LLIL_TAILCALL_SSA>(), GetSourceMemoryVersion<LLIL_TAILCALL_SSA>(), loc);
 	case LLIL_REG_PHI:
-		return dest->RegisterPhi(GetDestSSARegister<LLIL_REG_PHI>(), GetSourceSSARegisters<LLIL_REG_PHI>(), *this);
+		return dest->RegisterPhi(GetDestSSARegister<LLIL_REG_PHI>(), GetSourceSSARegisters<LLIL_REG_PHI>(), loc);
 	case LLIL_REG_STACK_PHI:
 		return dest->RegisterStackPhi(
-		    GetDestSSARegisterStack<LLIL_REG_STACK_PHI>(), GetSourceSSARegisterStacks<LLIL_REG_STACK_PHI>(), *this);
+		    GetDestSSARegisterStack<LLIL_REG_STACK_PHI>(), GetSourceSSARegisterStacks<LLIL_REG_STACK_PHI>(), loc);
 	case LLIL_FLAG_PHI:
-		return dest->FlagPhi(GetDestSSAFlag<LLIL_FLAG_PHI>(), GetSourceSSAFlags<LLIL_FLAG_PHI>(), *this);
+		return dest->FlagPhi(GetDestSSAFlag<LLIL_FLAG_PHI>(), GetSourceSSAFlags<LLIL_FLAG_PHI>(), loc);
 	case LLIL_MEM_PHI:
-		return dest->MemoryPhi(GetDestMemoryVersion<LLIL_MEM_PHI>(), GetSourceMemoryVersions<LLIL_MEM_PHI>(), *this);
+		return dest->MemoryPhi(GetDestMemoryVersion<LLIL_MEM_PHI>(), GetSourceMemoryVersions<LLIL_MEM_PHI>(), loc);
 	case LLIL_CONST:
-		return dest->Const(size, GetConstant<LLIL_CONST>(), *this);
+		return dest->Const(size, GetConstant<LLIL_CONST>(), loc);
 	case LLIL_CONST_PTR:
-		return dest->ConstPointer(size, GetConstant<LLIL_CONST_PTR>(), *this);
+		return dest->ConstPointer(size, GetConstant<LLIL_CONST_PTR>(), loc);
 	case LLIL_EXTERN_PTR:
-		return dest->ExternPointer(size, GetConstant<LLIL_EXTERN_PTR>(), GetOffset<LLIL_EXTERN_PTR>(), *this);
+		return dest->ExternPointer(size, GetConstant<LLIL_EXTERN_PTR>(), GetOffset<LLIL_EXTERN_PTR>(), loc);
 	case LLIL_FLOAT_CONST:
-		return dest->FloatConstRaw(size, GetConstant<LLIL_FLOAT_CONST>(), *this);
+		return dest->FloatConstRaw(size, GetConstant<LLIL_FLOAT_CONST>(), loc);
 	case LLIL_POP:
 	case LLIL_NORET:
 	case LLIL_SYSCALL:
 	case LLIL_BP:
 	case LLIL_UNDEF:
 	case LLIL_UNIMPL:
-		return dest->AddExprWithLocation(operation, *this, size, flags);
+		return dest->AddExprWithLocation(operation, loc, size, flags);
 	case LLIL_PUSH:
 	case LLIL_NEG:
 	case LLIL_NOT:
@@ -2294,7 +2297,7 @@ ExprId LowLevelILInstruction::CopyTo(
 	case LLIL_FLOOR:
 	case LLIL_CEIL:
 	case LLIL_FTRUNC:
-		return dest->AddExprWithLocation(operation, *this, size, flags, subExprHandler(AsOneOperand().GetSourceExpr()));
+		return dest->AddExprWithLocation(operation, loc, size, flags, subExprHandler(AsOneOperand().GetSourceExpr()));
 	case LLIL_ADD:
 	case LLIL_SUB:
 	case LLIL_AND:
@@ -2340,13 +2343,13 @@ ExprId LowLevelILInstruction::CopyTo(
 	case LLIL_FCMP_GT:
 	case LLIL_FCMP_O:
 	case LLIL_FCMP_UO:
-		return dest->AddExprWithLocation(operation, *this, size, flags, subExprHandler(AsTwoOperand().GetLeftExpr()),
+		return dest->AddExprWithLocation(operation, loc, size, flags, subExprHandler(AsTwoOperand().GetLeftExpr()),
 		    subExprHandler(AsTwoOperand().GetRightExpr()));
 	case LLIL_ADC:
 	case LLIL_SBB:
 	case LLIL_RLC:
 	case LLIL_RRC:
-		return dest->AddExprWithLocation(operation, *this, size, flags,
+		return dest->AddExprWithLocation(operation, loc, size, flags,
 		    subExprHandler(AsTwoOperandWithCarry().GetLeftExpr()),
 		    subExprHandler(AsTwoOperandWithCarry().GetRightExpr()),
 		    subExprHandler(AsTwoOperandWithCarry().GetCarryExpr()));
@@ -2354,25 +2357,25 @@ ExprId LowLevelILInstruction::CopyTo(
 		for (auto i : GetParameterExprs<LLIL_INTRINSIC>())
 			params.push_back(subExprHandler(i));
 		return dest->Intrinsic(
-		    GetOutputRegisterOrFlagList<LLIL_INTRINSIC>(), GetIntrinsic<LLIL_INTRINSIC>(), params, flags, *this);
+		    GetOutputRegisterOrFlagList<LLIL_INTRINSIC>(), GetIntrinsic<LLIL_INTRINSIC>(), params, flags, loc);
 	case LLIL_INTRINSIC_SSA:
 		for (auto i : GetParameterExprs<LLIL_INTRINSIC_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->IntrinsicSSA(
-		    GetOutputSSARegisterOrFlagList<LLIL_INTRINSIC_SSA>(), GetIntrinsic<LLIL_INTRINSIC_SSA>(), params, *this);
+		    GetOutputSSARegisterOrFlagList<LLIL_INTRINSIC_SSA>(), GetIntrinsic<LLIL_INTRINSIC_SSA>(), params, loc);
 	case LLIL_MEMORY_INTRINSIC_SSA:
 		for (auto i : GetParameterExprs<LLIL_MEMORY_INTRINSIC_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->MemoryIntrinsicSSA(GetOutputSSARegisterOrFlagList<LLIL_MEMORY_INTRINSIC_SSA>(), GetIntrinsic<LLIL_MEMORY_INTRINSIC_SSA>(),
-			params, GetDestMemoryVersion<LLIL_MEMORY_INTRINSIC_SSA>(), GetSourceMemoryVersion<LLIL_MEMORY_INTRINSIC_SSA>(), *this);
+			params, GetDestMemoryVersion<LLIL_MEMORY_INTRINSIC_SSA>(), GetSourceMemoryVersion<LLIL_MEMORY_INTRINSIC_SSA>(), loc);
 	case LLIL_SEPARATE_PARAM_LIST_SSA:
 		for (auto i : GetParameterExprs<LLIL_SEPARATE_PARAM_LIST_SSA>())
 			params.push_back(subExprHandler(i));
-		return dest->SeparateParamListSSA(params, *this);
+		return dest->SeparateParamListSSA(params, loc);
 	case LLIL_SHARED_PARAM_SLOT_SSA:
 		for (auto i : GetParameterExprs<LLIL_SHARED_PARAM_SLOT_SSA>())
 			params.push_back(subExprHandler(i));
-		return dest->SharedParamSlotSSA(params, *this);
+		return dest->SharedParamSlotSSA(params, loc);
 	default:
 		throw LowLevelILInstructionAccessException();
 	}

--- a/lowlevelilinstruction.h
+++ b/lowlevelilinstruction.h
@@ -24,6 +24,7 @@
 #include <unordered_map>
 #include <vector>
 #ifdef BINARYNINJACORE_LIBRARY
+	#include "ilsourcelocation.h"
 	#include "type.h"
 #else
 	#include "binaryninjaapi.h"
@@ -872,9 +873,10 @@ namespace BinaryNinja
 
 		void VisitExprs(const std::function<bool(const LowLevelILInstruction& expr)>& func) const;
 
-		ExprId CopyTo(LowLevelILFunction* dest) const;
+		ExprId CopyTo(LowLevelILFunction* dest, const ILSourceLocation& sourceLocation = {}) const;
 		ExprId CopyTo(LowLevelILFunction* dest,
-		    const std::function<ExprId(const LowLevelILInstruction& subExpr)>& subExprHandler) const;
+			const std::function<ExprId(const LowLevelILInstruction& subExpr)>& subExprHandler,
+			const ILSourceLocation& sourceLocation = {}) const;
 
 		// Templated accessors for instruction operands, use these for efficient access to a known instruction
 		template <BNLowLevelILOperation N>

--- a/mediumlevelilinstruction.cpp
+++ b/mediumlevelilinstruction.cpp
@@ -1578,145 +1578,149 @@ void MediumLevelILInstruction::VisitExprs(const std::function<bool(const MediumL
 }
 
 
-ExprId MediumLevelILInstruction::CopyTo(MediumLevelILFunction* dest) const
+ExprId MediumLevelILInstruction::CopyTo(MediumLevelILFunction* dest, const ILSourceLocation& sourceLocation) const
 {
-	return CopyTo(dest, [&](const MediumLevelILInstruction& subExpr) { return subExpr.CopyTo(dest); });
+	return CopyTo(dest, [&](const MediumLevelILInstruction& subExpr) { return subExpr.CopyTo(dest, sourceLocation); }, sourceLocation);
 }
 
 
 ExprId MediumLevelILInstruction::CopyTo(MediumLevelILFunction* dest,
-    const std::function<ExprId(const MediumLevelILInstruction& subExpr)>& subExprHandler) const
+    const std::function<ExprId(const MediumLevelILInstruction& subExpr)>& subExprHandler,
+	const ILSourceLocation& sourceLocation) const
 {
 	vector<ExprId> params;
 	BNMediumLevelILLabel* labelA;
 	BNMediumLevelILLabel* labelB;
+
+	const auto& loc = sourceLocation.valid ? sourceLocation : ILSourceLocation{*this};
+
 	switch (operation)
 	{
 	case MLIL_NOP:
-		return dest->Nop(*this);
+		return dest->Nop(loc);
 	case MLIL_SET_VAR:
 		return dest->SetVar(
-		    size, GetDestVariable<MLIL_SET_VAR>(), subExprHandler(GetSourceExpr<MLIL_SET_VAR>()), *this);
+		    size, GetDestVariable<MLIL_SET_VAR>(), subExprHandler(GetSourceExpr<MLIL_SET_VAR>()), loc);
 	case MLIL_SET_VAR_SSA:
 		return dest->SetVarSSA(
-		    size, GetDestSSAVariable<MLIL_SET_VAR_SSA>(), subExprHandler(GetSourceExpr<MLIL_SET_VAR_SSA>()), *this);
+		    size, GetDestSSAVariable<MLIL_SET_VAR_SSA>(), subExprHandler(GetSourceExpr<MLIL_SET_VAR_SSA>()), loc);
 	case MLIL_SET_VAR_ALIASED:
 		return dest->SetVarAliased(size, GetDestSSAVariable<MLIL_SET_VAR_ALIASED>().var,
 		    GetDestSSAVariable<MLIL_SET_VAR_ALIASED>().version, GetSourceSSAVariable<MLIL_SET_VAR_ALIASED>().version,
-		    subExprHandler(GetSourceExpr<MLIL_SET_VAR_ALIASED>()), *this);
+		    subExprHandler(GetSourceExpr<MLIL_SET_VAR_ALIASED>()), loc);
 	case MLIL_SET_VAR_SPLIT:
 		return dest->SetVarSplit(size, GetHighVariable<MLIL_SET_VAR_SPLIT>(), GetLowVariable<MLIL_SET_VAR_SPLIT>(),
-		    subExprHandler(GetSourceExpr<MLIL_SET_VAR_SPLIT>()), *this);
+		    subExprHandler(GetSourceExpr<MLIL_SET_VAR_SPLIT>()), loc);
 	case MLIL_SET_VAR_SPLIT_SSA:
 		return dest->SetVarSSASplit(size, GetHighSSAVariable<MLIL_SET_VAR_SPLIT_SSA>(),
 		    GetLowSSAVariable<MLIL_SET_VAR_SPLIT_SSA>(), subExprHandler(GetSourceExpr<MLIL_SET_VAR_SPLIT_SSA>()),
-		    *this);
+		    loc);
 	case MLIL_SET_VAR_FIELD:
 		return dest->SetVarField(size, GetDestVariable<MLIL_SET_VAR_FIELD>(), GetOffset<MLIL_SET_VAR_FIELD>(),
-		    subExprHandler(GetSourceExpr<MLIL_SET_VAR_FIELD>()), *this);
+		    subExprHandler(GetSourceExpr<MLIL_SET_VAR_FIELD>()), loc);
 	case MLIL_SET_VAR_SSA_FIELD:
 		return dest->SetVarSSAField(size, GetDestSSAVariable<MLIL_SET_VAR_SSA_FIELD>().var,
 		    GetDestSSAVariable<MLIL_SET_VAR_SSA_FIELD>().version,
 		    GetSourceSSAVariable<MLIL_SET_VAR_SSA_FIELD>().version, GetOffset<MLIL_SET_VAR_SSA_FIELD>(),
-		    subExprHandler(GetSourceExpr<MLIL_SET_VAR_SSA_FIELD>()), *this);
+		    subExprHandler(GetSourceExpr<MLIL_SET_VAR_SSA_FIELD>()), loc);
 	case MLIL_SET_VAR_ALIASED_FIELD:
 		return dest->SetVarAliasedField(size, GetDestSSAVariable<MLIL_SET_VAR_ALIASED_FIELD>().var,
 		    GetDestSSAVariable<MLIL_SET_VAR_ALIASED_FIELD>().version,
 		    GetSourceSSAVariable<MLIL_SET_VAR_ALIASED_FIELD>().version, GetOffset<MLIL_SET_VAR_ALIASED_FIELD>(),
-		    subExprHandler(GetSourceExpr<MLIL_SET_VAR_ALIASED_FIELD>()), *this);
+		    subExprHandler(GetSourceExpr<MLIL_SET_VAR_ALIASED_FIELD>()), loc);
 	case MLIL_VAR:
-		return dest->Var(size, GetSourceVariable<MLIL_VAR>(), *this);
+		return dest->Var(size, GetSourceVariable<MLIL_VAR>(), loc);
 	case MLIL_VAR_FIELD:
-		return dest->VarField(size, GetSourceVariable<MLIL_VAR_FIELD>(), GetOffset<MLIL_VAR_FIELD>(), *this);
+		return dest->VarField(size, GetSourceVariable<MLIL_VAR_FIELD>(), GetOffset<MLIL_VAR_FIELD>(), loc);
 	case MLIL_VAR_SPLIT:
-		return dest->VarSplit(size, GetHighVariable<MLIL_VAR_SPLIT>(), GetLowVariable<MLIL_VAR_SPLIT>(), *this);
+		return dest->VarSplit(size, GetHighVariable<MLIL_VAR_SPLIT>(), GetLowVariable<MLIL_VAR_SPLIT>(), loc);
 	case MLIL_VAR_SSA:
-		return dest->VarSSA(size, GetSourceSSAVariable<MLIL_VAR_SSA>(), *this);
+		return dest->VarSSA(size, GetSourceSSAVariable<MLIL_VAR_SSA>(), loc);
 	case MLIL_VAR_SSA_FIELD:
 		return dest->VarSSAField(
-		    size, GetSourceSSAVariable<MLIL_VAR_SSA_FIELD>(), GetOffset<MLIL_VAR_SSA_FIELD>(), *this);
+		    size, GetSourceSSAVariable<MLIL_VAR_SSA_FIELD>(), GetOffset<MLIL_VAR_SSA_FIELD>(), loc);
 	case MLIL_VAR_ALIASED:
 		return dest->VarAliased(size, GetSourceSSAVariable<MLIL_VAR_ALIASED>().var,
-		    GetSourceSSAVariable<MLIL_VAR_ALIASED>().version, *this);
+		    GetSourceSSAVariable<MLIL_VAR_ALIASED>().version, loc);
 	case MLIL_VAR_ALIASED_FIELD:
 		return dest->VarAliasedField(size, GetSourceSSAVariable<MLIL_VAR_ALIASED_FIELD>().var,
-		    GetSourceSSAVariable<MLIL_VAR_ALIASED_FIELD>().version, GetOffset<MLIL_VAR_ALIASED_FIELD>(), *this);
+		    GetSourceSSAVariable<MLIL_VAR_ALIASED_FIELD>().version, GetOffset<MLIL_VAR_ALIASED_FIELD>(), loc);
 	case MLIL_VAR_SPLIT_SSA:
 		return dest->VarSplitSSA(
-		    size, GetHighSSAVariable<MLIL_VAR_SPLIT_SSA>(), GetLowSSAVariable<MLIL_VAR_SPLIT_SSA>(), *this);
+		    size, GetHighSSAVariable<MLIL_VAR_SPLIT_SSA>(), GetLowSSAVariable<MLIL_VAR_SPLIT_SSA>(), loc);
 	case MLIL_FORCE_VER:
-		return dest->ForceVer(size, GetDestVariable<MLIL_FORCE_VER>(), GetSourceVariable<MLIL_FORCE_VER>(), *this);
+		return dest->ForceVer(size, GetDestVariable<MLIL_FORCE_VER>(), GetSourceVariable<MLIL_FORCE_VER>(), loc);
 	case MLIL_FORCE_VER_SSA:
-		return dest->ForceVerSSA(size, GetDestSSAVariable<MLIL_FORCE_VER_SSA>(), GetSourceSSAVariable<MLIL_FORCE_VER_SSA>(), *this);
+		return dest->ForceVerSSA(size, GetDestSSAVariable<MLIL_FORCE_VER_SSA>(), GetSourceSSAVariable<MLIL_FORCE_VER_SSA>(), loc);
 	case MLIL_ASSERT:
-		return dest->Assert(size, GetSourceVariable<MLIL_ASSERT>(), GetConstraint<MLIL_ASSERT>(), *this);
+		return dest->Assert(size, GetSourceVariable<MLIL_ASSERT>(), GetConstraint<MLIL_ASSERT>(), loc);
 	case MLIL_ASSERT_SSA:
-		return dest->AssertSSA(size, GetSourceSSAVariable<MLIL_ASSERT_SSA>(), GetConstraint<MLIL_ASSERT_SSA>(), *this);
+		return dest->AssertSSA(size, GetSourceSSAVariable<MLIL_ASSERT_SSA>(), GetConstraint<MLIL_ASSERT_SSA>(), loc);
 	case MLIL_ADDRESS_OF:
-		return dest->AddressOf(GetSourceVariable<MLIL_ADDRESS_OF>(), *this);
+		return dest->AddressOf(GetSourceVariable<MLIL_ADDRESS_OF>(), loc);
 	case MLIL_ADDRESS_OF_FIELD:
 		return dest->AddressOfField(
-		    GetSourceVariable<MLIL_ADDRESS_OF_FIELD>(), GetOffset<MLIL_ADDRESS_OF_FIELD>(), *this);
+		    GetSourceVariable<MLIL_ADDRESS_OF_FIELD>(), GetOffset<MLIL_ADDRESS_OF_FIELD>(), loc);
 	case MLIL_CALL:
 		for (auto i : GetParameterExprs<MLIL_CALL>())
 			params.push_back(subExprHandler(i));
-		return dest->Call(GetOutputVariables<MLIL_CALL>(), subExprHandler(GetDestExpr<MLIL_CALL>()), params, *this);
+		return dest->Call(GetOutputVariables<MLIL_CALL>(), subExprHandler(GetDestExpr<MLIL_CALL>()), params, loc);
 	case MLIL_CALL_UNTYPED:
 		for (auto i : GetParameterExprs<MLIL_CALL_UNTYPED>())
 			params.push_back(subExprHandler(i));
 		return dest->CallUntyped(GetOutputVariables<MLIL_CALL_UNTYPED>(),
 		    subExprHandler(GetDestExpr<MLIL_CALL_UNTYPED>()), params,
-		    subExprHandler(GetStackExpr<MLIL_CALL_UNTYPED>()), *this);
+		    subExprHandler(GetStackExpr<MLIL_CALL_UNTYPED>()), loc);
 	case MLIL_CALL_SSA:
 		for (auto i : GetParameterExprs<MLIL_CALL_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->CallSSA(GetOutputSSAVariables<MLIL_CALL_SSA>(), subExprHandler(GetDestExpr<MLIL_CALL_SSA>()),
-		    params, GetDestMemoryVersion<MLIL_CALL_SSA>(), GetSourceMemoryVersion<MLIL_CALL_SSA>(), *this);
+		    params, GetDestMemoryVersion<MLIL_CALL_SSA>(), GetSourceMemoryVersion<MLIL_CALL_SSA>(), loc);
 	case MLIL_CALL_UNTYPED_SSA:
 		for (auto i : GetParameterExprs<MLIL_CALL_UNTYPED_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->CallUntypedSSA(GetOutputSSAVariables<MLIL_CALL_UNTYPED_SSA>(),
 		    subExprHandler(GetDestExpr<MLIL_CALL_UNTYPED_SSA>()), params,
 		    GetDestMemoryVersion<MLIL_CALL_UNTYPED_SSA>(), GetSourceMemoryVersion<MLIL_CALL_UNTYPED_SSA>(),
-		    subExprHandler(GetStackExpr<MLIL_CALL_UNTYPED_SSA>()), *this);
+		    subExprHandler(GetStackExpr<MLIL_CALL_UNTYPED_SSA>()), loc);
 	case MLIL_SYSCALL:
 		for (auto i : GetParameterExprs<MLIL_SYSCALL>())
 			params.push_back(subExprHandler(i));
-		return dest->Syscall(GetOutputVariables<MLIL_SYSCALL>(), params, *this);
+		return dest->Syscall(GetOutputVariables<MLIL_SYSCALL>(), params, loc);
 	case MLIL_SYSCALL_UNTYPED:
 		for (auto i : GetParameterExprs<MLIL_SYSCALL_UNTYPED>())
 			params.push_back(subExprHandler(i));
 		return dest->SyscallUntyped(GetOutputVariables<MLIL_SYSCALL_UNTYPED>(),
-		    params, subExprHandler(GetStackExpr<MLIL_SYSCALL_UNTYPED>()), *this);
+		    params, subExprHandler(GetStackExpr<MLIL_SYSCALL_UNTYPED>()), loc);
 	case MLIL_SYSCALL_SSA:
 		for (auto i : GetParameterExprs<MLIL_SYSCALL_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->SyscallSSA(GetOutputSSAVariables<MLIL_SYSCALL_SSA>(), params,
-		    GetDestMemoryVersion<MLIL_SYSCALL_SSA>(), GetSourceMemoryVersion<MLIL_SYSCALL_SSA>(), *this);
+		    GetDestMemoryVersion<MLIL_SYSCALL_SSA>(), GetSourceMemoryVersion<MLIL_SYSCALL_SSA>(), loc);
 	case MLIL_SYSCALL_UNTYPED_SSA:
 		for (auto i : GetParameterExprs<MLIL_SYSCALL_UNTYPED_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->SyscallUntypedSSA(GetOutputSSAVariables<MLIL_SYSCALL_UNTYPED_SSA>(),
 		    params, GetDestMemoryVersion<MLIL_SYSCALL_UNTYPED_SSA>(),
 		    GetSourceMemoryVersion<MLIL_SYSCALL_UNTYPED_SSA>(),
-		    subExprHandler(GetStackExpr<MLIL_SYSCALL_UNTYPED_SSA>()), *this);
+		    subExprHandler(GetStackExpr<MLIL_SYSCALL_UNTYPED_SSA>()), loc);
 	case MLIL_TAILCALL:
 		for (auto i : GetParameterExprs<MLIL_TAILCALL>())
 			params.push_back(subExprHandler(i));
 		return dest->TailCall(
-		    GetOutputVariables<MLIL_TAILCALL>(), subExprHandler(GetDestExpr<MLIL_TAILCALL>()), params, *this);
+		    GetOutputVariables<MLIL_TAILCALL>(), subExprHandler(GetDestExpr<MLIL_TAILCALL>()), params, loc);
 	case MLIL_TAILCALL_UNTYPED:
 		for (auto i : GetParameterExprs<MLIL_TAILCALL_UNTYPED>())
 			params.push_back(subExprHandler(i));
 		return dest->TailCallUntyped(GetOutputVariables<MLIL_TAILCALL_UNTYPED>(),
 		    subExprHandler(GetDestExpr<MLIL_TAILCALL_UNTYPED>()), params,
-		    subExprHandler(GetStackExpr<MLIL_TAILCALL_UNTYPED>()), *this);
+		    subExprHandler(GetStackExpr<MLIL_TAILCALL_UNTYPED>()), loc);
 	case MLIL_TAILCALL_SSA:
 		for (auto i : GetParameterExprs<MLIL_TAILCALL_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->TailCallSSA(GetOutputSSAVariables<MLIL_TAILCALL_SSA>(),
 		    subExprHandler(GetDestExpr<MLIL_TAILCALL_SSA>()), params, GetDestMemoryVersion<MLIL_TAILCALL_SSA>(),
-		    GetSourceMemoryVersion<MLIL_TAILCALL_SSA>(), *this);
+		    GetSourceMemoryVersion<MLIL_TAILCALL_SSA>(), loc);
 	case MLIL_TAILCALL_UNTYPED_SSA:
 		for (auto i : GetParameterExprs<MLIL_TAILCALL_UNTYPED_SSA>())
 			params.push_back(subExprHandler(i));
@@ -1724,47 +1728,47 @@ ExprId MediumLevelILInstruction::CopyTo(MediumLevelILFunction* dest,
 		    subExprHandler(GetDestExpr<MLIL_TAILCALL_UNTYPED_SSA>()),
 		    params, GetDestMemoryVersion<MLIL_TAILCALL_UNTYPED_SSA>(),
 		    GetSourceMemoryVersion<MLIL_TAILCALL_UNTYPED_SSA>(),
-		    subExprHandler(GetStackExpr<MLIL_TAILCALL_UNTYPED_SSA>()), *this);
+		    subExprHandler(GetStackExpr<MLIL_TAILCALL_UNTYPED_SSA>()), loc);
 	case MLIL_SEPARATE_PARAM_LIST:
 		for (auto i : GetParameterExprs<MLIL_SEPARATE_PARAM_LIST>())
 			params.push_back(subExprHandler(i));
-		return dest->SeparateParamList(params, *this);
+		return dest->SeparateParamList(params, loc);
 	case MLIL_SHARED_PARAM_SLOT:
 		for (auto i : GetParameterExprs<MLIL_SHARED_PARAM_SLOT>())
 			params.push_back(subExprHandler(i));
-		return dest->SharedParamSlot(params, *this);
+		return dest->SharedParamSlot(params, loc);
 	case MLIL_RET:
 		for (auto i : GetSourceExprs<MLIL_RET>())
 			params.push_back(subExprHandler(i));
-		return dest->Return(params, *this);
+		return dest->Return(params, loc);
 	case MLIL_NORET:
-		return dest->NoReturn(*this);
+		return dest->NoReturn(loc);
 	case MLIL_STORE:
 		return dest->Store(
-		    size, subExprHandler(GetDestExpr<MLIL_STORE>()), subExprHandler(GetSourceExpr<MLIL_STORE>()), *this);
+		    size, subExprHandler(GetDestExpr<MLIL_STORE>()), subExprHandler(GetSourceExpr<MLIL_STORE>()), loc);
 	case MLIL_STORE_STRUCT:
 		return dest->StoreStruct(size, subExprHandler(GetDestExpr<MLIL_STORE_STRUCT>()), GetOffset<MLIL_STORE_STRUCT>(),
-		    subExprHandler(GetSourceExpr<MLIL_STORE_STRUCT>()), *this);
+		    subExprHandler(GetSourceExpr<MLIL_STORE_STRUCT>()), loc);
 	case MLIL_STORE_SSA:
 		return dest->StoreSSA(size, subExprHandler(GetDestExpr<MLIL_STORE_SSA>()),
 		    GetDestMemoryVersion<MLIL_STORE_SSA>(), GetSourceMemoryVersion<MLIL_STORE_SSA>(),
-		    subExprHandler(GetSourceExpr<MLIL_STORE_SSA>()), *this);
+		    subExprHandler(GetSourceExpr<MLIL_STORE_SSA>()), loc);
 	case MLIL_STORE_STRUCT_SSA:
 		return dest->StoreStructSSA(size, subExprHandler(GetDestExpr<MLIL_STORE_STRUCT_SSA>()),
 		    GetOffset<MLIL_STORE_STRUCT_SSA>(), GetDestMemoryVersion<MLIL_STORE_STRUCT_SSA>(),
 		    GetSourceMemoryVersion<MLIL_STORE_STRUCT_SSA>(), subExprHandler(GetSourceExpr<MLIL_STORE_STRUCT_SSA>()),
-		    *this);
+		    loc);
 	case MLIL_LOAD:
-		return dest->Load(size, subExprHandler(GetSourceExpr<MLIL_LOAD>()), *this);
+		return dest->Load(size, subExprHandler(GetSourceExpr<MLIL_LOAD>()), loc);
 	case MLIL_LOAD_STRUCT:
 		return dest->LoadStruct(
-		    size, subExprHandler(GetSourceExpr<MLIL_LOAD_STRUCT>()), GetOffset<MLIL_LOAD_STRUCT>(), *this);
+		    size, subExprHandler(GetSourceExpr<MLIL_LOAD_STRUCT>()), GetOffset<MLIL_LOAD_STRUCT>(), loc);
 	case MLIL_LOAD_SSA:
 		return dest->LoadSSA(
-		    size, subExprHandler(GetSourceExpr<MLIL_LOAD_SSA>()), GetSourceMemoryVersion<MLIL_LOAD_SSA>(), *this);
+		    size, subExprHandler(GetSourceExpr<MLIL_LOAD_SSA>()), GetSourceMemoryVersion<MLIL_LOAD_SSA>(), loc);
 	case MLIL_LOAD_STRUCT_SSA:
 		return dest->LoadStructSSA(size, subExprHandler(GetSourceExpr<MLIL_LOAD_STRUCT_SSA>()),
-		    GetOffset<MLIL_LOAD_STRUCT_SSA>(), GetSourceMemoryVersion<MLIL_LOAD_STRUCT_SSA>(), *this);
+		    GetOffset<MLIL_LOAD_STRUCT_SSA>(), GetSourceMemoryVersion<MLIL_LOAD_STRUCT_SSA>(), loc);
 	case MLIL_NEG:
 	case MLIL_NOT:
 	case MLIL_SX:
@@ -1784,7 +1788,7 @@ ExprId MediumLevelILInstruction::CopyTo(MediumLevelILFunction* dest,
 	case MLIL_FLOOR:
 	case MLIL_CEIL:
 	case MLIL_FTRUNC:
-		return dest->AddExprWithLocation(operation, *this, size, subExprHandler(AsOneOperand().GetSourceExpr()));
+		return dest->AddExprWithLocation(operation, loc, size, subExprHandler(AsOneOperand().GetSourceExpr()));
 	case MLIL_ADD:
 	case MLIL_SUB:
 	case MLIL_AND:
@@ -1830,13 +1834,13 @@ ExprId MediumLevelILInstruction::CopyTo(MediumLevelILFunction* dest,
 	case MLIL_FCMP_GT:
 	case MLIL_FCMP_O:
 	case MLIL_FCMP_UO:
-		return dest->AddExprWithLocation(operation, *this, size, subExprHandler(AsTwoOperand().GetLeftExpr()),
+		return dest->AddExprWithLocation(operation, loc, size, subExprHandler(AsTwoOperand().GetLeftExpr()),
 		    subExprHandler(AsTwoOperand().GetRightExpr()));
 	case MLIL_ADC:
 	case MLIL_SBB:
 	case MLIL_RLC:
 	case MLIL_RRC:
-		return dest->AddExprWithLocation(operation, *this, size, subExprHandler(AsTwoOperandWithCarry().GetLeftExpr()),
+		return dest->AddExprWithLocation(operation, loc, size, subExprHandler(AsTwoOperandWithCarry().GetLeftExpr()),
 		    subExprHandler(AsTwoOperandWithCarry().GetRightExpr()),
 		    subExprHandler(AsTwoOperandWithCarry().GetCarryExpr()));
 	case MLIL_JUMP_TO:
@@ -1846,10 +1850,10 @@ ExprId MediumLevelILInstruction::CopyTo(MediumLevelILFunction* dest,
 		{
 			labelA = dest->GetLabelForSourceInstruction(target.second);
 			if (!labelA)
-				return dest->Jump(subExprHandler(GetDestExpr<MLIL_JUMP_TO>()), *this);
+				return dest->Jump(subExprHandler(GetDestExpr<MLIL_JUMP_TO>()), loc);
 			labelList[target.first] = labelA;
 		}
-		return dest->JumpTo(subExprHandler(GetDestExpr<MLIL_JUMP_TO>()), labelList, *this);
+		return dest->JumpTo(subExprHandler(GetDestExpr<MLIL_JUMP_TO>()), labelList, loc);
 	}
 	case MLIL_GOTO:
 		labelA = dest->GetLabelForSourceInstruction(GetTarget<MLIL_GOTO>());
@@ -1857,56 +1861,56 @@ ExprId MediumLevelILInstruction::CopyTo(MediumLevelILFunction* dest,
 		{
 			return dest->Jump(dest->ConstPointer(function->GetArchitecture()->GetAddressSize(),
 			                      function->GetInstruction(GetTarget<MLIL_GOTO>()).address),
-			    *this);
+			    loc);
 		}
-		return dest->Goto(*labelA, *this);
+		return dest->Goto(*labelA, loc);
 	case MLIL_IF:
 		labelA = dest->GetLabelForSourceInstruction(GetTrueTarget<MLIL_IF>());
 		labelB = dest->GetLabelForSourceInstruction(GetFalseTarget<MLIL_IF>());
 		if ((!labelA) || (!labelB))
-			return dest->Undefined(*this);
-		return dest->If(subExprHandler(GetConditionExpr<MLIL_IF>()), *labelA, *labelB, *this);
+			return dest->Undefined(loc);
+		return dest->If(subExprHandler(GetConditionExpr<MLIL_IF>()), *labelA, *labelB, loc);
 	case MLIL_CONST:
-		return dest->Const(size, GetConstant<MLIL_CONST>(), *this);
+		return dest->Const(size, GetConstant<MLIL_CONST>(), loc);
 	case MLIL_CONST_PTR:
-		return dest->ConstPointer(size, GetConstant<MLIL_CONST_PTR>(), *this);
+		return dest->ConstPointer(size, GetConstant<MLIL_CONST_PTR>(), loc);
 	case MLIL_EXTERN_PTR:
-		return dest->ExternPointer(size, GetConstant<MLIL_EXTERN_PTR>(), GetOffset<MLIL_EXTERN_PTR>(), *this);
+		return dest->ExternPointer(size, GetConstant<MLIL_EXTERN_PTR>(), GetOffset<MLIL_EXTERN_PTR>(), loc);
 	case MLIL_FLOAT_CONST:
-		return dest->FloatConstRaw(size, GetConstant<MLIL_FLOAT_CONST>(), *this);
+		return dest->FloatConstRaw(size, GetConstant<MLIL_FLOAT_CONST>(), loc);
 	case MLIL_IMPORT:
-		return dest->ImportedAddress(size, GetConstant<MLIL_IMPORT>(), *this);
+		return dest->ImportedAddress(size, GetConstant<MLIL_IMPORT>(), loc);
 	case MLIL_CONST_DATA:
-		return dest->ConstData(size, GetConstantData<MLIL_CONST_DATA>(), *this);
+		return dest->ConstData(size, GetConstantData<MLIL_CONST_DATA>(), loc);
 	case MLIL_BP:
-		return dest->Breakpoint(*this);
+		return dest->Breakpoint(loc);
 	case MLIL_TRAP:
-		return dest->Trap(GetVector<MLIL_TRAP>(), *this);
+		return dest->Trap(GetVector<MLIL_TRAP>(), loc);
 	case MLIL_INTRINSIC:
 		for (auto i : GetParameterExprs<MLIL_INTRINSIC>())
 			params.push_back(subExprHandler(i));
-		return dest->Intrinsic(GetOutputVariables<MLIL_INTRINSIC>(), GetIntrinsic<MLIL_INTRINSIC>(), params, *this);
+		return dest->Intrinsic(GetOutputVariables<MLIL_INTRINSIC>(), GetIntrinsic<MLIL_INTRINSIC>(), params, loc);
 	case MLIL_INTRINSIC_SSA:
 		for (auto i : GetParameterExprs<MLIL_INTRINSIC_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->IntrinsicSSA(
-		    GetOutputSSAVariables<MLIL_INTRINSIC_SSA>(), GetIntrinsic<MLIL_INTRINSIC_SSA>(), params, *this);
+		    GetOutputSSAVariables<MLIL_INTRINSIC_SSA>(), GetIntrinsic<MLIL_INTRINSIC_SSA>(), params, loc);
 	case MLIL_MEMORY_INTRINSIC_SSA:
 		for (auto i : GetParameterExprs<MLIL_MEMORY_INTRINSIC_SSA>())
 			params.push_back(subExprHandler(i));
 		return dest->MemoryIntrinsicSSA(GetOutputSSAVariables<MLIL_MEMORY_INTRINSIC_SSA>(),
 		    GetIntrinsic<MLIL_MEMORY_INTRINSIC_SSA>(), params, GetDestMemoryVersion<MLIL_MEMORY_INTRINSIC_SSA>(),
-		    GetSourceMemoryVersion<MLIL_MEMORY_INTRINSIC_SSA>(), *this);
+		    GetSourceMemoryVersion<MLIL_MEMORY_INTRINSIC_SSA>(), loc);
 	case MLIL_FREE_VAR_SLOT:
-		return dest->FreeVarSlot(GetDestVariable<MLIL_FREE_VAR_SLOT>(), *this);
+		return dest->FreeVarSlot(GetDestVariable<MLIL_FREE_VAR_SLOT>(), loc);
 	case MLIL_FREE_VAR_SLOT_SSA:
 		return dest->FreeVarSlotSSA(GetDestSSAVariable<MLIL_FREE_VAR_SLOT_SSA>().var,
 		    GetDestSSAVariable<MLIL_FREE_VAR_SLOT_SSA>().version,
-		    GetSourceSSAVariable<MLIL_FREE_VAR_SLOT_SSA>().version, *this);
+		    GetSourceSSAVariable<MLIL_FREE_VAR_SLOT_SSA>().version, loc);
 	case MLIL_UNDEF:
-		return dest->Undefined(*this);
+		return dest->Undefined(loc);
 	case MLIL_UNIMPL:
-		return dest->Unimplemented(*this);
+		return dest->Unimplemented(loc);
 	default:
 		throw MediumLevelILInstructionAccessException();
 	}

--- a/mediumlevelilinstruction.h
+++ b/mediumlevelilinstruction.h
@@ -26,6 +26,7 @@
 #ifdef BINARYNINJACORE_LIBRARY
 	#include "constantdata.h"
 	#include "variable.h"
+	#include "ilsourcelocation.h"
 #else
 	#include "binaryninjaapi.h"
 #endif
@@ -620,9 +621,10 @@ namespace BinaryNinja
 
 		void VisitExprs(const std::function<bool(const MediumLevelILInstruction& expr)>& func) const;
 
-		ExprId CopyTo(MediumLevelILFunction* dest) const;
+		ExprId CopyTo(MediumLevelILFunction* dest, const ILSourceLocation& sourceLocation = {}) const;
 		ExprId CopyTo(MediumLevelILFunction* dest,
-		    const std::function<ExprId(const MediumLevelILInstruction& subExpr)>& subExprHandler) const;
+		    const std::function<ExprId(const MediumLevelILInstruction& subExpr)>& subExprHandler,
+			const ILSourceLocation& sourceLocation = {}) const;
 
 		// Templated accessors for instruction operands, use these for efficient access to a known instruction
 		template <BNMediumLevelILOperation N>


### PR DESCRIPTION
This support in `LowLevelILInstruction::CopyTo` will be used in the future to provide the option for automatic inlining during analysis to create the inlined instructions with the address of the call instruction, rather than the address of the instruction in the original function.

The `MediumLevelILInstruction` and `HighLevelILInstruction` versions are updated for consistency, with no specific use case in mind.