### PR TITLE
Use session scoped logger instance for unhandled relocation information

### DIFF
--- a/arch/arm64/arch_arm64.cpp
+++ b/arch/arm64/arch_arm64.cpp
@@ -2843,9 +2843,8 @@ class Arm64MachoRelocationHandler : public RelocationHandler
 	virtual bool GetRelocationInfo(
 	    Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view;
 		(void)arch;
-
+		Ref<Logger> logger = view->CreateLogger("Arm64MachoReloc");
 		set<MachoArm64RelocationType> unsupportedRelocations;
 		for (size_t i = 0; i < result.size(); i++)
 		{
@@ -2897,7 +2896,7 @@ class Arm64MachoRelocationHandler : public RelocationHandler
 		}
 
 		for (auto& relocType : unsupportedRelocations)
-			LogWarn("Unsupported relocation: %s (%x)", GetRelocationString(relocType), relocType);
+			logger->LogWarn("Unsupported relocation: %s (%x)", GetRelocationString(relocType), relocType);
 		return true;
 	}
 };
@@ -3159,9 +3158,9 @@ class Arm64ElfRelocationHandler : public RelocationHandler
 
 	virtual bool GetRelocationInfo(Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view;
 		(void)arch;
 		(void)result;
+		Ref<Logger> logger = view->CreateLogger("Arm64ElfReloc");
 		set<uint64_t> relocTypes;
 		for (auto& reloc : result)
 		{
@@ -3253,7 +3252,7 @@ class Arm64ElfRelocationHandler : public RelocationHandler
 			}
 		}
 		for (auto& reloc : relocTypes)
-			LogWarn("Unsupported ELF relocation type: %s", GetRelocationString((ElfArm64RelocationType)reloc));
+			logger->LogWarn("Unsupported ELF relocation type: %s", GetRelocationString((ElfArm64RelocationType)reloc));
 		return true;
 	}
 
@@ -3282,8 +3281,8 @@ class Arm64PeRelocationHandler : public RelocationHandler
 	virtual bool GetRelocationInfo(
 	    Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view;
 		(void)arch;
+		Ref<Logger> logger = view->CreateLogger("Arm64PeReloc");
 		set<uint64_t> relocTypes;
 		for (auto& reloc : result)
 		{
@@ -3291,7 +3290,7 @@ class Arm64PeRelocationHandler : public RelocationHandler
 			relocTypes.insert(reloc.nativeType);
 		}
 		for (auto& reloc : relocTypes)
-			LogWarn(
+			logger->LogWarn(
 			    "Unsupported PE relocation type: %s", GetRelocationString((PeArm64RelocationType)reloc));
 		return false;
 	}
@@ -3407,8 +3406,8 @@ public:
 
 	virtual bool GetRelocationInfo(Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view;
 		(void)arch;
+		Ref<Logger> logger = view->CreateLogger("Arm64CoffReloc");
 		set<uint64_t> relocTypes;
 		for (auto& reloc : result)
 		{
@@ -3477,7 +3476,7 @@ public:
 			}
 		}
 		for (auto& reloc : relocTypes)
-			LogWarn("Unsupported PE relocation type: %s", GetRelocationString((PeArm64RelocationType)reloc));
+			logger->LogWarn("Unsupported PE relocation type: %s", GetRelocationString((PeArm64RelocationType)reloc));
 		return false;
 	}
 };

--- a/arch/armv7/arch_armv7.cpp
+++ b/arch/armv7/arch_armv7.cpp
@@ -2497,8 +2497,8 @@ public:
 
 	virtual bool GetRelocationInfo(Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view;
 		(void)arch;
+		Ref<Logger> logger = view->CreateLogger("ArmElfReloc");
 		set<uint64_t> relocTypes;
 		for (auto& reloc: result)
 		{
@@ -2670,7 +2670,7 @@ public:
 			}
 		}
 		for (auto& reloc : relocTypes)
-			LogWarn("Unsupported ELF relocation: %s", GetRelocationString((ElfArmRelocationType)reloc));
+			logger->LogWarn("Unsupported ELF relocation: %s", GetRelocationString((ElfArmRelocationType)reloc));
 		return true;
 	}
 };
@@ -2693,8 +2693,8 @@ public:
 
 	virtual bool GetRelocationInfo(Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view;
 		(void)arch;
+		Ref<Logger> logger = view->CreateLogger("ArmMachoReloc");
 		set<uint64_t> relocTypes;
 		for (auto& reloc: result)
 		{
@@ -2702,7 +2702,7 @@ public:
 			relocTypes.insert(reloc.nativeType);
 		}
 		for (auto& reloc : relocTypes)
-			LogWarn("Unsupported Mach-O relocation %s", GetRelocationString((MachoArmRelocationType)reloc));
+			logger->LogWarn("Unsupported Mach-O relocation %s", GetRelocationString((MachoArmRelocationType)reloc));
 		return false;
 	};
 };
@@ -2745,8 +2745,8 @@ public:
 
 	virtual bool GetRelocationInfo(Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view;
 		(void)arch;
+		Ref<Logger> logger = view->CreateLogger("ArmPeReloc");
 		set<uint64_t> relocTypes;
 		for (auto& reloc: result)
 		{
@@ -2775,7 +2775,7 @@ public:
 			}
 		}
 		for (auto& reloc : relocTypes)
-			LogWarn("Unsupported PE relocation %s", GetRelocationString((PeRelocationType)reloc));
+			logger->LogWarn("Unsupported PE relocation %s", GetRelocationString((PeRelocationType)reloc));
 		return false;
 	}
 
@@ -3162,8 +3162,8 @@ public:
 
 	virtual bool GetRelocationInfo(Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view;
 		(void)arch;
+		Ref<Logger> logger = view->CreateLogger("ArmCoffReloc");
 		set<uint64_t> relocTypes;
 		for (auto& reloc: result)
 		{
@@ -3236,7 +3236,7 @@ public:
 			}
 		}
 		for (auto& reloc : relocTypes)
-			LogWarn("Unsupported COFF relocation %s", GetRelocationString((PeArmRelocationType)reloc));
+			logger->LogWarn("Unsupported COFF relocation %s", GetRelocationString((PeArmRelocationType)reloc));
 		return true;
 	}
 };

--- a/arch/powerpc/arch_ppc.cpp
+++ b/arch/powerpc/arch_ppc.cpp
@@ -2469,7 +2469,8 @@ public:
 
 	virtual bool GetRelocationInfo(Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view; (void)arch; (void)result;
+		(void)arch; (void)result;
+		Ref<Logger> logger = view->CreateLogger("PpcElfReloc");
 		set<uint64_t> relocTypes;
 		for (auto& reloc : result)
 		{
@@ -2526,7 +2527,7 @@ public:
 			}
 		}
 		for (auto& reloc : relocTypes)
-			LogWarn("Unsupported ELF relocation type: %s", GetRelocationString((ElfPpcRelocationType)reloc));
+			logger->LogWarn("Unsupported ELF relocation type: %s", GetRelocationString((ElfPpcRelocationType)reloc));
 		return true;
 	}
 
@@ -2555,7 +2556,8 @@ class PpcMachoRelocationHandler: public RelocationHandler
 public:
 	virtual bool GetRelocationInfo(Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view; (void)arch;
+		(void)arch;
+		Ref<Logger> logger = view->CreateLogger("PpcMachoReloc");
 		set<uint64_t> relocTypes;
 		for (auto& reloc : result)
 		{
@@ -2563,7 +2565,7 @@ public:
 			relocTypes.insert(reloc.nativeType);
 		}
 		for (auto& reloc : relocTypes)
-			LogWarn("Unsupported Mach-O relocation type: %s", GetRelocationString((MachoPpcRelocationType)reloc));
+			logger->LogWarn("Unsupported Mach-O relocation type: %s", GetRelocationString((MachoPpcRelocationType)reloc));
 		return false;
 	}
 };

--- a/arch/x86/arch_x86.cpp
+++ b/arch/x86/arch_x86.cpp
@@ -4058,7 +4058,8 @@ public:
 
 	virtual bool GetRelocationInfo(Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view; (void)arch;
+		(void)arch;
+		Ref<Logger> logger = view->CreateLogger("X86MachoReloc");
 		set<uint64_t> relocTypes;
 		for (size_t i = 0; i < result.size(); i++)
 		{
@@ -4080,7 +4081,7 @@ public:
 		}
 
 		for (auto& reloc : relocTypes)
-			LogWarn("Unsupported Mach-O relocation type: %s", GetRelocationString((Machox86RelocationType)reloc));
+			logger->LogWarn("Unsupported Mach-O relocation type: %s", GetRelocationString((Machox86RelocationType)reloc));
 		return true;
 	}
 };
@@ -4090,7 +4091,8 @@ class x86ElfRelocationHandler: public RelocationHandler
 public:
 	virtual bool GetRelocationInfo(Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view; (void)arch;
+		(void)arch;
+		Ref<Logger> logger = view->CreateLogger("X86ElfReloc");
 		set<uint64_t> relocTypes;
 		for (auto& reloc : result)
 		{
@@ -4154,7 +4156,7 @@ public:
 			}
 		}
 		for (auto& reloc : relocTypes)
-			LogWarn("Unsupported ELF relocation type: %s", GetRelocationString((Elfx86RelocationType)reloc));
+			logger->LogWarn("Unsupported ELF relocation type: %s", GetRelocationString((Elfx86RelocationType)reloc));
 		return true;
 	}
 };
@@ -4221,7 +4223,8 @@ public:
 
 	virtual bool GetRelocationInfo(Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view; (void)arch;
+		(void)arch;
+		Ref<Logger> logger = view->CreateLogger("X86MachoReloc");
 		set<uint64_t> relocTypes;
 		for (size_t i = 0; i < result.size(); i++)
 		{
@@ -4286,7 +4289,7 @@ public:
 		}
 
 		for (auto& reloc : relocTypes)
-			LogWarn("Unsupported Mach-O relocation: %s", GetRelocationString((Machox64RelocationType)reloc));
+			logger->LogWarn("Unsupported Mach-O relocation: %s", GetRelocationString((Machox64RelocationType)reloc));
 		return true;
 	}
 };
@@ -4345,7 +4348,8 @@ public:
 		The AMD64 ILP32 ABI architecture uses only Elf32_Rela relocation entries in relocatable files. Relocations
 			contained within executable files or shared objects may use either Elf32_Rela relocation or Elf32_Rel relocation.
 		*/
-		(void)view; (void)arch;
+		(void)arch;
+		Ref<Logger> logger = view->CreateLogger("X86ElfReloc");
 		set<uint64_t> relocTypes;
 		for (auto& reloc : result)
 		{
@@ -4477,7 +4481,7 @@ public:
 			}
 		}
 		for (auto& reloc : relocTypes)
-			LogWarn("Unsupported ELF relocation: %s", GetRelocationString((Elfx64RelocationType)reloc));
+			logger->LogWarn("Unsupported ELF relocation: %s", GetRelocationString((Elfx64RelocationType)reloc));
 		return true;
 	}
 };
@@ -4547,7 +4551,8 @@ public:
 
 	virtual bool GetRelocationInfo(Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view; (void)arch;
+		(void)arch;
+		Ref<Logger> logger = view->CreateLogger("X86CoffReloc");
 		set<uint64_t> relocTypes;
 		for (auto& reloc : result)
 		{
@@ -4608,7 +4613,7 @@ public:
 					relocTypes.insert(reloc.nativeType);
 				}
 				for (auto& reloc : relocTypes)
-					LogWarn("Unsupported COFF relocation: %s", GetRelocationString((COFFx64RelocationType)reloc));
+					logger->LogWarn("Unsupported COFF relocation: %s", GetRelocationString((COFFx64RelocationType)reloc));
 			}
 			else if (arch->GetName() == "x86")
 			{
@@ -4652,7 +4657,7 @@ public:
 					relocTypes.insert(reloc.nativeType);
 				}
 				for (auto& reloc : relocTypes)
-					LogWarn("Unsupported COFF relocation: %s", GetRelocationString((COFFx86RelocationType)reloc));
+					logger->LogWarn("Unsupported COFF relocation: %s", GetRelocationString((COFFx86RelocationType)reloc));
 			}
 		}
 
@@ -4708,7 +4713,8 @@ public:
 
 	virtual bool GetRelocationInfo(Ref<BinaryView> view, Ref<Architecture> arch, vector<BNRelocationInfo>& result) override
 	{
-		(void)view; (void)arch;
+		(void)arch;
+		Ref<Logger> logger = view->CreateLogger("X86PeReloc");
 		set<uint64_t> relocTypes;
 		for (auto& reloc : result)
 		{
@@ -4741,7 +4747,7 @@ public:
 		}
 
 		for (auto& reloc : relocTypes)
-			LogWarn("Unsupported PE relocation: %s", GetRelocationString((PeRelocationType)reloc));
+			logger->LogWarn("Unsupported PE relocation: %s", GetRelocationString((PeRelocationType)reloc));
 		return false;
 	}
 


### PR DESCRIPTION
Ran into this when running over certain object files on ppc, we can do it for all of them though.