### PR TITLE
Pass arch to finalized LowLevelILFunction

### DIFF
--- a/rust/src/low_level_il/function.rs
+++ b/rust/src/low_level_il/function.rs
@@ -254,7 +254,7 @@ impl Ref<LowLevelILFunction<Mutable, NonSSA>> {
         unsafe {
             BNFinalizeLowLevelILFunction(self.handle);
             // Now that we have finalized return the function as is so the caller can reference the "finalized function".
-            LowLevelILFunction::from_raw(self.handle).to_owned()
+            LowLevelILFunction::from_raw_with_arch(self.handle, self.arch).to_owned()
         }
     }
 }

--- a/rust/tests/low_level_il.rs
+++ b/rust/tests/low_level_il.rs
@@ -1,4 +1,6 @@
-use binaryninja::architecture::{ArchitectureExt, Intrinsic, Register};
+use binaryninja::architecture::{
+    Architecture, ArchitectureExt, CoreArchitecture, Intrinsic, Register,
+};
 use binaryninja::binary_view::BinaryViewExt;
 use binaryninja::headless::Session;
 use binaryninja::low_level_il::expression::{
@@ -8,7 +10,9 @@ use binaryninja::low_level_il::instruction::{
     InstructionHandler, LowLevelILInstructionKind, LowLevelInstructionIndex,
 };
 use binaryninja::low_level_il::operation::IntrinsicOutput;
-use binaryninja::low_level_il::{LowLevelILRegisterKind, LowLevelILSSARegisterKind, VisitorAction};
+use binaryninja::low_level_il::{
+    LowLevelILMutableFunction, LowLevelILRegisterKind, LowLevelILSSARegisterKind, VisitorAction,
+};
 use std::path::PathBuf;
 
 #[test]
@@ -348,4 +352,30 @@ fn test_llil_intrinsic() {
         }
         _ => panic!("Expected Intrinsic"),
     }
+}
+
+#[test]
+fn test_llil_unbacked_function_creation() {
+    let _session = Session::new().expect("Failed to initialize session");
+    let arch = CoreArchitecture::by_name("x86_64").unwrap();
+    // Create an LLIL function backed by no Function.
+    let llil = LowLevelILMutableFunction::new(arch, None);
+    let (instr_len, _) = arch.instruction_llil(&[0x8b, 0xd9], 0x0, &llil).unwrap();
+    assert_eq!(instr_len, 2);
+    let llil = llil.finalized();
+
+    // Validate to make sure we can read the llil instruction for a non-backed LLIL function.
+    let inst = llil
+        .instruction_from_index(LowLevelInstructionIndex(0))
+        .unwrap();
+    let LowLevelILInstructionKind::SetReg(inst_operation) = inst.kind() else {
+        panic!("Expected SetReg");
+    };
+    let LowLevelILExpressionKind::Reg(src_operation) = inst_operation.source_expr().kind() else {
+        panic!("Expected Reg");
+    };
+    let src_reg = src_operation.source_reg();
+    assert_eq!(src_reg.name(), "ecx");
+    let dest_reg = inst_operation.dest_reg();
+    assert_eq!(dest_reg.name(), "ebx");
 }


### PR DESCRIPTION
Currently it's possible to create a LowLevelILFunction with no backing function, but the finalized function does not have an arch associated with it so it's nearly unusable. For example:

```rs
let llil = LowLevelILMutableFunction::new(self.arch.clone(), None); // <- no owning function
let (instr_len, _) = self.arch.instruction_llil(&bytes, addr, &llil).unwrap();
let llil = llil.finalized();

let inst = llil.instruction_from_index(LowLevelInstructionIndex(0)).unwrap();
if let SetReg(operation) = inst.kind() {
    if let Reg(operation) = operation.source_expr().kind() {
        operation.source_reg(); // PANICS as unwrap in LowLevelILFunction::arch
    }
}
```