### PR TITLE
Fix slice handling in FunctionList, BasicBlockList, and TagList

### DIFF
--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -2466,10 +2466,8 @@ class FunctionList:
 			return _function.Function(self._view, core.BNNewFunctionReference(self._funcs[i]))
 		elif isinstance(i, slice):
 			result = []
-			if i.start < 0 or i.start >= len(self) or i.stop < 0 or i.stop >= len(self):
-				raise IndexError(f"Slice {i} out of bounds for FunctionList of size {len(self)}")
-
-			for j in range(i.start, i.stop, i.step if i.step is not None else 1):
+			start, stop, step = i.indices(len(self))
+			for j in range(start, stop, step):
 				result.append(_function.Function(self._view, core.BNNewFunctionReference(self._funcs[j])))
 			return result
 		raise ValueError("FunctionList.__getitem__ supports argument of type integer or slice")

--- a/python/function.py
+++ b/python/function.py
@@ -279,10 +279,8 @@ class BasicBlockList:
 			return self._function._instantiate_block(block)
 		elif isinstance(i, slice):
 			result = []
-			if i.start < 0 or i.start >= len(self) or i.stop < 0 or i.stop >= len(self):
-				raise IndexError(f"Slice {i} out of bounds for BasicBlockList of size {len(self)}")
-
-			for j in range(i.start, i.stop, i.step if i.step is not None else 1):
+			start, stop, step = i.indices(len(self))
+			for j in range(start, stop, step):
 				block = core.BNNewBasicBlockReference(self._blocks[j])
 				assert block is not None, "core.BNNewBasicBlockReference returned None"
 				result.append(self._function._instantiate_block(block))

--- a/python/function.py
+++ b/python/function.py
@@ -398,10 +398,8 @@ class TagList:
 			return arch, self._tags[i].addr, binaryview.Tag(core_tag)
 		elif isinstance(i, slice):
 			result = []
-			if i.start < 0 or i.start >= len(self) or i.stop < 0 or i.stop >= len(self):
-				raise IndexError(f"Slice {i} out of bounds for TagList of size {len(self)}")
-
-			for j in range(i.start, i.stop, i.step if i.step is not None else 1):
+			start, stop, step = i.indices(len(self))
+			for j in range(start, stop, step):
 				core_tag = core.BNNewTagReference(self._tags[j].tag)
 				assert core_tag is not None, "core.BNNewTagReference returned None"
 				arch = architecture.CoreArchitecture._from_cache(self._tags[j].arch)


### PR DESCRIPTION
The standard Python slicing syntax, i.e. `[:]`, `[2:]`, `[:5]`.. (anything with an open end) fail with TypeError on FunctionList, BasicBlockList and TagList. Other valid slices like `[0:len(list)]` would also cause an IndexError.

The slice bounds checking compares `i.start` and `i.stop` directly against integers, but Python sets these to `None` for open-ended slices. This means comparing `None < 0` raises TypeError. The check `i.stop >= len(self)` also rejects valid Python where stop equals length.

This PR replaces the manual bounds checking with `slice.indices()` that will handle None values and normalise the bounds correctly. Other places in the codebase already do this.