### PR TITLE
Fix PDB bitfield members importing with wrong offset

### DIFF
--- a/plugins/pdb-ng/src/struct_grouper.rs
+++ b/plugins/pdb-ng/src/struct_grouper.rs
@@ -340,7 +340,7 @@ pub fn group_structure(
         .enumerate()
         .map(|(i, member)| MemberSize {
             index: i,
-            offset: member.bitfield_position.unwrap_or(member.offset * 8),
+            offset: member.offset * 8 + member.bitfield_position.unwrap_or(0),
             width: member
                 .bitfield_size
                 .unwrap_or(member.ty.contents.width() * 8),
@@ -366,7 +366,7 @@ pub fn group_structure(
                         structure.insert_bitwise(
                             &member.ty,
                             &member.name,
-                            bit_pos,
+                            member.offset * 8 + bit_pos,
                             bit_width.map(|w| w as u8),
                             false,
                             member.access,
@@ -409,7 +409,7 @@ fn apply_groups(
                         structure.insert_bitwise(
                             &member.ty,
                             &member.name,
-                            bit_pos,
+                            (member.offset - offset) * 8 + bit_pos,
                             bit_width.map(|w| w as u8),
                             false,
                             member.access,


### PR DESCRIPTION
Test binary:
[bitflags.zip](https://github.com/user-attachments/files/24176139/bitflags.zip)

Source:
```cpp
struct MixedBitFields {
    uint64_t timestamp;
    uint32_t value : 24;
    bool enabled : 1;
    bool visible : 1;
    bool selected : 1;
    bool hovered : 1;
    bool focused : 1;
    bool disabled : 1;
    bool readonly : 1;
    bool dirty : 1;
    float scale;
    double position;
};
```

Before:
<img width="471" height="449" alt="image" src="https://github.com/user-attachments/assets/56d1023f-c85e-44f1-8a66-f90bf77bdde9" />

After:
<img width="359" height="325" alt="image" src="https://github.com/user-attachments/assets/aef4b4a1-6d19-4389-b16e-b63838aa9619" />
