### PR TITLE
[WARP] Fix `warp_headless` example not linking binaryninjacore

### DIFF
--- a/plugins/warp/examples/headless/build.rs
+++ b/plugins/warp/examples/headless/build.rs
@@ -1,0 +1,15 @@
+fn main() {
+    let link_path = std::env::var_os("DEP_BINARYNINJACORE_PATH")
+        .expect("DEP_BINARYNINJACORE_PATH not specified");
+
+    println!("cargo::rustc-link-lib=dylib=binaryninjacore");
+    println!("cargo::rustc-link-search={}", link_path.to_str().unwrap());
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        println!(
+            "cargo::rustc-link-arg=-Wl,-rpath,{0},-L{0}",
+            link_path.to_string_lossy()
+        );
+    }
+}


### PR DESCRIPTION
Would result in binaryninjacore not being loaded:

```
dyld[19068]: Library not loaded: @rpath/libbinaryninjacore.1.dylib
```

Simply forgot to add build.rs to direct cargo at where to find the lib.