### PR TITLE
Add APIs to allow calling conventions to provide requirements for being considered during heuristic calling convention detection

### DIFF
--- a/arch/x86/arch_x86.cpp
+++ b/arch/x86/arch_x86.cpp
@@ -3814,6 +3814,11 @@ public:
 		return vector<uint32_t>{ XED_REG_ECX };
 	}
 
+	virtual vector<uint32_t> GetRequiredArgumentRegisters() override
+	{
+		return vector<uint32_t>{ XED_REG_ECX };
+	}
+
 	virtual bool IsStackAdjustedOnReturn() override
 	{
 		return true;

--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -17223,6 +17223,8 @@ namespace BinaryNinja {
 		static uint32_t* GetCalleeSavedRegistersCallback(void* ctxt, size_t* count);
 		static uint32_t* GetIntegerArgumentRegistersCallback(void* ctxt, size_t* count);
 		static uint32_t* GetFloatArgumentRegistersCallback(void* ctxt, size_t* count);
+		static uint32_t* GetRequiredArgumentRegistersCallback(void* ctxt, size_t* count);
+		static uint32_t* GetRequiredClobberedRegistersCallback(void* ctxt, size_t* count);
 		static void FreeRegisterListCallback(void* ctxt, uint32_t* regs, size_t len);
 
 		static bool AreArgumentRegistersSharedIndexCallback(void* ctxt);
@@ -17255,6 +17257,21 @@ namespace BinaryNinja {
 
 		virtual std::vector<uint32_t> GetIntegerArgumentRegisters();
 		virtual std::vector<uint32_t> GetFloatArgumentRegisters();
+
+		/*! Gets the set of registers that must be arguments for heuristic calling convention
+			detection to consider this calling convention as a valid option.
+
+			\return The set of registers that must be arguments
+		*/
+		virtual std::vector<uint32_t> GetRequiredArgumentRegisters();
+
+		/*! Gets the set of registers that must be clobbered for heuristic calling convention
+			detection to consider this calling convention as a valid option.
+
+			\return The set of registers that must be clobbered
+		*/
+		virtual std::vector<uint32_t> GetRequiredClobberedRegisters();
+
 		virtual bool AreArgumentRegistersSharedIndex();
 		virtual bool AreArgumentRegistersUsedForVarArgs();
 		virtual bool IsStackReservedForArgumentRegisters();
@@ -17287,6 +17304,8 @@ namespace BinaryNinja {
 
 		virtual std::vector<uint32_t> GetIntegerArgumentRegisters() override;
 		virtual std::vector<uint32_t> GetFloatArgumentRegisters() override;
+		virtual std::vector<uint32_t> GetRequiredArgumentRegisters() override;
+		virtual std::vector<uint32_t> GetRequiredClobberedRegisters() override;
 		virtual bool AreArgumentRegistersSharedIndex() override;
 		virtual bool AreArgumentRegistersUsedForVarArgs() override;
 		virtual bool IsStackReservedForArgumentRegisters() override;

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -2770,6 +2770,8 @@ extern "C"
 		uint32_t* (*getCalleeSavedRegisters)(void* ctxt, size_t* count);
 		uint32_t* (*getIntegerArgumentRegisters)(void* ctxt, size_t* count);
 		uint32_t* (*getFloatArgumentRegisters)(void* ctxt, size_t* count);
+		uint32_t* (*getRequiredArgumentRegisters)(void* ctxt, size_t* count);
+		uint32_t* (*getRequiredClobberedRegisters)(void* ctxt, size_t* count);
 		void (*freeRegisterList)(void* ctxt, uint32_t* regs, size_t len);
 
 		bool (*areArgumentRegistersSharedIndex)(void* ctxt);
@@ -7412,6 +7414,8 @@ extern "C"
 
 	BINARYNINJACOREAPI uint32_t* BNGetIntegerArgumentRegisters(BNCallingConvention* cc, size_t* count);
 	BINARYNINJACOREAPI uint32_t* BNGetFloatArgumentRegisters(BNCallingConvention* cc, size_t* count);
+	BINARYNINJACOREAPI uint32_t* BNGetRequiredArgumentRegisters(BNCallingConvention* cc, size_t* count);
+	BINARYNINJACOREAPI uint32_t* BNGetRequiredClobberedRegisters(BNCallingConvention* cc, size_t* count);
 	BINARYNINJACOREAPI bool BNAreArgumentRegistersSharedIndex(BNCallingConvention* cc);
 	BINARYNINJACOREAPI bool BNAreArgumentRegistersUsedForVarArgs(BNCallingConvention* cc);
 	BINARYNINJACOREAPI bool BNIsStackReservedForArgumentRegisters(BNCallingConvention* cc);

--- a/callingconvention.cpp
+++ b/callingconvention.cpp
@@ -39,6 +39,8 @@ CallingConvention::CallingConvention(Architecture* arch, const string& name)
 	cc.getCalleeSavedRegisters = GetCalleeSavedRegistersCallback;
 	cc.getIntegerArgumentRegisters = GetIntegerArgumentRegistersCallback;
 	cc.getFloatArgumentRegisters = GetFloatArgumentRegistersCallback;
+	cc.getRequiredArgumentRegisters = GetRequiredArgumentRegistersCallback;
+	cc.getRequiredClobberedRegisters = GetRequiredClobberedRegistersCallback;
 	cc.freeRegisterList = FreeRegisterListCallback;
 	cc.areArgumentRegistersSharedIndex = AreArgumentRegistersSharedIndexCallback;
 	cc.areArgumentRegistersUsedForVarArgs = AreArgumentRegistersUsedForVarArgsCallback;
@@ -110,6 +112,32 @@ uint32_t* CallingConvention::GetFloatArgumentRegistersCallback(void* ctxt, size_
 {
 	CallbackRef<CallingConvention> cc(ctxt);
 	vector<uint32_t> regs = cc->GetFloatArgumentRegisters();
+	*count = regs.size();
+
+	uint32_t* result = new uint32_t[regs.size()];
+	for (size_t i = 0; i < regs.size(); i++)
+		result[i] = regs[i];
+	return result;
+}
+
+
+uint32_t* CallingConvention::GetRequiredArgumentRegistersCallback(void* ctxt, size_t* count)
+{
+	CallbackRef<CallingConvention> cc(ctxt);
+	vector<uint32_t> regs = cc->GetRequiredArgumentRegisters();
+	*count = regs.size();
+
+	uint32_t* result = new uint32_t[regs.size()];
+	for (size_t i = 0; i < regs.size(); i++)
+		result[i] = regs[i];
+	return result;
+}
+
+
+uint32_t* CallingConvention::GetRequiredClobberedRegistersCallback(void* ctxt, size_t* count)
+{
+	CallbackRef<CallingConvention> cc(ctxt);
+	vector<uint32_t> regs = cc->GetRequiredClobberedRegisters();
 	*count = regs.size();
 
 	uint32_t* result = new uint32_t[regs.size()];
@@ -284,6 +312,18 @@ vector<uint32_t> CallingConvention::GetFloatArgumentRegisters()
 }
 
 
+vector<uint32_t> CallingConvention::GetRequiredArgumentRegisters()
+{
+	return vector<uint32_t>();
+}
+
+
+vector<uint32_t> CallingConvention::GetRequiredClobberedRegisters()
+{
+	return vector<uint32_t>();
+}
+
+
 bool CallingConvention::AreArgumentRegistersSharedIndex()
 {
 	return false;
@@ -410,6 +450,28 @@ vector<uint32_t> CoreCallingConvention::GetFloatArgumentRegisters()
 {
 	size_t count;
 	uint32_t* regs = BNGetFloatArgumentRegisters(m_object, &count);
+	vector<uint32_t> result;
+	result.insert(result.end(), regs, &regs[count]);
+	BNFreeRegisterList(regs);
+	return result;
+}
+
+
+vector<uint32_t> CoreCallingConvention::GetRequiredArgumentRegisters()
+{
+	size_t count;
+	uint32_t* regs = BNGetRequiredArgumentRegisters(m_object, &count);
+	vector<uint32_t> result;
+	result.insert(result.end(), regs, &regs[count]);
+	BNFreeRegisterList(regs);
+	return result;
+}
+
+
+vector<uint32_t> CoreCallingConvention::GetRequiredClobberedRegisters()
+{
+	size_t count;
+	uint32_t* regs = BNGetRequiredClobberedRegisters(m_object, &count);
 	vector<uint32_t> result;
 	result.insert(result.end(), regs, &regs[count]);
 	BNFreeRegisterList(regs);

--- a/python/callingconvention.py
+++ b/python/callingconvention.py
@@ -40,6 +40,8 @@ class CallingConvention:
 	callee_saved_regs = []
 	int_arg_regs = []
 	float_arg_regs = []
+	required_arg_regs = []
+	required_clobbered_regs = []
 	arg_regs_share_index = False
 	arg_regs_for_varargs = True
 	stack_reserved_for_arg_regs = False
@@ -70,6 +72,8 @@ class CallingConvention:
 			    self._get_int_arg_regs
 			)
 			self._cb.getFloatArgumentRegisters = self._cb.getFloatArgumentRegisters.__class__(self._get_float_arg_regs)
+			self._cb.getRequiredArgumentRegisters = self._cb.getRequiredArgumentRegisters.__class__(self._get_required_arg_regs)
+			self._cb.getRequiredClobberedRegisters = self._cb.getRequiredClobberedRegisters.__class__(self._get_required_clobbered_regs)
 			self._cb.freeRegisterList = self._cb.freeRegisterList.__class__(self._free_register_list)
 			self._cb.areArgumentRegistersSharedIndex = self._cb.areArgumentRegistersSharedIndex.__class__(
 			    self._arg_regs_share_index
@@ -160,6 +164,26 @@ class CallingConvention:
 				result.append(arch.get_reg_name(regs[i]))
 			core.BNFreeRegisterList(regs)
 			self.__dict__["float_arg_regs"] = result
+
+			count = ctypes.c_ulonglong()
+			regs = core.BNGetRequiredArgumentRegisters(_handle, count)
+			assert regs is not None, "core.BNGetRequiredArgumentRegisters returned None"
+			result = []
+			arch = self.arch
+			for i in range(0, count.value):
+				result.append(arch.get_reg_name(regs[i]))
+			core.BNFreeRegisterList(regs)
+			self.__dict__["required_arg_regs"] = result
+
+			count = ctypes.c_ulonglong()
+			regs = core.BNGetRequiredClobberedRegisters(_handle, count)
+			assert regs is not None, "core.BNGetRequiredClobberedRegisters returned None"
+			result = []
+			arch = self.arch
+			for i in range(0, count.value):
+				result.append(arch.get_reg_name(regs[i]))
+			core.BNFreeRegisterList(regs)
+			self.__dict__["required_clobbered_regs"] = result
 
 			reg = core.BNGetIntegerReturnValueRegister(_handle)
 			if reg == 0xffffffff:
@@ -278,6 +302,36 @@ class CallingConvention:
 			return result.value
 		except:
 			log_error_for_exception("Unhandled Python exception in CallingConvention._get_float_arg_regs")
+			count[0] = 0
+			return None
+
+	def _get_required_arg_regs(self, ctxt, count):
+		try:
+			regs = self.__class__.required_arg_regs
+			count[0] = len(regs)
+			reg_buf = (ctypes.c_uint * len(regs))()
+			for i in range(0, len(regs)):
+				reg_buf[i] = self.arch.regs[regs[i]].index
+			result = ctypes.cast(reg_buf, ctypes.c_void_p)
+			self._pending_reg_lists[result.value] = (result, reg_buf)
+			return result.value
+		except:
+			log_error_for_exception("Unhandled Python exception in CallingConvention._get_required_arg_regs")
+			count[0] = 0
+			return None
+
+	def _get_required_clobbered_regs(self, ctxt, count):
+		try:
+			regs = self.__class__.required_clobbered_regs
+			count[0] = len(regs)
+			reg_buf = (ctypes.c_uint * len(regs))()
+			for i in range(0, len(regs)):
+				reg_buf[i] = self.arch.regs[regs[i]].index
+			result = ctypes.cast(reg_buf, ctypes.c_void_p)
+			self._pending_reg_lists[result.value] = (result, reg_buf)
+			return result.value
+		except:
+			log_error_for_exception("Unhandled Python exception in CallingConvention._get_required_clobbered_regs")
 			count[0] = 0
 			return None
 

--- a/rust/src/calling_convention.rs
+++ b/rust/src/calling_convention.rs
@@ -39,6 +39,12 @@ pub trait CallingConvention: Sync {
     fn callee_saved_registers(&self) -> Vec<RegisterId>;
     fn int_arg_registers(&self) -> Vec<RegisterId>;
     fn float_arg_registers(&self) -> Vec<RegisterId>;
+    fn required_argument_registers(&self) -> Vec<RegisterId> {
+        Vec::new()
+    }
+    fn required_clobbered_registers(&self) -> Vec<RegisterId> {
+        Vec::new()
+    }
 
     fn arg_registers_shared_index(&self) -> bool;
     fn reserved_stack_space_for_arg_registers(&self) -> bool;
@@ -154,6 +160,54 @@ where
         ffi_wrap!("CallingConvention::float_arg_registers", unsafe {
             let ctxt = &*(ctxt as *mut CustomCallingConventionContext<C>);
             let mut regs: Vec<_> = ctxt.cc.float_arg_registers().iter().map(|r| r.0).collect();
+
+            // SAFETY: `count` is an out parameter
+            *count = regs.len();
+            let regs_ptr = regs.as_mut_ptr();
+            std::mem::forget(regs);
+            regs_ptr
+        })
+    }
+
+    extern "C" fn cb_required_argument_registers<C>(
+        ctxt: *mut c_void,
+        count: *mut usize,
+    ) -> *mut u32
+    where
+        C: CallingConvention,
+    {
+        ffi_wrap!("CallingConvention::required_argument_registers", unsafe {
+            let ctxt = &*(ctxt as *mut CustomCallingConventionContext<C>);
+            let mut regs: Vec<_> = ctxt
+                .cc
+                .required_argument_registers()
+                .iter()
+                .map(|r| r.0)
+                .collect();
+
+            // SAFETY: `count` is an out parameter
+            *count = regs.len();
+            let regs_ptr = regs.as_mut_ptr();
+            std::mem::forget(regs);
+            regs_ptr
+        })
+    }
+
+    extern "C" fn cb_required_clobbered_registers<C>(
+        ctxt: *mut c_void,
+        count: *mut usize,
+    ) -> *mut u32
+    where
+        C: CallingConvention,
+    {
+        ffi_wrap!("CallingConvention::required_clobbered_registers", unsafe {
+            let ctxt = &*(ctxt as *mut CustomCallingConventionContext<C>);
+            let mut regs: Vec<_> = ctxt
+                .cc
+                .required_clobbered_registers()
+                .iter()
+                .map(|r| r.0)
+                .collect();
 
             // SAFETY: `count` is an out parameter
             *count = regs.len();
@@ -390,6 +444,8 @@ where
         getCalleeSavedRegisters: Some(cb_callee_saved::<C>),
         getIntegerArgumentRegisters: Some(cb_int_args::<C>),
         getFloatArgumentRegisters: Some(cb_float_args::<C>),
+        getRequiredArgumentRegisters: Some(cb_required_argument_registers::<C>),
+        getRequiredClobberedRegisters: Some(cb_required_clobbered_registers::<C>),
         freeRegisterList: Some(cb_free_register_list),
 
         areArgumentRegistersSharedIndex: Some(cb_arg_shared_index::<C>),
@@ -520,6 +576,14 @@ impl Debug for CoreCallingConvention {
             .field("int_arg_registers", &self.int_arg_registers())
             .field("float_arg_registers", &self.float_arg_registers())
             .field(
+                "required_argument_registers",
+                &self.required_argument_registers(),
+            )
+            .field(
+                "required_clobbered_registers",
+                &self.required_clobbered_registers(),
+            )
+            .field(
                 "arg_registers_shared_index",
                 &self.arg_registers_shared_index(),
             )
@@ -601,6 +665,34 @@ impl CallingConvention for CoreCallingConvention {
         unsafe {
             let mut count = 0;
             let regs_ptr = BNGetFloatArgumentRegisters(self.handle, &mut count);
+            let regs: Vec<RegisterId> = std::slice::from_raw_parts(regs_ptr, count)
+                .iter()
+                .copied()
+                .map(RegisterId::from)
+                .collect();
+            BNFreeRegisterList(regs_ptr);
+            regs
+        }
+    }
+
+    fn required_argument_registers(&self) -> Vec<RegisterId> {
+        unsafe {
+            let mut count = 0;
+            let regs_ptr = BNGetRequiredArgumentRegisters(self.handle, &mut count);
+            let regs: Vec<RegisterId> = std::slice::from_raw_parts(regs_ptr, count)
+                .iter()
+                .copied()
+                .map(RegisterId::from)
+                .collect();
+            BNFreeRegisterList(regs_ptr);
+            regs
+        }
+    }
+
+    fn required_clobbered_registers(&self) -> Vec<RegisterId> {
+        unsafe {
+            let mut count = 0;
+            let regs_ptr = BNGetRequiredClobberedRegisters(self.handle, &mut count);
             let regs: Vec<RegisterId> = std::slice::from_raw_parts(regs_ptr, count)
                 .iter()
                 .copied()
@@ -738,6 +830,8 @@ pub struct ConventionBuilder<A: Architecture> {
     callee_saved_registers: Vec<RegisterId>,
     int_arg_registers: Vec<RegisterId>,
     float_arg_registers: Vec<RegisterId>,
+    required_argument_registers: Vec<RegisterId>,
+    required_clobbered_registers: Vec<RegisterId>,
 
     arg_registers_shared_index: bool,
     reserved_stack_space_for_arg_registers: bool,
@@ -807,6 +901,8 @@ impl<A: Architecture> ConventionBuilder<A> {
             callee_saved_registers: Vec::new(),
             int_arg_registers: Vec::new(),
             float_arg_registers: Vec::new(),
+            required_argument_registers: Vec::new(),
+            required_clobbered_registers: Vec::new(),
 
             arg_registers_shared_index: false,
             reserved_stack_space_for_arg_registers: false,
@@ -832,6 +928,8 @@ impl<A: Architecture> ConventionBuilder<A> {
     reg_list!(callee_saved_registers);
     reg_list!(int_arg_registers);
     reg_list!(float_arg_registers);
+    reg_list!(required_argument_registers);
+    reg_list!(required_clobbered_registers);
 
     bool_arg!(arg_registers_shared_index);
     bool_arg!(reserved_stack_space_for_arg_registers);
@@ -869,6 +967,14 @@ impl<A: Architecture> CallingConvention for ConventionBuilder<A> {
 
     fn float_arg_registers(&self) -> Vec<RegisterId> {
         self.float_arg_registers.clone()
+    }
+
+    fn required_argument_registers(&self) -> Vec<RegisterId> {
+        self.required_argument_registers.clone()
+    }
+
+    fn required_clobbered_registers(&self) -> Vec<RegisterId> {
+        self.required_clobbered_registers.clone()
     }
 
     fn arg_registers_shared_index(&self) -> bool {


### PR DESCRIPTION
Several modern languages, like Rust and Swift, have custom calling conventions that input or output in registers that are normally reserved as callee saved registers. To account for this, we need to add calling conventions that define these additional register uses.

Unfortunately, adding these calling conventions will cause the heuristic calling convention detection to run into a lot of cases where there are multiple apparently equivalent solutions to the optimal calling convention. Most of the time we want the base calling convention that doesn't include the non-standard register usage.

To allow for this, this commit adds two new APIs. One provides the set of arguments that must be present, and the other provides the set of registers that must be clobbered.

For non-standard inputs, the calling convention should supply the register as an argument register, and also supply it as a required argument register. This will cause the calling convention detection code to avoid the calling convention unless usage of the non-standard input register is actually found. It will also allow the calling convention code to avoid it even if there are no arguments to the function (in this case, just adding the register as a normal argument register will cause a conflict and may not choose the desired base convention).

For non-standard outputs, supply the register as a required clobbered register. This will avoid detecting the convention when the non-standard output is not written.