### PR TITLE
[Rust] Add more type library examples

### DIFF
--- a/rust/examples/bndb_to_type_library.rs
+++ b/rust/examples/bndb_to_type_library.rs
@@ -1,0 +1,39 @@
+// Usage: cargo run --example bndb_to_type_library <bndb_path> <type_library_path>
+
+use binaryninja::binary_view::BinaryViewExt;
+use binaryninja::type_library::TypeLibrary;
+use binaryninja::types::QualifiedName;
+
+fn main() {
+    let bndb_path_str = std::env::args().nth(1).expect("No header provided");
+    let bndb_path = std::path::Path::new(&bndb_path_str);
+
+    let type_lib_path_str = std::env::args().nth(2).expect("No type library provided");
+    let type_lib_path = std::path::Path::new(&type_lib_path_str);
+    let type_lib_name = type_lib_path.file_stem().unwrap().to_str().unwrap();
+
+    println!("Starting session...");
+    // This loads all the core architecture, platform, etc plugins
+    let headless_session =
+        binaryninja::headless::Session::new().expect("Failed to initialize session");
+
+    let file = headless_session
+        .load(bndb_path)
+        .expect("Failed to load BNDB");
+
+    let type_lib = TypeLibrary::new(file.default_arch().unwrap(), type_lib_name);
+
+    for ty in &file.types() {
+        println!("Adding type: {}", ty.name);
+        type_lib.add_named_type(ty.name, &ty.ty);
+    }
+
+    for func in &file.functions() {
+        println!("Adding function: {}", func.symbol());
+        let qualified_name =
+            QualifiedName::from(func.symbol().short_name().to_string_lossy().to_string());
+        type_lib.add_named_object(qualified_name, &func.function_type());
+    }
+
+    type_lib.write_to_file(&type_lib_path);
+}

--- a/rust/examples/create_type_library.rs
+++ b/rust/examples/create_type_library.rs
@@ -1,0 +1,52 @@
+// Usage: cargo run --example create_type_library <header_file_path> <platform> <type_library_path>
+
+use binaryninja::platform::Platform;
+use binaryninja::type_library::TypeLibrary;
+use binaryninja::type_parser::{CoreTypeParser, TypeParser};
+
+fn main() {
+    let header_path_str = std::env::args().nth(1).expect("No header provided");
+    let header_path = std::path::Path::new(&header_path_str);
+    let header_name = header_path.file_stem().unwrap().to_str().unwrap();
+    let type_lib_plat_str = std::env::args().nth(2).expect("No type library provided");
+    let type_lib_path_str = std::env::args().nth(3).expect("No type library provided");
+    let type_lib_path = std::path::Path::new(&type_lib_path_str);
+    let type_lib_name = type_lib_path.file_stem().unwrap().to_str().unwrap();
+
+    let header_contents = std::fs::read_to_string(header_path).expect("Failed to read header file");
+
+    println!("Starting session...");
+    // This loads all the core architecture, platform, etc plugins
+    let _headless_session =
+        binaryninja::headless::Session::new().expect("Failed to initialize session");
+
+    let type_lib_plat = Platform::by_name(&type_lib_plat_str).expect("Invalid platform");
+
+    let type_lib = TypeLibrary::new(type_lib_plat.arch(), type_lib_name);
+
+    let plat_type_container = type_lib_plat.type_container();
+    let parser = CoreTypeParser::default();
+    let parsed_types = parser
+        .parse_types_from_source(
+            &header_contents,
+            header_name,
+            &type_lib_plat,
+            &plat_type_container,
+            &[],
+            &[],
+            "",
+        )
+        .expect("Parsed types");
+
+    for ty in parsed_types.types {
+        println!("Adding type: {}", ty.name);
+        type_lib.add_named_type(ty.name, &ty.ty);
+    }
+
+    for func in parsed_types.functions {
+        println!("Adding function: {}", func.name);
+        type_lib.add_named_object(func.name, &func.ty);
+    }
+
+    type_lib.write_to_file(&type_lib_path);
+}

--- a/rust/examples/dump_type_library.rs
+++ b/rust/examples/dump_type_library.rs
@@ -15,15 +15,21 @@ fn main() {
         binaryninja::headless::Session::new().expect("Failed to initialize session");
 
     let type_lib = TypeLibrary::load_from_file(type_lib_path).expect("Failed to load type library");
-    let named_types = type_lib.named_types();
     println!("Name: `{}`", type_lib.name());
     println!("GUID: `{}`", type_lib.guid());
 
     // Print out all the types as a c header.
     let type_lib_header_path = type_lib_path.with_extension("h");
+
+    let all_types: Vec<_> = type_lib
+        .named_types()
+        .iter()
+        .chain(type_lib.named_objects().iter())
+        .collect();
+
     println!(
         "Dumping {} types to: `{:?}`",
-        named_types.len(),
+        all_types.len(),
         type_lib_header_path
     );
     let type_printer = CoreTypePrinter::default();
@@ -31,7 +37,7 @@ fn main() {
         BinaryView::from_data(&FileMetadata::new(), &[]).expect("Failed to create empty view");
     let printed_types = type_printer
         .print_all_types(
-            &type_lib.named_types(),
+            all_types,
             &empty_bv,
             4,
             TokenEscapingType::NoTokenEscapingType,


### PR DESCRIPTION
Examples for turning c header files and BNDBs into type libraries in headless rust