### PR TITLE
Add missing std::vector reserve calls

### DIFF
--- a/architecture.cpp
+++ b/architecture.cpp
@@ -1699,6 +1699,7 @@ vector<Ref<TypeLibrary>> Architecture::GetTypeLibraries()
 	BNTypeLibrary** libs = BNGetArchitectureTypeLibraries(m_object, &count);
 
 	vector<Ref<TypeLibrary>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.push_back(new TypeLibrary(BNNewTypeLibraryReference(libs[i])));
@@ -2133,6 +2134,7 @@ vector<NameAndType> CoreArchitecture::GetIntrinsicInputs(uint32_t intrinsic)
 	BNNameAndType* inputs = BNGetArchitectureIntrinsicInputs(m_object, intrinsic, &count);
 
 	vector<NameAndType> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		result.push_back(NameAndType(inputs[i].name,
@@ -2150,6 +2152,7 @@ vector<Confidence<Ref<Type>>> CoreArchitecture::GetIntrinsicOutputs(uint32_t int
 	BNTypeWithConfidence* outputs = BNGetArchitectureIntrinsicOutputs(m_object, intrinsic, &count);
 
 	vector<Confidence<Ref<Type>>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(Confidence<Ref<Type>>(new Type(BNNewTypeReference(outputs[i].type)), outputs[i].confidence));
 

--- a/architecture.cpp
+++ b/architecture.cpp
@@ -1902,6 +1902,7 @@ vector<uint32_t> CoreArchitecture::GetAllSemanticFlagClasses()
 	uint32_t* regs = BNGetAllArchitectureSemanticFlagClasses(m_object, &count);
 
 	vector<uint32_t> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(regs[i]);
 
@@ -1916,6 +1917,7 @@ vector<uint32_t> CoreArchitecture::GetAllSemanticFlagGroups()
 	uint32_t* regs = BNGetAllArchitectureSemanticFlagGroups(m_object, &count);
 
 	vector<uint32_t> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(regs[i]);
 
@@ -1936,6 +1938,7 @@ vector<uint32_t> CoreArchitecture::GetFlagsRequiredForFlagCondition(BNLowLevelIL
 	uint32_t* flags = BNGetArchitectureFlagsRequiredForFlagCondition(m_object, cond, semClass, &count);
 
 	vector<uint32_t> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(flags[i]);
 
@@ -2079,6 +2082,7 @@ vector<uint32_t> CoreArchitecture::GetAllRegisterStacks()
 	uint32_t* regs = BNGetAllArchitectureRegisterStacks(m_object, &count);
 
 	vector<uint32_t> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(regs[i]);
 
@@ -2114,6 +2118,7 @@ vector<uint32_t> CoreArchitecture::GetAllIntrinsics()
 	uint32_t* regs = BNGetAllArchitectureIntrinsics(m_object, &count);
 
 	vector<uint32_t> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(regs[i]);
 

--- a/basedetection.cpp
+++ b/basedetection.cpp
@@ -84,6 +84,7 @@ std::vector<BNBaseAddressDetectionReason> BaseAddressDetection::GetReasonsForBas
     if (!reasons)
         return result;
 
+    result.reserve(count);
     for (size_t i = 0; i < count; i++)
         result.push_back(reasons[i]);
 

--- a/binaryninjaapi.cpp
+++ b/binaryninjaapi.cpp
@@ -454,6 +454,7 @@ BinaryNinja::ProgressFunction BinaryNinja::SplitProgress(
 	// Keep a running count of weights for the start
 	std::vector<double> subpartStarts;
 	double start = 0.0;
+	subpartStarts.reserve(subpartWeights.size());
 	for (size_t i = 0; i < subpartWeights.size(); ++i)
 	{
 		subpartStarts.push_back(start);

--- a/binaryview.cpp
+++ b/binaryview.cpp
@@ -3095,6 +3095,7 @@ unordered_set<QualifiedName> BinaryView::GetOutgoingRecursiveTypeReferences(cons
 {
 	size_t count;
 	vector<BNQualifiedName> apiTypes;
+	apiTypes.resize(types.size());
 	for (auto& type: types)
 	{
 		apiTypes.push_back(type.GetAPIObject());
@@ -3146,6 +3147,7 @@ unordered_set<QualifiedName> BinaryView::GetIncomingRecursiveTypeReferences(cons
 {
 	size_t count;
 	vector<BNQualifiedName> apiTypes;
+	apiTypes.reserve(types.size());
 	for (auto& type: types)
 	{
 		apiTypes.push_back(type.GetAPIObject());
@@ -4045,6 +4047,7 @@ vector<DerivedString> BinaryView::GetDerivedStrings()
 	size_t count;
 	BNDerivedString* strings = BNGetDerivedStrings(m_object, &count);
 	vector<DerivedString> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(DerivedString::FromAPIObject(&strings[i], false));
 	BNFreeDerivedStringList(strings, count);
@@ -4281,10 +4284,12 @@ bool BinaryView::ParseTypesFromSource(const string& source, const vector<string>
 	}
 
 	vector<const char*> coreOptions;
+	coreOptions.reserve(options.size());
 	for (auto& option : options)
 		coreOptions.push_back(option.c_str());
 
 	vector<const char*> coreIncludeDirs;
+	coreIncludeDirs.reserve(includeDirs.size());
 	for (auto& includeDir : includeDirs)
 		coreIncludeDirs.push_back(includeDir.c_str());
 
@@ -4911,6 +4916,7 @@ bool BinaryView::DisassociateTypeArchiveType(const std::string& typeId)
 bool BinaryView::PullTypeArchiveTypes(const std::string& archiveId, const std::unordered_set<std::string>& archiveTypeIds, std::unordered_map<std::string, std::string>& updatedTypes)
 {
 	std::vector<const char*> apiArchiveTypeIds;
+	apiArchiveTypeIds.reserve(archiveTypeIds.size());
 	for (const auto& archiveTypeId: archiveTypeIds)
 	{
 		apiArchiveTypeIds.push_back(archiveTypeId.c_str());
@@ -4935,6 +4941,7 @@ bool BinaryView::PullTypeArchiveTypes(const std::string& archiveId, const std::u
 bool BinaryView::PushTypeArchiveTypes(const std::string& archiveId, const std::unordered_set<std::string>& typeIds, std::unordered_map<std::string, std::string>& updatedTypes)
 {
 	std::vector<const char*> apiTypeIds;
+	apiTypeIds.reserve(typeIds.size());
 	for (const auto& typeId: typeIds)
 	{
 		apiTypeIds.push_back(typeId.c_str());

--- a/binaryview.cpp
+++ b/binaryview.cpp
@@ -2418,6 +2418,7 @@ vector<Ref<Function>> BinaryView::GetAllEntryFunctions()
 		return {};
 
 	vector<Ref<Function>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(new Function(BNNewFunctionReference(funcs[i])));
 	BNFreeFunctionList(funcs, count);
@@ -4377,6 +4378,7 @@ vector<pair<QualifiedName, Ref<Type>>> BinaryView::GetDependencySortedTypes()
 	BNQualifiedNameAndType* types = BNGetAnalysisDependencySortedTypeList(m_object, &count);
 
 	vector<pair<QualifiedName, Ref<Type>>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		QualifiedName name = QualifiedName::FromAPIObject(&types[i].name);
@@ -4647,6 +4649,7 @@ std::vector<Ref<TypeLibrary>> BinaryView::GetTypeLibraries()
 	BNTypeLibrary** libs = BNGetBinaryViewTypeLibraries(m_object, &count);
 
 	vector<Ref<TypeLibrary>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.push_back(new TypeLibrary(BNNewTypeLibraryReference(libs[i])));

--- a/collaboration.cpp
+++ b/collaboration.cpp
@@ -437,6 +437,7 @@ bool BinaryNinja::Collaboration::TypeArchiveConflictHandlerCallback(void* ctxt, 
 	if (!chctxt->callback)
 		return true;
 	std::vector<Ref<TypeArchiveMergeConflict>> conflictVec;
+	conflictVec.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		conflictVec.push_back(new TypeArchiveMergeConflict(conflicts[i]));
@@ -658,6 +659,7 @@ std::vector<std::pair<std::string, std::string>> Remote::GetAuthBackends()
 		throw RemoteException("Failed to get authentication backends");
 
 	std::vector<std::pair<std::string, std::string>> results;
+	results.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		results.push_back({methods[i], names[i]});
@@ -855,6 +857,7 @@ std::vector<std::pair<uint64_t, std::string>> Remote::SearchGroups(const std::st
 		throw RemoteException("Failed to search groups");
 
 	std::vector<std::pair<uint64_t, std::string>> results;
+	results.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		results.push_back({ids[i], names[i]});
@@ -965,6 +968,7 @@ std::vector<std::pair<std::string, std::string>> Remote::SearchUsers(const std::
 		throw RemoteException("Failed to search users");
 
 	std::vector<std::pair<std::string, std::string>> results;
+	results.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		results.push_back({ids[i], names[i]});
@@ -2527,6 +2531,7 @@ std::vector<std::string> CollabSnapshot::GetParentIds()
 	size_t count = 0;
 	char** strs = BNCollaborationSnapshotGetParentIds(m_object, &count);
 	std::vector<std::string> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		result.push_back(strs[i]);
@@ -2541,6 +2546,7 @@ std::vector<std::string> CollabSnapshot::GetChildIds()
 	size_t count = 0;
 	char** strs = BNCollaborationSnapshotGetParentIds(m_object, &count);
 	std::vector<std::string> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		result.push_back(strs[i]);

--- a/database.cpp
+++ b/database.cpp
@@ -248,6 +248,7 @@ vector<Ref<Snapshot>> Snapshot::GetParents()
 	size_t count;
 	BNSnapshot** parents = BNGetSnapshotParents(m_object, &count);
 	vector<Ref<Snapshot>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		result.push_back(new Snapshot(BNNewSnapshotReference(parents[i])));
@@ -262,6 +263,7 @@ vector<Ref<Snapshot>> Snapshot::GetChildren()
 	size_t count;
 	BNSnapshot** children = BNGetSnapshotChildren(m_object, &count);
 	vector<Ref<Snapshot>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		result.push_back(new Snapshot(BNNewSnapshotReference(children[i])));
@@ -323,6 +325,7 @@ vector<Ref<UndoEntry>> Snapshot::GetUndoEntries(const ProgressFunction& progress
 	}
 
 	vector<Ref<UndoEntry>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		result.push_back(new UndoEntry(BNNewUndoEntryReference(entries[i])));
@@ -390,6 +393,7 @@ vector<Ref<Snapshot>> Database::GetSnapshots()
 	size_t count;
 	BNSnapshot** snapshots = BNGetDatabaseSnapshots(m_object, &count);
 	vector<Ref<Snapshot>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(new Snapshot(BNNewSnapshotReference(snapshots[i])));
 	BNFreeSnapshotList(snapshots, count);
@@ -455,6 +459,7 @@ std::vector<std::string> Database::GetGlobalKeys() const
 	}
 
 	std::vector<std::string> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		result.push_back(value[i]);

--- a/debuginfo.cpp
+++ b/debuginfo.cpp
@@ -44,6 +44,7 @@ vector<string> DebugInfo::GetParsers() const
 	char** parsers = BNGetDebugParserNames(m_object, &count);
 
 	vector<string> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.emplace_back(parsers[i]);
@@ -70,6 +71,7 @@ vector<NameAndType> DebugInfo::GetTypes(const string& parserName) const
 		return {};
 
 	vector<NameAndType> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.emplace_back(nameAndTypes[i].name,
@@ -136,6 +138,7 @@ vector<DataVariableAndName> DebugInfo::GetDataVariables(const string& parserName
 		return {};
 
 	vector<DataVariableAndName> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.emplace_back(variablesAndName[i].address,
@@ -193,6 +196,7 @@ vector<tuple<string, Ref<Type>>> DebugInfo::GetTypesByName(const string& name) c
 		return {};
 
 	vector<tuple<string, Ref<Type>>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.emplace_back(namesAndTypes[i].name, Ref<Type>(new Type(BNNewTypeReference(namesAndTypes[i].type))));
@@ -213,6 +217,7 @@ vector<tuple<string, uint64_t, Ref<Type>>> DebugInfo::GetDataVariablesByName(con
 		return {};
 
 	vector<tuple<string, uint64_t, Ref<Type>>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.emplace_back(variablesAndName[i].name, variablesAndName[i].address,
@@ -234,6 +239,7 @@ vector<tuple<string, string, Ref<Type>>> DebugInfo::GetDataVariablesByAddress(co
 		return {};
 
 	vector<tuple<string, string, Ref<Type>>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.emplace_back(variablesAndName[i].parser, variablesAndName[i].name,
@@ -376,6 +382,7 @@ vector<Ref<DebugInfoParser>> DebugInfoParser::GetList()
 	BNDebugInfoParser** parsers = BNGetDebugInfoParsers(&count);
 
 	vector<Ref<DebugInfoParser>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.emplace_back(new DebugInfoParser(BNNewDebugInfoParserReference(parsers[i])));
@@ -392,6 +399,7 @@ vector<Ref<DebugInfoParser>> DebugInfoParser::GetListForView(const Ref<BinaryVie
 	BNDebugInfoParser** parsers = BNGetDebugInfoParsersForView(data->GetObject(), &count);
 
 	vector<Ref<DebugInfoParser>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.emplace_back(new DebugInfoParser(BNNewDebugInfoParserReference(parsers[i])));

--- a/debuginfo.cpp
+++ b/debuginfo.cpp
@@ -91,13 +91,16 @@ vector<DebugFunctionInfo> DebugInfo::GetFunctions(const string& parserName) cons
 		return {};
 
 	vector<DebugFunctionInfo> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		vector<string> components;
+		components.reserve(functions[i].componentN);
 		for (size_t componentN = 0; componentN < functions[i].componentN; ++componentN)
 			components.emplace_back(functions[i].components[componentN]);
 
 		vector<VariableNameAndType> localVariables;
+		localVariables.reserve(functions[i].localVariableN);
 		for (size_t localVariableN = 0; localVariableN < functions[i].localVariableN; ++localVariableN)
 		{
 			auto& bnVar = functions[i].localVariables[localVariableN];

--- a/demangle.cpp
+++ b/demangle.cpp
@@ -191,6 +191,7 @@ namespace BinaryNinja {
 		size_t count;
 		BNDemangler** list = BNGetDemanglerList(&count);
 		vector<Ref<Demangler>> result;
+		result.reserve(count);
 		for (size_t i = 0; i < count; i++)
 			result.push_back(new CoreDemangler(list[i]));
 		BNFreeDemanglerList(list);

--- a/downloadprovider.cpp
+++ b/downloadprovider.cpp
@@ -230,6 +230,7 @@ vector<Ref<DownloadProvider>> DownloadProvider::GetList()
 	size_t count;
 	BNDownloadProvider** list = BNGetDownloadProviderList(&count);
 	vector<Ref<DownloadProvider>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(new CoreDownloadProvider(list[i]));
 	BNFreeDownloadProviderList(list);

--- a/enterprise.cpp
+++ b/enterprise.cpp
@@ -55,6 +55,7 @@ std::vector<std::pair<std::string, std::string>> BinaryNinja::Enterprise::GetAut
 	size_t count = BNGetEnterpriseServerAuthenticationMethods(&methods, &names);
 
 	std::vector<std::pair<std::string, std::string>> results;
+	results.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		results.push_back({methods[i], names[i]});

--- a/filemetadata.cpp
+++ b/filemetadata.cpp
@@ -389,6 +389,7 @@ vector<Ref<UndoEntry>> FileMetadata::GetUndoEntries()
 	BNUndoEntry** entries = BNGetUndoEntries(m_object, &count);
 
 	vector<Ref<UndoEntry>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		result.push_back(new UndoEntry(BNNewUndoEntryReference(entries[i])));
@@ -404,6 +405,7 @@ vector<Ref<UndoEntry>> FileMetadata::GetRedoEntries()
 	BNUndoEntry** entries = BNGetRedoEntries(m_object, &count);
 
 	vector<Ref<UndoEntry>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		result.push_back(new UndoEntry(BNNewUndoEntryReference(entries[i])));

--- a/firmwareninja.cpp
+++ b/firmwareninja.cpp
@@ -508,6 +508,7 @@ std::vector<FirmwareNinjaFunctionMemoryAccesses> FirmwareNinja::GetFunctionMemor
 		FirmwareNinjaFunctionMemoryAccesses info;
 		info.start = fma[i]->start;
 		info.count = fma[i]->count;
+		info.accesses.reserve(info.count);
 		for (size_t j = 0; j < info.count; j++)
 		{
 			BNFirmwareNinjaMemoryAccess access;

--- a/flowgraph.cpp
+++ b/flowgraph.cpp
@@ -442,6 +442,7 @@ std::vector<RenderLayer*> FlowGraph::GetRenderLayers() const
 	size_t count = 0;
 	BNRenderLayer** layers = BNGetFlowGraphRenderLayers(m_object, &count);
 	std::vector<RenderLayer*> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i ++)
 	{
 		result.push_back(new CoreRenderLayer(layers[i]));

--- a/function.cpp
+++ b/function.cpp
@@ -733,6 +733,7 @@ Confidence<vector<uint32_t>> Function::GetReturnRegisters() const
 {
 	BNRegisterSetWithConfidence regs = BNGetFunctionReturnRegisters(m_object);
 	vector<uint32_t> regList;
+	regList.reserve(regs.count);
 	for (size_t i = 0; i < regs.count; i++)
 		regList.push_back(regs.regs[i]);
 	Confidence<vector<uint32_t>> result(regList, regs.confidence);

--- a/highlevelilinstruction.cpp
+++ b/highlevelilinstruction.cpp
@@ -840,6 +840,7 @@ void HighLevelILInstructionBase::UpdateRawOperandAsExprList(
     size_t operandIndex, const vector<HighLevelILInstruction>& exprs)
 {
 	vector<ExprId> exprIndexList;
+	exprIndexList.reserve(exprs.size());
 	for (auto& i : exprs)
 		exprIndexList.push_back((ExprId)i.exprIndex);
 	UpdateRawOperand(operandIndex, exprIndexList.size());

--- a/interaction.cpp
+++ b/interaction.cpp
@@ -276,6 +276,7 @@ static bool GetChoiceInputCallback(
 {
 	InteractionHandler* handler = (InteractionHandler*)ctxt;
 	vector<string> choiceStrs;
+	choiceStrs.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		choiceStrs.push_back(choices[i]);
 	return handler->GetChoiceInput(*result, prompt, title, choiceStrs);
@@ -287,6 +288,7 @@ static bool GetLargeChoiceInputCallback(
 {
 	InteractionHandler* handler = (InteractionHandler*)ctxt;
 	vector<string> choiceStrs;
+	choiceStrs.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		choiceStrs.push_back(choices[i]);
 	return handler->GetLargeChoiceInput(*result, prompt,title, choiceStrs);

--- a/linearviewcursor.cpp
+++ b/linearviewcursor.cpp
@@ -88,6 +88,7 @@ vector<Ref<LinearViewObject>> LinearViewCursor::GetPathObjects() const
 	size_t count;
 	BNLinearViewObject** path = BNGetLinearViewCursorPathObjects(m_object, &count);
 	vector<Ref<LinearViewObject>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(new LinearViewObject(BNNewLinearViewObjectReference(path[i])));
 	BNFreeLinearViewCursorPathObjects(path, count);
@@ -217,6 +218,7 @@ std::vector<RenderLayer*> LinearViewCursor::GetRenderLayers() const
 	size_t count = 0;
 	BNRenderLayer** layers = BNGetLinearViewCursorRenderLayers(m_object, &count);
 	std::vector<RenderLayer*> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i ++)
 	{
 		result.push_back(new CoreRenderLayer(layers[i]));

--- a/linearviewcursor.cpp
+++ b/linearviewcursor.cpp
@@ -68,6 +68,7 @@ vector<LinearViewObjectIdentifier> LinearViewCursor::GetPath() const
 	size_t count;
 	BNLinearViewObjectIdentifier* path = BNGetLinearViewCursorPath(m_object, &count);
 	vector<LinearViewObjectIdentifier> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		LinearViewObjectIdentifier id;

--- a/lineformatter.cpp
+++ b/lineformatter.cpp
@@ -126,6 +126,7 @@ vector<Ref<LineFormatter>> LineFormatter::GetList()
 	size_t count;
 	BNLineFormatter** list = BNGetLineFormatterList(&count);
 	vector<Ref<LineFormatter>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(new CoreLineFormatter(list[i]));
 	BNFreeLineFormatterList(list);

--- a/mediumlevelilinstruction.cpp
+++ b/mediumlevelilinstruction.cpp
@@ -1014,6 +1014,7 @@ void MediumLevelILInstructionBase::UpdateRawOperandAsExprList(
     size_t operandIndex, const vector<MediumLevelILInstruction>& exprs)
 {
 	vector<ExprId> exprIndexList;
+	exprIndexList.reserve(exprs.size());
 	for (auto& i : exprs)
 		exprIndexList.push_back((ExprId)i.exprIndex);
 	UpdateRawOperand(operandIndex, exprIndexList.size());

--- a/platform.cpp
+++ b/platform.cpp
@@ -124,11 +124,14 @@ void Platform::AdjustTypeParserInputCallback(
 	Ref<TypeParser> parserCpp = new CoreTypeParser(parser);
 
 	vector<string> arguments;
+	arguments.reserve(argumentsLenIn);
 	for (size_t i = 0; i < argumentsLenIn; i ++)
 	{
 		arguments.push_back(argumentsIn[i]);
 	}
+
 	vector<pair<string, string>> sourceFiles;
+	sourceFiles.reserve(sourceFilesLenIn);
 	for (size_t i = 0; i < sourceFilesLenIn; i ++)
 	{
 		sourceFiles.push_back(make_pair(sourceFileNamesIn[i], sourceFileValuesIn[i]));
@@ -141,6 +144,7 @@ void Platform::AdjustTypeParserInputCallback(
 	);
 
 	vector<const char*> argumentsPtrs;
+	argumentsPtrs.reserve(arguments.size());
 	for (auto& argument : arguments)
 	{
 		argumentsPtrs.push_back(argument.c_str());
@@ -490,6 +494,7 @@ void CorePlatform::AdjustTypeParserInput(
 )
 {
 	vector<const char*> argumentsIn;
+	argumentsIn.reserve(arguments.size());
 	for (size_t i = 0; i < arguments.size(); i ++)
 	{
 		argumentsIn.push_back(arguments[i].c_str());
@@ -561,6 +566,7 @@ std::vector<Ref<Platform>> Platform::GetRelatedPlatforms()
 	BNPlatform** related = BNGetRelatedPlatforms(m_object, &count);
 
 	std::vector<Ref<Platform>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		result.push_back(new CorePlatform(BNNewPlatformReference(related[i])));
@@ -656,6 +662,7 @@ vector<Ref<TypeLibrary>> Platform::GetTypeLibraries()
 	BNTypeLibrary** libs = BNGetPlatformTypeLibraries(m_object, &count);
 
 	vector<Ref<TypeLibrary>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.push_back(new TypeLibrary(BNNewTypeLibraryReference(libs[i])));
@@ -672,6 +679,7 @@ vector<Ref<TypeLibrary>> Platform::GetTypeLibrariesByName(const std::string& nam
 	BNTypeLibrary** libs = BNGetPlatformTypeLibrariesByName(m_object, name.c_str(), &count);
 
 	vector<Ref<TypeLibrary>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.push_back(new TypeLibrary(BNNewTypeLibraryReference(libs[i])));

--- a/platform.cpp
+++ b/platform.cpp
@@ -446,6 +446,7 @@ std::vector<uint32_t> CorePlatform::GetGlobalRegisters()
 	uint32_t* regs = BNGetPlatformGlobalRegisters(m_object, &count);
 
 	std::vector<uint32_t> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(regs[i]);
 

--- a/pluginmanager.cpp
+++ b/pluginmanager.cpp
@@ -114,6 +114,7 @@ vector<PluginType> RepoPlugin::GetPluginTypes() const
 	size_t count;
 	BNPluginType* pluginTypesPtr = BNPluginGetPluginTypes(m_object, &count);
 	vector<PluginType> pluginTypes;
+	pluginTypes.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		pluginTypes.push_back((PluginType)pluginTypesPtr[i]);
@@ -170,6 +171,7 @@ vector<string> RepoPlugin::GetInstallPlatforms() const
 	vector<string> result;
 	size_t count = 0;
 	char** platforms = BNPluginGetPlatforms(m_object, &count);
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(platforms[i]);
 	BNFreeStringList(platforms, count);
@@ -335,6 +337,7 @@ vector<Ref<Repository>> RepositoryManager::GetRepositories()
 	vector<Ref<Repository>> repos;
 	size_t count = 0;
 	BNRepository** reposPtr = BNRepositoryManagerGetRepositories(m_object, &count);
+	repos.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		repos.push_back(new Repository(BNNewRepositoryReference(reposPtr[i])));
 	BNFreeRepositoryManagerRepositoriesList(reposPtr);

--- a/possiblevalueset.cpp
+++ b/possiblevalueset.cpp
@@ -34,6 +34,7 @@ PossibleValueSet PossibleValueSet::FromAPIObject(BNPossibleValueSet& value)
 	result.size = value.size;
 	if (value.state == LookupTableValue)
 	{
+		result.table.reserve(value.count);
 		for (size_t i = 0; i < value.count; i++)
 		{
 			LookupTableEntry entry;
@@ -45,6 +46,7 @@ PossibleValueSet PossibleValueSet::FromAPIObject(BNPossibleValueSet& value)
 	}
 	else if ((value.state == SignedRangeValue) || (value.state == UnsignedRangeValue))
 	{
+		result.ranges.reserve(value.count);
 		for (size_t i = 0; i < value.count; i++)
 			result.ranges.push_back(value.ranges[i]);
 	}

--- a/scriptingprovider.cpp
+++ b/scriptingprovider.cpp
@@ -388,6 +388,7 @@ vector<Ref<ScriptingProvider>> ScriptingProvider::GetList()
 	size_t count;
 	BNScriptingProvider** list = BNGetScriptingProviderList(&count);
 	vector<Ref<ScriptingProvider>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(new CoreScriptingProvider(list[i]));
 	BNFreeScriptingProviderList(list);

--- a/secretsprovider.cpp
+++ b/secretsprovider.cpp
@@ -73,6 +73,7 @@ std::vector<Ref<SecretsProvider>> SecretsProvider::GetList()
 	size_t count;
 	BNSecretsProvider** list = BNGetSecretsProviderList(&count);
 	std::vector<Ref<SecretsProvider>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(new CoreSecretsProvider(list[i]));
 	BNFreeSecretsProviderList(list);

--- a/type.cpp
+++ b/type.cpp
@@ -758,6 +758,7 @@ std::vector<TypeAttribute> Type::GetAttributes() const
 	size_t count = 0;
 	BNTypeAttribute* attributes = BNGetTypeAttributes(m_object, &count);
 	std::vector<TypeAttribute> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.emplace_back(attributes[i].name, attributes[i].value);
 	BNFreeTypeAttributeList(attributes, count);
@@ -2259,6 +2260,7 @@ std::vector<TypeAttribute> TypeBuilder::GetAttributes() const
 	size_t count;
 	BNTypeAttribute* attributes = BNGetTypeBuilderAttributes(m_object, &count);
 	std::vector<TypeAttribute> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.emplace_back(attributes[i].name, attributes[i].value);
 	BNFreeTypeAttributeList(attributes, count);

--- a/type.cpp
+++ b/type.cpp
@@ -2218,6 +2218,7 @@ TypeBuilder& TypeBuilder::AddPointerSuffix(BNPointerSuffix ps)
 TypeBuilder& TypeBuilder::SetPointerSuffix(const std::set<BNPointerSuffix>& suffix)
 {
 	std::vector<BNPointerSuffix> apiSuffix;
+	apiSuffix.reserve(suffix.size());
 	for (auto& s: suffix)
 	{
 		apiSuffix.push_back(s);

--- a/typearchive.cpp
+++ b/typearchive.cpp
@@ -177,6 +177,7 @@ std::vector<std::string> TypeArchive::GetAllSnapshotIds() const
 		throw ExceptionWithStackTrace("BNGetTypeArchiveAllSnapshotIds");
 
 	std::vector<std::string> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i ++)
 	{
 		result.push_back(ids[i]);
@@ -195,6 +196,7 @@ std::vector<std::string> TypeArchive::GetSnapshotParentIds(const std::string& id
 		throw ExceptionWithStackTrace("BNGetTypeArchiveSnapshotParentIds");
 
 	std::vector<std::string> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i ++)
 	{
 		result.push_back(ids[i]);
@@ -213,6 +215,7 @@ std::vector<std::string> TypeArchive::GetSnapshotChildIds(const std::string& id)
 		throw ExceptionWithStackTrace("BNGetTypeArchiveSnapshotChildIds");
 
 	std::vector<std::string> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i ++)
 	{
 		result.push_back(ids[i]);
@@ -348,6 +351,7 @@ std::vector<std::string> TypeArchive::GetTypeIds(std::string snapshot) const
 		throw ExceptionWithStackTrace("BNGetTypeArchiveTypeIds");
 
 	std::vector<std::string> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.push_back(ids[i]);
@@ -367,6 +371,7 @@ std::vector<QualifiedName> TypeArchive::GetTypeNames(std::string snapshot) const
 		throw ExceptionWithStackTrace("BNGetTypeArchiveTypeNames");
 
 	std::vector<QualifiedName> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; ++i)
 	{
 		result.push_back(QualifiedName::FromAPIObject(&names[i]));
@@ -500,6 +505,7 @@ std::string TypeArchive::NewSnapshotTransaction(std::function<void(const std::st
 	ctxt.func = func;
 
 	std::vector<const char*> apiParents;
+	apiParents.reserve(parents.size());
 	for (const auto& parent: parents)
 	{
 		apiParents.push_back(parent.c_str());

--- a/typearchive.cpp
+++ b/typearchive.cpp
@@ -232,6 +232,7 @@ TypeContainer TypeArchive::GetTypeContainer() const
 bool TypeArchive::AddTypes(const std::vector<QualifiedNameAndType>& types)
 {
 	std::vector<BNQualifiedNameAndType> apiTypes;
+	apiTypes.reserve(types.size());
 	for (auto& type : types)
 	{
 		BNQualifiedNameAndType qnat;

--- a/typeparser.cpp
+++ b/typeparser.cpp
@@ -20,6 +20,7 @@ vector<Ref<TypeParser>> TypeParser::GetList()
 	size_t count;
 	BNTypeParser** list = BNGetTypeParserList(&count);
 	vector<Ref<TypeParser>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(new CoreTypeParser(list[i]));
 	BNFreeTypeParserList(list);
@@ -63,6 +64,7 @@ std::vector<std::string> TypeParser::ParseOptionsText(const std::string& options
 	char** options = BNParseTypeParserOptionsText(optionsText.c_str(), &count);
 
 	std::vector<std::string> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 	{
 		result.push_back(options[i]);
@@ -140,12 +142,14 @@ bool TypeParser::PreprocessSourceCallback(void* ctxt,
 	TypeParser* parser = (TypeParser*)ctxt;
 
 	vector<string> optionsCpp;
+	optionsCpp.reserve(optionCount);
 	for (size_t i = 0; i < optionCount; i ++)
 	{
 		optionsCpp.push_back(options[i]);
 	}
 
 	vector<string> includeDirsCpp;
+	includeDirsCpp.reserve(includeDirCount);
 	for (size_t i = 0; i < includeDirCount; i ++)
 	{
 		includeDirsCpp.push_back(includeDirs[i]);
@@ -200,12 +204,14 @@ bool TypeParser::ParseTypesFromSourceCallback(void* ctxt,
 	TypeParser* parser = (TypeParser*)ctxt;
 
 	vector<string> optionsCpp;
+	optionsCpp.reserve(optionCount);
 	for (size_t i = 0; i < optionCount; i ++)
 	{
 		optionsCpp.push_back(options[i]);
 	}
 
 	vector<string> includeDirsCpp;
+	includeDirsCpp.reserve(includeDirCount);
 	for (size_t i = 0; i < includeDirCount; i ++)
 	{
 		includeDirsCpp.push_back(includeDirs[i]);

--- a/typeprinter.cpp
+++ b/typeprinter.cpp
@@ -121,6 +121,7 @@ bool TypePrinter::PrintAllTypesCallback(void* ctxt, BNQualifiedName* names, BNTy
 {
 	TypePrinter* printer = (TypePrinter*)ctxt;
 	vector<pair<QualifiedName, Ref<Type>>> apiTypes;
+	apiTypes.reserve(typeCount);
 	for (size_t i = 0; i < typeCount; ++i)
 	{
 		apiTypes.push_back({QualifiedName::FromAPIObject(&names[i]), new Type(types[i])});
@@ -173,6 +174,7 @@ std::vector<Ref<TypePrinter>> TypePrinter::GetList()
 	size_t count;
 	BNTypePrinter** list = BNGetTypePrinterList(&count);
 	vector<Ref<TypePrinter>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(new CoreTypePrinter(list[i]));
 	BNFreeTypePrinterList(list);
@@ -449,7 +451,7 @@ std::vector<TypeDefinitionLine> CoreTypePrinter::GetTypeLines(Ref<Type> type,
 		return {};
 
 	vector<TypeDefinitionLine> cppLines;
-
+	cppLines.reserve(lineCount);
 	for (size_t i = 0; i < lineCount; ++i)
 	{
 		cppLines.push_back(TypeDefinitionLine::FromAPIObject(&lines[i]));

--- a/unicode.cpp
+++ b/unicode.cpp
@@ -64,6 +64,7 @@ std::vector<std::vector<std::pair<uint32_t, uint32_t>>> BinaryNinja::Unicode::Ge
 	for (size_t i = 0; i < blockListCounts; i ++)
 	{
 		std::vector<std::pair<uint32_t, uint32_t>> blockList;
+		blockList.reserve(blockCounts[i]);
 		for (size_t j = 0; j < blockCounts[i]; j ++)
 		{
 			blockList.push_back(std::make_pair(blockStarts[i][j], blockEnds[i][j]));

--- a/websocketprovider.cpp
+++ b/websocketprovider.cpp
@@ -165,6 +165,7 @@ vector<Ref<WebsocketProvider>> WebsocketProvider::GetList()
 	size_t count;
 	BNWebsocketProvider** list = BNGetWebsocketProviderList(&count);
 	vector<Ref<WebsocketProvider>> result;
+	result.reserve(count);
 	for (size_t i = 0; i < count; i++)
 		result.push_back(new CoreWebsocketProvider(list[i]));
 	BNFreeWebsocketProviderList(list);


### PR DESCRIPTION
Fixes issue #7702 and adds `vector.reverse()` calls in other places