### PR TITLE
Share context between BB recovery, lifting, and disassembly

### DIFF
--- a/architecture.cpp
+++ b/architecture.cpp
@@ -307,12 +307,11 @@ std::map<ArchAndAddr, ArchAndAddr>& BasicBlockAnalysisContext::GetInlinedUnresol
 }
 
 
-bool BasicBlockAnalysisContext::SetFunctionArchContext(void* context)
+bool BasicBlockAnalysisContext::SetFunctionArchContextRaw(void* p)
 {
 	if (m_context->functionArchContext)
 		return false;
-
-	m_context->functionArchContext = context;
+	m_context->functionArchContext = p;
 	return true;
 }
 
@@ -588,12 +587,6 @@ std::map<ArchAndAddr, bool>& FunctionLifterContext::GetContextualReturns()
 std::set<uint64_t>& FunctionLifterContext::GetInlinedCalls()
 {
 	return m_inlinedCalls;
-}
-
-
-void *FunctionLifterContext::GetFunctionArchContext()
-{
-	return m_functionArchContext;
 }
 
 

--- a/architecture.cpp
+++ b/architecture.cpp
@@ -518,6 +518,7 @@ FunctionLifterContext::FunctionLifterContext(LowLevelILFunction* func, BNFunctio
 		m_inlinedCalls.insert(context->inlinedCalls[i]);
 	}
 
+	m_functionArchContext = context->functionArchContext;
 	m_containsInlinedFunctions = context->containsInlinedFunctions;
 }
 
@@ -579,6 +580,12 @@ std::map<ArchAndAddr, bool>& FunctionLifterContext::GetContextualReturns()
 std::set<uint64_t>& FunctionLifterContext::GetInlinedCalls()
 {
 	return m_inlinedCalls;
+}
+
+
+void *FunctionLifterContext::GetFunctionArchContext()
+{
+	return m_functionArchContext;
 }
 
 
@@ -730,6 +737,26 @@ bool Architecture::GetInstructionTextCallback(
 }
 
 
+bool Architecture::GetInstructionTextWithContextCallback(void* ctxt, const uint8_t* data, uint64_t addr, size_t* len,
+	void* context, BNInstructionTextToken** result, size_t* count)
+{
+	CallbackRef<Architecture> arch(ctxt);
+
+	vector<InstructionTextToken> tokens;
+	bool ok = arch->GetInstructionTextWithContext(data, addr, *len, context, tokens);
+	if (!ok)
+	{
+		*result = nullptr;
+		*count = 0;
+		return false;
+	}
+
+	*count = tokens.size();
+	*result = InstructionTextToken::CreateInstructionTextTokenList(tokens);
+	return true;
+}
+
+
 void Architecture::FreeInstructionTextCallback(BNInstructionTextToken* tokens, size_t count)
 {
 	for (size_t i = 0; i < count; i++)
@@ -769,6 +796,13 @@ bool Architecture::LiftFunctionCallback(void* ctxt, BNLowLevelILFunction* functi
 	Ref func(new LowLevelILFunction(BNNewLowLevelILFunctionReference(function)));
 	FunctionLifterContext flc(func, context);
 	return arch->LiftFunction(func, flc);
+}
+
+
+void Architecture::FreeFunctionArchContextCallback(void* ctxt, void* context)
+{
+	CallbackRef<Architecture> arch(ctxt);
+	arch->FreeFunctionArchContext(context);
 }
 
 
@@ -1260,10 +1294,12 @@ void Architecture::Register(Architecture* arch)
 	callbacks.getAssociatedArchitectureByAddress = GetAssociatedArchitectureByAddressCallback;
 	callbacks.getInstructionInfo = GetInstructionInfoCallback;
 	callbacks.getInstructionText = GetInstructionTextCallback;
+	callbacks.getInstructionTextWithContext = GetInstructionTextWithContextCallback;
 	callbacks.freeInstructionText = FreeInstructionTextCallback;
 	callbacks.getInstructionLowLevelIL = GetInstructionLowLevelILCallback;
 	callbacks.analyzeBasicBlocks = AnalyzeBasicBlocksCallback;
 	callbacks.liftFunction = LiftFunctionCallback;
+	callbacks.freeFunctionArchContext = FreeFunctionArchContextCallback;
 	callbacks.getRegisterName = GetRegisterNameCallback;
 	callbacks.getFlagName = GetFlagNameCallback;
 	callbacks.getFlagWriteTypeName = GetFlagWriteTypeNameCallback;
@@ -1402,6 +1438,16 @@ bool Architecture::LiftFunction(LowLevelILFunction* function, FunctionLifterCont
 {
 	return DefaultLiftFunction(function, context);
 }
+
+
+bool Architecture::GetInstructionTextWithContext(
+	const uint8_t* data, uint64_t addr, size_t& len, void* context, std::vector<InstructionTextToken>& result)
+{
+	return GetInstructionText(data, addr, len, result);
+}
+
+
+void Architecture::FreeFunctionArchContext(void* context) {}
 
 
 string Architecture::GetRegisterName(uint32_t reg)
@@ -1959,6 +2005,19 @@ bool CoreArchitecture::GetInstructionText(
 }
 
 
+bool CoreArchitecture::GetInstructionTextWithContext(
+	const uint8_t* data, uint64_t addr, size_t& len, void* context, std::vector<InstructionTextToken>& result)
+{
+	BNInstructionTextToken* tokens = nullptr;
+	size_t count = 0;
+	if (!BNGetInstructionTextWithContext(m_object, data, addr, &len, context, &tokens, &count))
+		return false;
+
+	result = InstructionTextToken::ConvertAndFreeInstructionTextTokenList(tokens, count);
+	return true;
+}
+
+
 bool CoreArchitecture::GetInstructionLowLevelIL(const uint8_t* data, uint64_t addr, size_t& len, LowLevelILFunction& il)
 {
 	return BNGetInstructionLowLevelIL(m_object, data, addr, &len, il.GetObject());
@@ -1974,6 +2033,12 @@ void CoreArchitecture::AnalyzeBasicBlocks(Function* function, BasicBlockAnalysis
 bool CoreArchitecture::LiftFunction(LowLevelILFunction* function, FunctionLifterContext& context)
 {
 	return BNArchitectureLiftFunction(m_object, function->GetObject(), context.m_context);
+}
+
+
+void CoreArchitecture::FreeFunctionArchContext(void* context)
+{
+	BNArchitectureFreeFunctionArchContext(m_object, context);
 }
 
 
@@ -2484,6 +2549,13 @@ bool ArchitectureExtension::GetInstructionText(
     const uint8_t* data, uint64_t addr, size_t& len, vector<InstructionTextToken>& result)
 {
 	return m_base->GetInstructionText(data, addr, len, result);
+}
+
+
+bool ArchitectureExtension::GetInstructionTextWithContext(
+	const uint8_t* data, uint64_t addr, size_t& len, void* context, vector<InstructionTextToken>& result)
+{
+	return m_base->GetInstructionTextWithContext(data, addr, len, context, result);
 }
 
 

--- a/architecture.cpp
+++ b/architecture.cpp
@@ -307,6 +307,16 @@ std::map<ArchAndAddr, ArchAndAddr>& BasicBlockAnalysisContext::GetInlinedUnresol
 }
 
 
+bool BasicBlockAnalysisContext::SetFunctionArchContext(void* context)
+{
+	if (m_context->functionArchContext)
+		return false;
+
+	m_context->functionArchContext = context;
+	return true;
+}
+
+
 void BasicBlockAnalysisContext::AddTempOutgoingReference(Function* targetFunc)
 {
 	BNAnalyzeBasicBlocksContextAddTempReference(m_context, targetFunc->m_object);
@@ -461,8 +471,6 @@ void BasicBlockAnalysisContext::Finalize()
 			delete[] values;
 		}
 	}
-
-	BNAnalyzeBasicBlocksContextFinalize(m_context);
 }
 
 

--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -9414,6 +9414,9 @@ namespace BinaryNinja {
 		std::set<ArchAndAddr>& GetHaltedDisassemblyAddresses();
 		std::map<ArchAndAddr, ArchAndAddr>& GetInlinedUnresolvedIndirectBranches();
 
+		void* GetFunctionArchContext() { return m_context->functionArchContext; }
+		void SetFunctionArchContext(void* context) { m_context->functionArchContext = context; }
+
 		void AddTempOutgoingReference(Function* targetFunc);
 
 		Ref<BasicBlock> CreateBasicBlock(Architecture* arch, uint64_t start);
@@ -9436,6 +9439,7 @@ namespace BinaryNinja {
 		std::map<ArchAndAddr, std::set<ArchAndAddr>> m_autoIndirectBranches;
 		std::set<uint64_t> m_inlinedCalls;
 		bool* m_containsInlinedFunctions;
+		void* m_functionArchContext;
 
 	public:
 		BNFunctionLifterContext* m_context;
@@ -9451,6 +9455,7 @@ namespace BinaryNinja {
 		std::map<ArchAndAddr, std::set<ArchAndAddr>>& GetAutoIndirectBranches();
 		std::set<uint64_t>& GetInlinedCalls();
 		void SetContainsInlinedFunctions(bool value);
+		void* GetFunctionArchContext();
 
 		void CheckForInlinedCall(BasicBlock* block, size_t instrCountBefore, size_t instrCountAfter, uint64_t prevAddr,
 			uint64_t addr, const uint8_t* opcode, size_t len,
@@ -9484,11 +9489,14 @@ namespace BinaryNinja {
 		    void* ctxt, const uint8_t* data, uint64_t addr, size_t maxLen, BNInstructionInfo* result);
 		static bool GetInstructionTextCallback(void* ctxt, const uint8_t* data, uint64_t addr, size_t* len,
 		    BNInstructionTextToken** result, size_t* count);
+		static bool GetInstructionTextWithContextCallback(void* ctxt, const uint8_t* data, uint64_t addr, size_t* len,
+			void* context, BNInstructionTextToken** result, size_t* count);
 		static void FreeInstructionTextCallback(BNInstructionTextToken* tokens, size_t count);
 		static bool GetInstructionLowLevelILCallback(
 		    void* ctxt, const uint8_t* data, uint64_t addr, size_t* len, BNLowLevelILFunction* il);
 		static void AnalyzeBasicBlocksCallback(void *ctxt, BNFunction* function, BNBasicBlockAnalysisContext* context);
 		static bool LiftFunctionCallback(void* ctxt, BNLowLevelILFunction* function, BNFunctionLifterContext* context);
+		static void FreeFunctionArchContextCallback(void* ctxt, void* context);
 		static char* GetRegisterNameCallback(void* ctxt, uint32_t reg);
 		static char* GetFlagNameCallback(void* ctxt, uint32_t flag);
 		static char* GetFlagWriteTypeNameCallback(void* ctxt, uint32_t flags);
@@ -9666,6 +9674,20 @@ namespace BinaryNinja {
 		virtual bool GetInstructionText(
 		    const uint8_t* data, uint64_t addr, size_t& len, std::vector<InstructionTextToken>& result) = 0;
 
+		/*! Retrieves a list of InstructionTextTokens while supplying contextual information
+
+		    \note Architecture subclasses can implement this method to provide contextual information from AnalyzeBasicBlocks
+
+			\param[in] data pointer to the instruction data to retrieve text for
+			\param[in] addr address of the instruction data to retrieve text for
+			\param[out] len will be written to with the length of the instruction data which was translated
+			\param[in] context context to use when retrieving instruction text
+			\param[out] result
+			\return Whether instruction info was successfully retrieved.
+		*/
+		virtual bool GetInstructionTextWithContext(const uint8_t* data, uint64_t addr, size_t& len, void* context,
+			std::vector<InstructionTextToken>& result);
+
 		/*! Translates an instruction at addr and appends it onto the LowLevelILFunction& il.
 
 		    \note Architecture subclasses should implement this method.
@@ -9691,6 +9713,12 @@ namespace BinaryNinja {
 		    \return Whether lifting was successful
 		*/
 		virtual bool LiftFunction(LowLevelILFunction* function, FunctionLifterContext& context);
+
+		/*! Free the function architecture context
+
+			\param context Function architecture context
+		*/
+		virtual void FreeFunctionArchContext(void* context);
 
 		/*! Gets a register name from a register index.
 
@@ -10086,10 +10114,13 @@ namespace BinaryNinja {
 		    const uint8_t* data, uint64_t addr, size_t maxLen, InstructionInfo& result) override;
 		virtual bool GetInstructionText(
 		    const uint8_t* data, uint64_t addr, size_t& len, std::vector<InstructionTextToken>& result) override;
+		virtual bool GetInstructionTextWithContext(const uint8_t* data, uint64_t addr, size_t& len, void* context,
+			std::vector<InstructionTextToken>& result) override;
 		virtual bool GetInstructionLowLevelIL(
 		    const uint8_t* data, uint64_t addr, size_t& len, LowLevelILFunction& il) override;
 		virtual void AnalyzeBasicBlocks(Function* function, BasicBlockAnalysisContext& context) override;
 		virtual bool LiftFunction(LowLevelILFunction* function, FunctionLifterContext& context) override;
+		virtual void FreeFunctionArchContext(void* context) override;
 		virtual std::string GetRegisterName(uint32_t reg) override;
 		virtual std::string GetFlagName(uint32_t flag) override;
 		virtual std::string GetFlagWriteTypeName(uint32_t flags) override;
@@ -10173,6 +10204,8 @@ namespace BinaryNinja {
 		    const uint8_t* data, uint64_t addr, size_t maxLen, InstructionInfo& result) override;
 		virtual bool GetInstructionText(
 		    const uint8_t* data, uint64_t addr, size_t& len, std::vector<InstructionTextToken>& result) override;
+		virtual bool GetInstructionTextWithContext(const uint8_t* data, uint64_t addr, size_t& len, void* context,
+			std::vector<InstructionTextToken>& result) override;
 		virtual bool GetInstructionLowLevelIL(
 		    const uint8_t* data, uint64_t addr, size_t& len, LowLevelILFunction& il) override;
 		virtual std::string GetRegisterName(uint32_t reg) override;

--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -9415,7 +9415,7 @@ namespace BinaryNinja {
 		std::map<ArchAndAddr, ArchAndAddr>& GetInlinedUnresolvedIndirectBranches();
 
 		void* GetFunctionArchContext() { return m_context->functionArchContext; }
-		void SetFunctionArchContext(void* context) { m_context->functionArchContext = context; }
+		bool SetFunctionArchContext(void* context);
 
 		void AddTempOutgoingReference(Function* targetFunc);
 

--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -9414,8 +9414,20 @@ namespace BinaryNinja {
 		std::set<ArchAndAddr>& GetHaltedDisassemblyAddresses();
 		std::map<ArchAndAddr, ArchAndAddr>& GetInlinedUnresolvedIndirectBranches();
 
-		void* GetFunctionArchContext() { return m_context->functionArchContext; }
-		bool SetFunctionArchContext(void* context);
+		bool SetFunctionArchContextRaw(void* p);
+		void* GetFunctionArchContextRaw() const { return m_context->functionArchContext; }
+
+		template <class ArchT>
+		bool SetFunctionArchContext(const ArchT* arch, typename ArchT::FunctionArchContext* context)
+		{
+			return arch->SetFunctionArchContext(*this, context);
+		}
+
+		template <class ArchT>
+		typename ArchT::FunctionArchContext* GetFunctionArchContext(const ArchT* arch)
+		{
+			return arch->GetFunctionArchContext(*this);
+		}
 
 		void AddTempOutgoingReference(Function* targetFunc);
 
@@ -9455,7 +9467,12 @@ namespace BinaryNinja {
 		std::map<ArchAndAddr, std::set<ArchAndAddr>>& GetAutoIndirectBranches();
 		std::set<uint64_t>& GetInlinedCalls();
 		void SetContainsInlinedFunctions(bool value);
-		void* GetFunctionArchContext();
+		void* GetFunctionArchContextRaw() const { return m_functionArchContext; }
+		template <class ArchT>
+		typename ArchT::FunctionArchContext* GetFunctionArchContext(const ArchT* arch)
+		{
+			return arch->GetFunctionArchContext(*this);
+		}
 
 		void CheckForInlinedCall(BasicBlock* block, size_t instrCountBefore, size_t instrCountAfter, uint64_t prevAddr,
 			uint64_t addr, const uint8_t* opcode, size_t len,
@@ -9674,17 +9691,7 @@ namespace BinaryNinja {
 		virtual bool GetInstructionText(
 		    const uint8_t* data, uint64_t addr, size_t& len, std::vector<InstructionTextToken>& result) = 0;
 
-		/*! Retrieves a list of InstructionTextTokens while supplying contextual information
-
-		    \note Architecture subclasses can implement this method to provide contextual information from AnalyzeBasicBlocks
-
-			\param[in] data pointer to the instruction data to retrieve text for
-			\param[in] addr address of the instruction data to retrieve text for
-			\param[out] len will be written to with the length of the instruction data which was translated
-			\param[in] context context to use when retrieving instruction text
-			\param[out] result
-			\return Whether instruction info was successfully retrieved.
-		*/
+		/* For use in architecture plugins that inherit from ArchitectureWithFunctionContext */
 		virtual bool GetInstructionTextWithContext(const uint8_t* data, uint64_t addr, size_t& len, void* context,
 			std::vector<InstructionTextToken>& result);
 
@@ -9714,10 +9721,7 @@ namespace BinaryNinja {
 		*/
 		virtual bool LiftFunction(LowLevelILFunction* function, FunctionLifterContext& context);
 
-		/*! Free the function architecture context
-
-			\param context Function architecture context
-		*/
+		/* For use in architecture plugins that inherit from ArchitectureWithFunctionContext */
 		virtual void FreeFunctionArchContext(void* context);
 
 		/*! Gets a register name from a register index.
@@ -10093,6 +10097,71 @@ namespace BinaryNinja {
 		std::vector<Ref<TypeLibrary>> GetTypeLibraries();
 
 		void AddArchitectureRedirection(Architecture* from, Architecture* to);
+	};
+
+	/*! The ArchitectureWithFunctionContext class is to be inherited by architecture plugins that need to maintain a
+	 * function context that is set during AnalyzeBasicBlocks and accessed in LiftFunction and/or
+	 * GetInstructionTextWithContext.
+
+	    \ingroup architectures
+	*/
+	template <class FnCtxT>
+	class ArchitectureWithFunctionContext : public Architecture
+	{
+	public:
+		using Architecture::Architecture;
+		using FunctionArchContext = FnCtxT;
+
+		/*! Set the function architecture context
+
+			\param bbac Basic block analysis context
+			\param ctx Function architecture context
+			\return True if the context was set successfully
+		 */
+		bool SetFunctionArchContext(BasicBlockAnalysisContext& bbac, FnCtxT* ctx) const
+		{
+			return bbac.SetFunctionArchContextRaw(static_cast<void*>(ctx));
+		}
+
+		/*! Get the function architecture context from the basic block analysis context
+
+			\param bbac Basic block analysis context
+			\return Function architecture context
+		 */
+		FnCtxT* GetFunctionArchContext(const BasicBlockAnalysisContext& bbac) const
+		{
+			return static_cast<FnCtxT*>(bbac.GetFunctionArchContextRaw());
+		}
+
+		/*! Free the function architecture context
+			\param context Function architecture context
+		 */
+		virtual void FreeFunctionArchContext(FnCtxT* context) {}
+		void FreeFunctionArchContext(void* context) override final
+		{
+			FreeFunctionArchContext(static_cast<FnCtxT*>(context));
+		}
+
+		/*! Get instruction text with function context
+
+			\param data Pointer to the instruction data to retrieve text for
+			\param addr Address of the instruction data to retrieve text for
+			\param len Will be written to with the length of the instruction data which was translated
+			\param context Context to use when retrieving instruction text
+			\param result Output vector of instruction text tokens
+			\return Whether instruction info was successfully retrieved.
+		*/
+		virtual bool GetInstructionTextWithContext(
+			const uint8_t* data, uint64_t addr, size_t& len, FnCtxT* context, std::vector<InstructionTextToken>& result)
+		{
+			return Architecture::GetInstructionTextWithContext(data, addr, len, static_cast<void*>(context), result);
+		}
+
+		bool GetInstructionTextWithContext(const uint8_t* data, uint64_t addr, size_t& len, void* context,
+			std::vector<InstructionTextToken>& result) override final
+		{
+			return GetInstructionTextWithContext(data, addr, len, static_cast<FnCtxT*>(context), result);
+		}
 	};
 
 	/*!

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -5604,7 +5604,6 @@ extern "C"
 	// BNAnalyzeBasicBlockContext operations
 	BINARYNINJACOREAPI BNBasicBlock* BNAnalyzeBasicBlocksContextCreateBasicBlock(BNBasicBlockAnalysisContext* abb, BNArchitecture* arch, uint64_t addr);
 	BINARYNINJACOREAPI void BNAnalyzeBasicBlocksContextAddBasicBlockToFunction(BNBasicBlockAnalysisContext* abb, BNBasicBlock* block);
-	BINARYNINJACOREAPI void BNAnalyzeBasicBlocksContextFinalize(BNBasicBlockAnalysisContext* abb);
 
 	BINARYNINJACOREAPI void BNAnalyzeBasicBlocksContextAddTempReference(BNBasicBlockAnalysisContext* abb, BNFunction* target);
 

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -2049,6 +2049,8 @@ extern "C"
 
 		size_t inlinedUnresolvedIndirectBranchCount;
 		BNArchitectureAndAddress* inlinedUnresolvedIndirectBranches;
+
+		void* functionArchContext;
 	} BNBasicBlockAnalysisContext;
 
 	typedef struct BNFunctionLifterContext {
@@ -2075,6 +2077,8 @@ extern "C"
 		size_t inlinedCallsCount;
 		uint64_t* inlinedCalls;
 
+		void* functionArchContext;
+
 		// OUT
 		bool* containsInlinedFunctions;
 	} BNFunctionLifterContext;
@@ -2094,11 +2098,14 @@ extern "C"
 		    void* ctxt, const uint8_t* data, uint64_t addr, size_t maxLen, BNInstructionInfo* result);
 		bool (*getInstructionText)(void* ctxt, const uint8_t* data, uint64_t addr, size_t* len,
 		    BNInstructionTextToken** result, size_t* count);
+		bool (*getInstructionTextWithContext)(void* ctxt, const uint8_t* data, uint64_t addr, size_t* len,
+			void* context, BNInstructionTextToken** result, size_t* count);
 		void (*freeInstructionText)(BNInstructionTextToken* tokens, size_t count);
 		bool (*getInstructionLowLevelIL)(
 		    void* ctxt, const uint8_t* data, uint64_t addr, size_t* len, BNLowLevelILFunction* il);
 		void (*analyzeBasicBlocks)(void* ctxt, BNFunction* function, BNBasicBlockAnalysisContext* context);
 		bool (*liftFunction)(void *ctext, BNLowLevelILFunction* function, BNFunctionLifterContext* context);
+		void (*freeFunctionArchContext)(void *ctxt, void* context);
 		char* (*getRegisterName)(void* ctxt, uint32_t reg);
 		char* (*getFlagName)(void* ctxt, uint32_t flag);
 		char* (*getFlagWriteTypeName)(void* ctxt, uint32_t flags);
@@ -4934,6 +4941,8 @@ extern "C"
 	    BNArchitecture* arch, const uint8_t* data, uint64_t addr, size_t maxLen, BNInstructionInfo* result);
 	BINARYNINJACOREAPI bool BNGetInstructionText(BNArchitecture* arch, const uint8_t* data, uint64_t addr, size_t* len,
 	    BNInstructionTextToken** result, size_t* count);
+	BINARYNINJACOREAPI bool BNGetInstructionTextWithContext(BNArchitecture* arch, const uint8_t* data, uint64_t addr, size_t* len,
+		void* context, BNInstructionTextToken** result, size_t* count);
 	BINARYNINJACOREAPI bool BNGetInstructionLowLevelIL(
 	    BNArchitecture* arch, const uint8_t* data, uint64_t addr, size_t* len, BNLowLevelILFunction* il);
 	BINARYNINJACOREAPI void BNFreeInstructionText(BNInstructionTextToken* tokens, size_t count);
@@ -4945,6 +4954,7 @@ extern "C"
 	BINARYNINJACOREAPI bool BNArchitectureDefaultLiftFunction(BNLowLevelILFunction* function, BNFunctionLifterContext* context);
 	BINARYNINJACOREAPI bool BNArchitectureLiftFunction(BNArchitecture* arch, BNLowLevelILFunction* function,
 		BNFunctionLifterContext* context);
+	BINARYNINJACOREAPI void BNArchitectureFreeFunctionArchContext(BNArchitecture* arch, void* context);
 	BINARYNINJACOREAPI void BNFreeInstructionTextLines(BNInstructionTextLine* lines, size_t count);
 	BINARYNINJACOREAPI char* BNGetArchitectureRegisterName(BNArchitecture* arch, uint32_t reg);
 	BINARYNINJACOREAPI char* BNGetArchitectureFlagName(BNArchitecture* arch, uint32_t flag);

--- a/python/architecture.py
+++ b/python/architecture.py
@@ -405,13 +405,13 @@ class BasicBlockAnalysisContext:
 				direct_no_return_calls[i].address = loc.addr
 			core.BNAnalyzeBasicBlocksContextSetDirectNoReturnCalls(self._handle, direct_no_return_calls, total)
 
-        if self._halted_disassembly_addresses:
-            total = len(self._halted_disassembly_addresses)
-            halted_addresses = (core.BNArchitectureAndAddress * total)()
-            for i, loc in enumerate(self._halted_disassembly_addresses):
-                halted_addresses[i].arch = loc.arch.handle
-                halted_addresses[i].address = loc.addr
-            core.BNAnalyzeBasicBlocksContextSetHaltedDisassemblyAddresses(self._handle, halted_addresses, total)
+		if self._halted_disassembly_addresses:
+			total = len(self._halted_disassembly_addresses)
+			halted_addresses = (core.BNArchitectureAndAddress * total)()
+			for i, loc in enumerate(self._halted_disassembly_addresses):
+				halted_addresses[i].arch = loc.arch.handle
+				halted_addresses[i].address = loc.addr
+			core.BNAnalyzeBasicBlocksContextSetHaltedDisassemblyAddresses(self._handle, halted_addresses, total)
 
 		self._handle.maxSizeReached = ctypes.c_bool(self._max_size_reached)
 		if self._contextual_returns_dirty:

--- a/python/architecture.py
+++ b/python/architecture.py
@@ -96,7 +96,6 @@ class BasicBlockAnalysisContext:
 	_direct_code_references: Dict[int, "function.ArchAndAddr"]
 	_direct_no_return_calls: Set["function.ArchAndAddr"]
 	_halted_disassembly_addresses: Set["function.ArchAndAddr"]
-	_function_arch_context_token: int
 
 	@staticmethod
 	def from_core_struct(bn_bb_context: core.BNBasicBlockAnalysisContext) -> "BasicBlockAnalysisContext":
@@ -167,7 +166,6 @@ class BasicBlockAnalysisContext:
 		    _contextual_returns=contextual_returns, _contextual_returns_dirty=False,
 		    _direct_code_references=direct_code_references, _direct_no_return_calls=direct_no_return_calls,
 		    _halted_disassembly_addresses=halted_disassembly_addresses,
-		    _function_arch_context_token=bn_bb_context.functionArchContext,
 		)
 
 	@property
@@ -328,15 +326,20 @@ class BasicBlockAnalysisContext:
 	def function_arch_context(self) -> Any:
 		"""Get the function architecture context"""
 
-		return self._function.arch.function_arch_contexts.get(self._function_arch_context_token, None)
+		tok = int(self._handle.functionArchContext or 0)
+		if tok == 0:
+			return None
+		return self._function.arch.function_arch_contexts.get(tok, None)
 
 	@function_arch_context.setter
 	def function_arch_context(self, value: Any) -> None:
 		"""Set the function architecture context"""
 
-		token = id(self._function)
+		if self._handle.functionArchContext:
+			raise ValueError("Function architecture context has already been set")
+		token = self._function.start
 		self._function.arch.function_arch_contexts[token] = value
-		self._function_arch_context_token = token
+		self._handle.functionArchContext = ctypes.c_void_p(token)
 
 	def create_basic_block(self, arch: "Architecture", start: int) -> Optional["basicblock.BasicBlock"]:
 		"""
@@ -420,9 +423,6 @@ class BasicBlockAnalysisContext:
 				returns[i].address = loc.addr
 				values[i] = value
 			core.BNAnalyzeBasicBlocksContextSetContextualFunctionReturns(self._handle, returns, values, total)
-
-		self._handle.functionArchContext = self._function_arch_context_token
-		core.BNAnalyzeBasicBlocksContextFinalize(self._handle)
 
 
 @dataclass

--- a/python/architecture.py
+++ b/python/architecture.py
@@ -69,326 +69,338 @@ IntrinsicType = Union[IntrinsicName, 'lowlevelil.ILIntrinsic', IntrinsicIndex]
 
 @dataclass
 class BasicBlockAnalysisContext:
-    """Used by ``analyze_basic_blocks`` and contains analysis settings and other contextual information.
+	"""Used by ``analyze_basic_blocks`` and contains analysis settings and other contextual information.
 
     .. note:: This class is meant to be used by Architecture plugins only
     """
 
-    _handle: core.BNBasicBlockAnalysisContext
-    _function: "function.Function"
-    _contextual_returns_dirty: bool
+	_handle: core.BNBasicBlockAnalysisContext
+	_function: "function.Function"
+	_contextual_returns_dirty: bool
 
-    # In
-    _indirect_branches: List["variable.IndirectBranchInfo"]
-    _indirect_no_return_calls: Set["function.ArchAndAddr"]
-    _analysis_skip_override: core.FunctionAnalysisSkipOverride
-    _guided_analysis_mode: bool
-    _trigger_guided_on_invalid_instruction: bool
-    _translate_tail_calls: bool
-    _disallow_branch_to_string: bool
-    _max_function_size: int
+	# In
+	_indirect_branches: List["variable.IndirectBranchInfo"]
+	_indirect_no_return_calls: Set["function.ArchAndAddr"]
+	_analysis_skip_override: core.FunctionAnalysisSkipOverride
+	_guided_analysis_mode: bool
+	_trigger_guided_on_invalid_instruction: bool
+	_translate_tail_calls: bool
+	_disallow_branch_to_string: bool
+	_max_function_size: int
 
-    # In/Out
-    _max_size_reached: bool
-    _contextual_returns: Dict["function.ArchAndAddr", bool]
+	# In/Out
+	_max_size_reached: bool
+	_contextual_returns: Dict["function.ArchAndAddr", bool]
 
-    # Out
-    _direct_code_references: Dict[int, "function.ArchAndAddr"]
-    _direct_no_return_calls: Set["function.ArchAndAddr"]
-    _halted_disassembly_addresses: Set["function.ArchAndAddr"]
+	# Out
+	_direct_code_references: Dict[int, "function.ArchAndAddr"]
+	_direct_no_return_calls: Set["function.ArchAndAddr"]
+	_halted_disassembly_addresses: Set["function.ArchAndAddr"]
+	_function_arch_context_token: int
 
-    @staticmethod
-    def from_core_struct(bn_bb_context: core.BNBasicBlockAnalysisContext) -> "BasicBlockAnalysisContext":
-        """Create a BasicBlockAnalysisContext from a core.BNBasicBlockAnalysisContext structure."""
+	@staticmethod
+	def from_core_struct(bn_bb_context: core.BNBasicBlockAnalysisContext) -> "BasicBlockAnalysisContext":
+		"""Create a BasicBlockAnalysisContext from a core.BNBasicBlockAnalysisContext structure."""
 
-        indirect_branches = []
-        for i in range(0, bn_bb_context.indirectBranchesCount):
-            ibi = variable.IndirectBranchInfo(
-                source_arch=CoreArchitecture._from_cache(bn_bb_context.indirectBranches[i].sourceArch),
-                source_addr=bn_bb_context.indirectBranches[i].sourceAddr,
-                dest_arch=CoreArchitecture._from_cache(bn_bb_context.indirectBranches[i].destArch),
-                dest_addr=bn_bb_context.indirectBranches[i].destAddr,
-                auto_defined=bn_bb_context.indirectBranches[i].autoDefined,
-            )
-            indirect_branches.append(ibi)
+		indirect_branches = []
+		for i in range(0, bn_bb_context.indirectBranchesCount):
+			ibi = variable.IndirectBranchInfo(
+			    source_arch=CoreArchitecture._from_cache(bn_bb_context.indirectBranches[i].sourceArch),
+			    source_addr=bn_bb_context.indirectBranches[i].sourceAddr,
+			    dest_arch=CoreArchitecture._from_cache(bn_bb_context.indirectBranches[i].destArch),
+			    dest_addr=bn_bb_context.indirectBranches[i].destAddr,
+			    auto_defined=bn_bb_context.indirectBranches[i].autoDefined,
+			)
+			indirect_branches.append(ibi)
 
-        indirect_no_return_calls = set()
-        for i in range(0, bn_bb_context.indirectNoReturnCallsCount):
-            loc = function.ArchAndAddr(
-                CoreArchitecture._from_cache(bn_bb_context.indirectNoReturnCalls[i].arch),
-                bn_bb_context.indirectNoReturnCalls[i].address,
-            )
-            indirect_no_return_calls.add(loc)
+		indirect_no_return_calls = set()
+		for i in range(0, bn_bb_context.indirectNoReturnCallsCount):
+			loc = function.ArchAndAddr(
+			    CoreArchitecture._from_cache(bn_bb_context.indirectNoReturnCalls[i].arch),
+			    bn_bb_context.indirectNoReturnCalls[i].address,
+			)
+			indirect_no_return_calls.add(loc)
 
-        contextual_returns = {}
-        for i in range(0, bn_bb_context.contextualFunctionReturnCount):
-            loc = function.ArchAndAddr(
-                CoreArchitecture._from_cache(bn_bb_context.contextualFunctionReturnLocations[i].arch),
-                bn_bb_context.contextualFunctionReturnLocations[i].address,
-            )
-            contextual_returns[loc] = bn_bb_context._contextualFunctionReturnValues[i]
+		contextual_returns = {}
+		for i in range(0, bn_bb_context.contextualFunctionReturnCount):
+			loc = function.ArchAndAddr(
+			    CoreArchitecture._from_cache(bn_bb_context.contextualFunctionReturnLocations[i].arch),
+			    bn_bb_context.contextualFunctionReturnLocations[i].address,
+			)
+			contextual_returns[loc] = bn_bb_context._contextualFunctionReturnValues[i]
 
-        direct_code_references = {}
-        for i in range(0, bn_bb_context.directRefCount):
-            src = function.ArchAndAddr(
-                CoreArchitecture._from_cache(bn_bb_context.directRefSources[i].arch),
-                bn_bb_context.directRefSources[i].address,
-            )
-            direct_code_references[bn_bb_context.directRefTargets[i]] = src
+		direct_code_references = {}
+		for i in range(0, bn_bb_context.directRefCount):
+			src = function.ArchAndAddr(
+			    CoreArchitecture._from_cache(bn_bb_context.directRefSources[i].arch),
+			    bn_bb_context.directRefSources[i].address,
+			)
+			direct_code_references[bn_bb_context.directRefTargets[i]] = src
 
-        direct_no_return_calls = set()
-        for i in range(0, bn_bb_context.directNoReturnCallsCount):
-            loc = function.ArchAndAddr(
-                CoreArchitecture._from_cache(bn_bb_context.directNoReturnCallLocations[i].arch),
-                bn_bb_context.directNoReturnCallLocations[i].address,
-            )
-            direct_no_return_calls.add(loc)
+		direct_no_return_calls = set()
+		for i in range(0, bn_bb_context.directNoReturnCallsCount):
+			loc = function.ArchAndAddr(
+			    CoreArchitecture._from_cache(bn_bb_context.directNoReturnCallLocations[i].arch),
+			    bn_bb_context.directNoReturnCallLocations[i].address,
+			)
+			direct_no_return_calls.add(loc)
 
-        halted_disassembly_addresses = set()
-        for i in range(0, bn_bb_context.haltedDisassemblyAddressesCount):
-            addr = function.ArchAndAddr(
-                CoreArchitecture._from_cache(bn_bb_context.haltedDisassemblyAddresses[i].arch),
-                bn_bb_context.haltedDisassemblyAddresses[i].address,
-            )
-            halted_disassembly_addresses.add(addr)
+		halted_disassembly_addresses = set()
+		for i in range(0, bn_bb_context.haltedDisassemblyAddressesCount):
+			addr = function.ArchAndAddr(
+			    CoreArchitecture._from_cache(bn_bb_context.haltedDisassemblyAddresses[i].arch),
+			    bn_bb_context.haltedDisassemblyAddresses[i].address,
+			)
+			halted_disassembly_addresses.add(addr)
 
-        view = binaryview.BinaryView(handle=core.BNGetFunctionData(bn_bb_context.function))
-        return BasicBlockAnalysisContext(
-            _handle=bn_bb_context,
-            _function=function.Function(view, core.BNNewFunctionReference(bn_bb_context.function)),
-            _indirect_branches=indirect_branches,
-            _indirect_no_return_calls=indirect_no_return_calls,
-            _analysis_skip_override=bn_bb_context.analysisSkipOverride,
-            _guided_analysis_mode=bn_bb_context.guidedAnalysisMode,
-            _trigger_guided_on_invalid_instruction=bn_bb_context.triggerGuidedOnInvalidInstruction,
-            _translate_tail_calls=bn_bb_context.translateTailCalls,
-            _disallow_branch_to_string=bn_bb_context.disallowBranchToString,
-            _max_function_size=bn_bb_context.maxFunctionSize,
-            _max_size_reached=bn_bb_context.maxSizeReached,
-            _contextual_returns=contextual_returns,
-            _contextual_returns_dirty=False,
-            _direct_code_references=direct_code_references,
-            _direct_no_return_calls=direct_no_return_calls,
-            _halted_disassembly_addresses=halted_disassembly_addresses,
-        )
+		view = binaryview.BinaryView(handle=core.BNGetFunctionData(bn_bb_context.function))
+		return BasicBlockAnalysisContext(
+		    _handle=bn_bb_context,
+		    _function=function.Function(view, core.BNNewFunctionReference(bn_bb_context.function)),
+		    _indirect_branches=indirect_branches, _indirect_no_return_calls=indirect_no_return_calls,
+		    _analysis_skip_override=bn_bb_context.analysisSkipOverride,
+		    _guided_analysis_mode=bn_bb_context.guidedAnalysisMode,
+		    _trigger_guided_on_invalid_instruction=bn_bb_context.triggerGuidedOnInvalidInstruction,
+		    _translate_tail_calls=bn_bb_context.translateTailCalls,
+		    _disallow_branch_to_string=bn_bb_context.disallowBranchToString,
+		    _max_function_size=bn_bb_context.maxFunctionSize, _max_size_reached=bn_bb_context.maxSizeReached,
+		    _contextual_returns=contextual_returns, _contextual_returns_dirty=False,
+		    _direct_code_references=direct_code_references, _direct_no_return_calls=direct_no_return_calls,
+		    _halted_disassembly_addresses=halted_disassembly_addresses,
+		    _function_arch_context_token=bn_bb_context.functionArchContext,
+		)
 
-    @property
-    def indirect_branches(self) -> List["variable.IndirectBranchInfo"]:
-        """Get the list of indirect branches in this context."""
+	@property
+	def indirect_branches(self) -> List["variable.IndirectBranchInfo"]:
+		"""Get the list of indirect branches in this context."""
 
-        return self._indirect_branches
+		return self._indirect_branches
 
-    @property
-    def indirect_no_return_calls(self) -> Set["function.ArchAndAddr"]:
-        """Get the set of indirect no-return calls in this context."""
+	@property
+	def indirect_no_return_calls(self) -> Set["function.ArchAndAddr"]:
+		"""Get the set of indirect no-return calls in this context."""
 
-        return self._indirect_no_return_calls
+		return self._indirect_no_return_calls
 
-    @property
-    def analysis_skip_override(self) -> core.FunctionAnalysisSkipOverride:
-        """Get the analysis skip override setting for this context."""
+	@property
+	def analysis_skip_override(self) -> core.FunctionAnalysisSkipOverride:
+		"""Get the analysis skip override setting for this context."""
 
-        return self._analysis_skip_override
+		return self._analysis_skip_override
 
-    @property
-    def guided_analysis_mode(self) -> bool:
-        """Get the setting that determines if functions start in guided analysis mode."""
+	@property
+	def guided_analysis_mode(self) -> bool:
+		"""Get the setting that determines if functions start in guided analysis mode."""
 
-        return self._guided_analysis_mode
+		return self._guided_analysis_mode
 
-    @property
-    def trigger_guided_on_invalid_instruction(self) -> bool:
-        """Get the setting that determines if guided mode should be triggered on invalid instructions."""
+	@property
+	def trigger_guided_on_invalid_instruction(self) -> bool:
+		"""Get the setting that determines if guided mode should be triggered on invalid instructions."""
 
-        return self._trigger_guided_on_invalid_instruction
+		return self._trigger_guided_on_invalid_instruction
 
-    @property
-    def translate_tail_calls(self) -> bool:
-        """Get setting from context that determines if tail calls should be translated."""
+	@property
+	def translate_tail_calls(self) -> bool:
+		"""Get setting from context that determines if tail calls should be translated."""
 
-        return self._translate_tail_calls
+		return self._translate_tail_calls
 
-    @property
-    def disallow_branch_to_string(self) -> bool:
-        """Get setting from context that determines if branches to string addresses should be disallowed."""
+	@property
+	def disallow_branch_to_string(self) -> bool:
+		"""Get setting from context that determines if branches to string addresses should be disallowed."""
 
-        return self._disallow_branch_to_string
+		return self._disallow_branch_to_string
 
-    @property
-    def max_function_size(self) -> int:
-        """Get the maximum function size setting for this context."""
+	@property
+	def max_function_size(self) -> int:
+		"""Get the maximum function size setting for this context."""
 
-        return self._max_function_size
+		return self._max_function_size
 
-    @property
-    def halt_on_invalid_instruction(self) -> bool:
-        """Get the setting from context that determines if analysis should halt on invalid instructions."""
+	@property
+	def halt_on_invalid_instruction(self) -> bool:
+		"""Get the setting from context that determines if analysis should halt on invalid instructions."""
 
-        return self._halt_on_invalid_instruction
+		return self._halt_on_invalid_instruction
 
-    @property
-    def max_size_reached(self) -> bool:
-        """Get boolean that indicates if the maximum function size has been reached."""
+	@property
+	def max_size_reached(self) -> bool:
+		"""Get boolean that indicates if the maximum function size has been reached."""
 
-        return self._max_size_reached
+		return self._max_size_reached
 
-    @max_size_reached.setter
-    def max_size_reached(self, value: bool) -> None:
-        """Set boolean that indicates if the maximum function size has been reached.
+	@max_size_reached.setter
+	def max_size_reached(self, value: bool) -> None:
+		"""Set boolean that indicates if the maximum function size has been reached.
 
         :param bool value: The new value for max_size_reached
         """
-        if not isinstance(value, bool):
-            raise TypeError("value must be a boolean")
+		if not isinstance(value, bool):
+			raise TypeError("value must be a boolean")
 
-        self._max_size_reached = value
+		self._max_size_reached = value
 
-    @property
-    def contextual_returns(self) -> Dict["function.ArchAndAddr", bool]:
-        """Get the mapping of contextual function return locations to their values."""
+	@property
+	def contextual_returns(self) -> Dict["function.ArchAndAddr", bool]:
+		"""Get the mapping of contextual function return locations to their values."""
 
-        return self._contextual_returns
+		return self._contextual_returns
 
-    def add_contextual_return(self, loc: "function.ArchAndAddr", value: bool) -> None:
-        """
+	def add_contextual_return(self, loc: "function.ArchAndAddr", value: bool) -> None:
+		"""
         ``add_contextual_return`` adds a contextual function return location and its value to the current function.
 
         :param function.ArchAndAddr loc: The location of the contextual function return
         :param bool value: The value of the contextual function return
         """
-        if not isinstance(value, bool):
-            raise TypeError("value must be a boolean")
+		if not isinstance(value, bool):
+			raise TypeError("value must be a boolean")
 
-        if not isinstance(loc, function.ArchAndAddr):
-            raise TypeError("loc must be an instance of function.ArchAndAddr")
+		if not isinstance(loc, function.ArchAndAddr):
+			raise TypeError("loc must be an instance of function.ArchAndAddr")
 
-        # Update existing value if it exists
-        if loc in self._contextual_returns:
-            if self._contextual_returns[loc] == value:
-                return
+		# Update existing value if it exists
+		if loc in self._contextual_returns:
+			if self._contextual_returns[loc] == value:
+				return
 
-        self._contextual_returns[loc] = value
-        self._contextual_returns_dirty = True
+		self._contextual_returns[loc] = value
+		self._contextual_returns_dirty = True
 
-    @property
-    def direct_code_references(self) -> Dict[int, "function.ArchAndAddr"]:
-        """Get the mapping of direct code reference targets to their source locations."""
+	@property
+	def direct_code_references(self) -> Dict[int, "function.ArchAndAddr"]:
+		"""Get the mapping of direct code reference targets to their source locations."""
 
-        return self._direct_code_references
+		return self._direct_code_references
 
-    def add_direct_code_reference(self, target: int, source: "function.ArchAndAddr") -> None:
-        """
+	def add_direct_code_reference(self, target: int, source: "function.ArchAndAddr") -> None:
+		"""
         ``add_direct_code_reference`` adds a direct code reference to the current function.
 
         :param int target: The target address of the direct code reference
         :param function.ArchAndAddr source: The source location of the direct code reference
         """
 
-        if not isinstance(target, int):
-            raise TypeError("target must be an integer")
+		if not isinstance(target, int):
+			raise TypeError("target must be an integer")
 
-        if not isinstance(source, function.ArchAndAddr):
-            raise TypeError("source must be an instance of function.ArchAndAddr")
+		if not isinstance(source, function.ArchAndAddr):
+			raise TypeError("source must be an instance of function.ArchAndAddr")
 
-        self._direct_code_references[target] = source
+		self._direct_code_references[target] = source
 
-    @property
-    def direct_no_return_calls(self) -> Set["function.ArchAndAddr"]:
-        """Get the set of direct no-return call locations in this context."""
+	@property
+	def direct_no_return_calls(self) -> Set["function.ArchAndAddr"]:
+		"""Get the set of direct no-return call locations in this context."""
 
-        return self._direct_no_return_calls
+		return self._direct_no_return_calls
 
-    def add_direct_no_return_call(self, loc: "function.ArchAndAddr") -> None:
-        """
+	def add_direct_no_return_call(self, loc: "function.ArchAndAddr") -> None:
+		"""
         ``add_direct_no_return_call`` adds a direct no-return call location to the current function.
 
         :param function.ArchAndAddr loc: The location of the direct no-return call
         """
-        if not isinstance(loc, function.ArchAndAddr):
-            raise TypeError("loc must be an instance of function.ArchAndAddr")
+		if not isinstance(loc, function.ArchAndAddr):
+			raise TypeError("loc must be an instance of function.ArchAndAddr")
 
-        self._direct_no_return_calls.add(loc)
+		self._direct_no_return_calls.add(loc)
 
-    @property
-    def halted_disassembly_addresses(self) -> Set["function.ArchAndAddr"]:
-        """Get the set of addresses where disassembly has been halted."""
+	@property
+	def halted_disassembly_addresses(self) -> Set["function.ArchAndAddr"]:
+		"""Get the set of addresses where disassembly has been halted."""
 
-        return self._halted_disassembly_addresses
+		return self._halted_disassembly_addresses
 
-    def add_halted_disassembly_address(self, loc: "function.ArchAndAddr") -> None:
-        """
+	def add_halted_disassembly_address(self, loc: "function.ArchAndAddr") -> None:
+		"""
         ``add_halted_disassembly_address`` adds an address to the set of halted disassembly addresses.
 
         :param function.ArchAndAddr loc: The location of the halted disassembly address
         """
-        if not isinstance(loc, function.ArchAndAddr):
-            raise TypeError("loc must be an instance of function.ArchAndAddr")
+		if not isinstance(loc, function.ArchAndAddr):
+			raise TypeError("loc must be an instance of function.ArchAndAddr")
 
-        self._halted_disassembly_addresses.add(loc)
+		self._halted_disassembly_addresses.add(loc)
 
-    def create_basic_block(self, arch: "Architecture", start: int) -> Optional["basicblock.BasicBlock"]:
-        """
+	@property
+	def function_arch_context(self) -> Any:
+		"""Get the function architecture context"""
+
+		return self._function.arch.function_arch_contexts.get(self._function_arch_context_token, None)
+
+	@function_arch_context.setter
+	def function_arch_context(self, value: Any) -> None:
+		"""Set the function architecture context"""
+
+		token = id(self._function)
+		self._function.arch.function_arch_contexts[token] = value
+		self._function_arch_context_token = token
+
+	def create_basic_block(self, arch: "Architecture", start: int) -> Optional["basicblock.BasicBlock"]:
+		"""
         ``create_basic_block`` creates a new BasicBlock at the specified address for the given Architecture.
 
         :param Architecture arch: Architecture of the BasicBlock to create
         :param int start: Address of the BasicBlock to create
         """
 
-        if not isinstance(arch, Architecture):
-            raise TypeError("arch must be an instance of architecture.Architecture")
+		if not isinstance(arch, Architecture):
+			raise TypeError("arch must be an instance of architecture.Architecture")
 
-        bnblock = core.BNAnalyzeBasicBlocksContextCreateBasicBlock(self._handle, arch.handle, start)
-        if not bnblock:
-            return None
+		bnblock = core.BNAnalyzeBasicBlocksContextCreateBasicBlock(self._handle, arch.handle, start)
+		if not bnblock:
+			return None
 
-        view = binaryview.BinaryView(handle=core.BNGetFunctionData(self._function.handle))
-        return basicblock.BasicBlock(bnblock, view)
+		view = binaryview.BinaryView(handle=core.BNGetFunctionData(self._function.handle))
+		return basicblock.BasicBlock(bnblock, view)
 
-    def add_basic_block(self, block: "basicblock.BasicBlock") -> None:
-        """
+	def add_basic_block(self, block: "basicblock.BasicBlock") -> None:
+		"""
         ``add_basic_block`` adds a BasicBlock to the current function.
 
         :param basicblock.BasicBlock block: The BasicBlock to add
         """
-        if not isinstance(block, basicblock.BasicBlock):
-            raise TypeError("block must be an instance of basicblock.BasicBlock")
+		if not isinstance(block, basicblock.BasicBlock):
+			raise TypeError("block must be an instance of basicblock.BasicBlock")
 
-        core.BNAnalyzeBasicBlocksContextAddBasicBlockToFunction(self._handle, block.handle)
+		core.BNAnalyzeBasicBlocksContextAddBasicBlockToFunction(self._handle, block.handle)
 
-    def add_temp_outgoing_reference(self, target: "function.Function") -> None:
-        """
+	def add_temp_outgoing_reference(self, target: "function.Function") -> None:
+		"""
         ``add_temp_outgoing_reference`` adds a temporary outgoing reference to the specified function.
 
         :param function.Function target: The target function to add a temporary outgoing reference to
         """
-        if not isinstance(target, function.Function):
-            raise TypeError("target must be an instance of function.Function")
+		if not isinstance(target, function.Function):
+			raise TypeError("target must be an instance of function.Function")
 
-        core.BNAnalyzeBasicBlocksContextAddTempReference(self._handle, target.handle)
+		core.BNAnalyzeBasicBlocksContextAddTempReference(self._handle, target.handle)
 
-    def finalize(self) -> None:
-        """
+	def finalize(self) -> None:
+		"""
         ``finalize`` finalizes the function's basic block analysis
         """
 
-        if self._direct_code_references:
-            total = len(self._direct_code_references)
-            sources = (core.BNArchitectureAndAddress * total)()
-            targets = (ctypes.c_ulonglong * total)()
-            for i, (target, src) in enumerate(self._direct_code_references.items()):
-                sources[i].arch = src.arch.handle
-                sources[i].address = src.addr
-                targets[i] = target
+		if self._direct_code_references:
+			total = len(self._direct_code_references)
+			sources = (core.BNArchitectureAndAddress * total)()
+			targets = (ctypes.c_ulonglong * total)()
+			for i, (target, src) in enumerate(self._direct_code_references.items()):
+				sources[i].arch = src.arch.handle
+				sources[i].address = src.addr
+				targets[i] = target
 
-            core.BNAnalyzeBasicBlocksContextSetDirectCodeReferences(self._handle, sources, targets, total)
+			core.BNAnalyzeBasicBlocksContextSetDirectCodeReferences(self._handle, sources, targets, total)
 
-        if self._direct_no_return_calls:
-            total = len(self._direct_no_return_calls)
-            direct_no_return_calls = (core.BNArchitectureAndAddress * total)()
-            for i, loc in enumerate(self._direct_no_return_calls):
-                direct_no_return_calls[i].arch = loc.arch.handle
-                direct_no_return_calls[i].address = loc.addr
-            core.BNAnalyzeBasicBlocksContextSetDirectNoReturnCalls(self._handle, direct_no_return_calls, total)
+		if self._direct_no_return_calls:
+			total = len(self._direct_no_return_calls)
+			direct_no_return_calls = (core.BNArchitectureAndAddress * total)()
+			for i, loc in enumerate(self._direct_no_return_calls):
+				direct_no_return_calls[i].arch = loc.arch.handle
+				direct_no_return_calls[i].address = loc.addr
+			core.BNAnalyzeBasicBlocksContextSetDirectNoReturnCalls(self._handle, direct_no_return_calls, total)
 
         if self._halted_disassembly_addresses:
             total = len(self._halted_disassembly_addresses)
@@ -398,18 +410,19 @@ class BasicBlockAnalysisContext:
                 halted_addresses[i].address = loc.addr
             core.BNAnalyzeBasicBlocksContextSetHaltedDisassemblyAddresses(self._handle, halted_addresses, total)
 
-        self._handle.maxSizeReached = ctypes.c_bool(self._max_size_reached)
-        if self._contextual_returns_dirty:
-            total = len(self._contextual_returns)
-            values = (ctypes.c_bool * total)()
-            returns = (core.BNArchitectureAndAddress * total)()
-            for i, (loc, value) in enumerate(self._contextual_returns.items()):
-                returns[i].arch = loc.arch.handle
-                returns[i].address = loc.addr
-                values[i] = value
-            core.BNAnalyzeBasicBlocksContextSetContextualFunctionReturns(self._handle, returns, values, total)
+		self._handle.maxSizeReached = ctypes.c_bool(self._max_size_reached)
+		if self._contextual_returns_dirty:
+			total = len(self._contextual_returns)
+			values = (ctypes.c_bool * total)()
+			returns = (core.BNArchitectureAndAddress * total)()
+			for i, (loc, value) in enumerate(self._contextual_returns.items()):
+				returns[i].arch = loc.arch.handle
+				returns[i].address = loc.addr
+				values[i] = value
+			core.BNAnalyzeBasicBlocksContextSetContextualFunctionReturns(self._handle, returns, values, total)
 
-        core.BNAnalyzeBasicBlocksContextFinalize(self._handle)
+		self._handle.functionArchContext = self._function_arch_context_token
+		core.BNAnalyzeBasicBlocksContextFinalize(self._handle)
 
 
 @dataclass
@@ -429,10 +442,12 @@ class FunctionLifterContext:
 	_user_indirect_branches: Dict["function.ArchAndAddr", Set["function.ArchAndAddr"]]
 	_auto_indirect_branches: Dict["function.ArchAndAddr", Set["function.ArchAndAddr"]]
 	_inlined_calls: Set[int]
+	_function_arch_context_token: int
 
 	@staticmethod
-	def from_core_struct(func: core.BNLowLevelILFunction,
-		bn_fl_context: core.BNFunctionLifterContext) -> "FunctionLifterContext":
+	def from_core_struct(
+	    func: core.BNLowLevelILFunction, bn_fl_context: core.BNFunctionLifterContext
+	) -> "FunctionLifterContext":
 		"""Create a FunctionLifterContext from a core.BNFunctionLifterContext structure."""
 
 		session_id = core.BNLoggerGetSessionId(bn_fl_context.logger)
@@ -442,17 +457,13 @@ class FunctionLifterContext:
 		plat = platform.CorePlatform._from_cache(core.BNNewPlatformReference(bn_fl_context.platform))
 		blocks = []
 		for i in range(0, bn_fl_context.basicBlockCount):
-			blocks.append(
-				basicblock.BasicBlock(
-					core.BNNewBasicBlockReference(bn_fl_context.basicBlocks[i])
-				)
-			)
+			blocks.append(basicblock.BasicBlock(core.BNNewBasicBlockReference(bn_fl_context.basicBlocks[i])))
 
 		contextual_returns = {}
 		for i in range(0, bn_fl_context.contextualFunctionReturnCount):
 			loc = function.ArchAndAddr(
-				CoreArchitecture._from_cache(bn_fl_context.contextualFunctionReturnLocations[i].arch),
-				bn_fl_context.contextualFunctionReturnLocations[i].address,
+			    CoreArchitecture._from_cache(bn_fl_context.contextualFunctionReturnLocations[i].arch),
+			    bn_fl_context.contextualFunctionReturnLocations[i].address,
 			)
 
 			contextual_returns[loc] = bn_fl_context._contextualFunctionReturnValues[i]
@@ -460,12 +471,12 @@ class FunctionLifterContext:
 		inline_remapping = {}
 		for i in range(0, bn_fl_context.inlinedRemappingEntryCount):
 			key = function.ArchAndAddr(
-				CoreArchitecture._from_cache(bn_fl_context.inlinedRemappingKeys[i].arch),
-				bn_fl_context.inlinedRemappingKeys[i].address,
+			    CoreArchitecture._from_cache(bn_fl_context.inlinedRemappingKeys[i].arch),
+			    bn_fl_context.inlinedRemappingKeys[i].address,
 			)
 			dest = function.ArchAndAddr(
-				CoreArchitecture._from_cache(bn_fl_context.inlinedRemappingEntries[i].destination.arch),
-				bn_fl_context.inlinedRemappingEntries[i].destination.address,
+			    CoreArchitecture._from_cache(bn_fl_context.inlinedRemappingEntries[i].destination.arch),
+			    bn_fl_context.inlinedRemappingEntries[i].destination.address,
 			)
 			inline_remapping[src] = dest
 
@@ -473,8 +484,8 @@ class FunctionLifterContext:
 		auto_indirect_branches = {}
 		for i in range(0, bn_fl_context.indirectBranchesCount):
 			src = function.ArchAndAddr(
-				CoreArchitecture._from_cache(bn_fl_context.indirectBranches[i].sourceArch),
-				bn_fl_context.indirectBranches[i].sourceAddr,
+			    CoreArchitecture._from_cache(bn_fl_context.indirectBranches[i].sourceArch),
+			    bn_fl_context.indirectBranches[i].sourceAddr,
 			)
 
 			dest = function.ArchAndAddr(
@@ -491,37 +502,35 @@ class FunctionLifterContext:
 					user_indirect_branches[src] = set()
 				user_indirect_branches[src].add(dest)
 
-
 		inlined_calls = set()
 		for i in range(0, bn_fl_context.inlinedCallsCount):
 			inlined_calls.add(bn_fl_context.inlinedCalls[i])
 
 		return FunctionLifterContext(
-			_handle=bn_fl_context,
-			_function=lowlevelil.LowLevelILFunction(
-				plat.arch, core.BNNewLowLevelILFunctionReference(func)
-			),
-			_platform=plat,
-			_logger=logger,
-			_blocks=blocks,
-			_contextual_returns=contextual_returns,
-			_inline_remapping=inline_remapping,
-			_user_indirect_branches=user_indirect_branches,
-			_auto_indirect_branches=auto_indirect_branches,
-			_inlined_calls=inlined_calls,
+		    _handle=bn_fl_context,
+		    _function=lowlevelil.LowLevelILFunction(plat.arch,
+		                                            core.BNNewLowLevelILFunctionReference(func)), _platform=plat,
+		    _logger=logger, _blocks=blocks, _contextual_returns=contextual_returns, _inline_remapping=inline_remapping,
+		    _user_indirect_branches=user_indirect_branches, _auto_indirect_branches=auto_indirect_branches,
+		    _inlined_calls=inlined_calls, _function_arch_context_token=bn_fl_context.functionArchContext,
 		)
 
 	def prepare_block_translation(self, function, arch, address):
-		"""Prepare block for translation"""
+		"""Prepare the basic block for translation"""
 
 		core.BNPrepareBlockTranslation(function.handle, arch.handle, address)
 
 	@property
 	def blocks(self) -> List["basicblock.BasicBlock"]:
-		"""Get the list of basic blocks in this context."""
+		"""Get the list of basic blocks in this context"""
 
 		return self._blocks
 
+	@property
+	def function_arch_context(self) -> Any:
+		"""Get the function architecture context"""
+
+		return self._function.arch.function_arch_contexts.get(self._function_arch_context_token, None)
 
 @dataclass(frozen=True)
 class RegisterInfo:
@@ -696,6 +705,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 	reg_stacks: Dict[RegisterStackName, RegisterStackInfo] = {}
 	intrinsics = {}
 	next_address = 0
+	function_arch_contexts: Dict[int, Any] = {}
 
 	def __init__(self):
 		binaryninja._init_plugins()
@@ -717,12 +727,16 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 		)
 		self._cb.getInstructionInfo = self._cb.getInstructionInfo.__class__(self._get_instruction_info)
 		self._cb.getInstructionText = self._cb.getInstructionText.__class__(self._get_instruction_text)
+		self._cb.getInstructionTextWithContext = self._cb.getInstructionTextWithContext.__class__(
+		    self._get_instruction_text_with_context
+		)
 		self._cb.freeInstructionText = self._cb.freeInstructionText.__class__(self._free_instruction_text)
 		self._cb.getInstructionLowLevelIL = self._cb.getInstructionLowLevelIL.__class__(
 		    self._get_instruction_low_level_il
 		)
 		self._cb.analyzeBasicBlocks = self._cb.analyzeBasicBlocks.__class__(self._analyze_basic_blocks)
 		self._cb.liftFunction = self._cb.liftFunction.__class__(self._lift_function)
+		self._cb.freeFunctionArchContext = self._cb.freeFunctionArchContext.__class__(self._free_function_arch_context)
 		self._cb.getRegisterName = self._cb.getRegisterName.__class__(self._get_register_name)
 		self._cb.getFlagName = self._cb.getFlagName.__class__(self._get_flag_name)
 		self._cb.getFlagWriteTypeName = self._cb.getFlagWriteTypeName.__class__(self._get_flag_write_type_name)
@@ -1164,6 +1178,26 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			log_error_for_exception("Unhandled Python exception in Architecture._get_instruction_text")
 			return False
 
+	def _get_instruction_text_with_context(self, ctxt, data, addr, length, context_token, result, count):
+		try:
+			buf = ctypes.create_string_buffer(length[0])
+			ctypes.memmove(buf, data, length[0])
+			context = self.function_arch_contexts.get(context_token, None)
+			info = self.get_instruction_text_with_context(buf.raw, addr, context)
+			if info is None:
+				return False
+			tokens = info[0]
+			length[0] = info[1]
+			count[0] = len(tokens)
+			token_buf = function.InstructionTextToken._get_core_struct(tokens)
+			result[0] = token_buf
+			ptr = ctypes.cast(token_buf, ctypes.c_void_p)
+			self._pending_token_lists[ptr.value] = (ptr.value, token_buf)
+			return True
+		except:
+			log_error_for_exception("Unhandled Python exception in Architecture._get_instruction_text_with_context")
+			return False
+
 	def _free_instruction_text(self, tokens, count):
 		try:
 			buf = ctypes.cast(tokens, ctypes.c_void_p)
@@ -1204,6 +1238,12 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 		except:
 			log_error_for_exception("Unhandled Python exception in Architecture._lift_function")
 			return False
+
+	def _free_function_arch_context(self, ctx, context_token):
+		try:
+			self.function_arch_contexts.pop(context_token, None)
+		except:
+			log_error_for_exception("Unhandled Python exception in Architecture._free_function_arch_context")
 
 	def _get_register_name(self, ctxt, reg):
 		try:
@@ -1893,6 +1933,20 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 		:rtype: tuple(list(InstructionTextToken), int)
 		"""
 		raise NotImplementedError
+
+	def get_instruction_text_with_context(self, data: bytes, addr: int, context: Any) -> Optional[Tuple[List['function.InstructionTextToken'], int]]:
+		"""
+		``get_instruction_text`` returns a tuple containing a list of decoded InstructionTextToken objects and the bytes used at the given virtual
+		address ``addr`` with data ``data``.
+
+		.. note:: Architecture subclasses should implement this method if they require context from analyze_basic_blocks for instruction decoding.
+
+		:param str data: a maximum of max_instruction_length bytes from the binary at virtual address ``addr``
+		:param int addr: virtual address of bytes in ``data``
+		:param Any context: function architecture context
+		:return: a tuple containing the InstructionTextToken list and length of bytes decoded
+		"""
+		return self.get_instruction_text(data, addr)
 
 	def get_instruction_low_level_il_instruction(
 	    self, bv: 'binaryview.BinaryView', addr: int
@@ -3283,6 +3337,8 @@ class ArchitectureHook(CoreArchitecture):
 			self._cb.getInstructionInfo = self._cb.getInstructionInfo.__class__()
 		if self.get_instruction_text.__code__ == CoreArchitecture.get_instruction_text.__code__:
 			self._cb.getInstructionText = self._cb.getInstructionText.__class__()
+		if self.get_instruction_text_with_context.__code__ == CoreArchitecture.get_instruction_text_with_context.__code__:
+			self._cb.getInstructionTextWithContext = self._cb.getInstructionTextWithContext.__class__()
 		if self.__class__.stack_pointer is None:
 			self._cb.getStackPointerRegister = self._cb.getStackPointerRegister.__class__()
 		if self.__class__.link_reg is None:

--- a/rust/src/architecture.rs
+++ b/rust/src/architecture.rs
@@ -42,6 +42,8 @@ use std::{
     mem::MaybeUninit,
 };
 
+use std::ptr::NonNull;
+
 use crate::function_recognizer::FunctionRecognizer;
 use crate::relocation::{CustomRelocationHandlerHandle, RelocationHandler};
 
@@ -192,6 +194,30 @@ pub trait Architecture: 'static + Sized + AsRef<CoreArchitecture> {
         addr: u64,
     ) -> Option<(usize, Vec<InstructionTextToken>)>;
 
+    /// Disassembles a raw byte sequence into a human-readable list of text tokens.
+    ///
+    /// This function is responsible for the visual representation of assembly instructions.
+    /// It does *not* define semantics (use [`Architecture::instruction_llil`] for that);
+    /// it simply tells the UI how to print the instruction. This variant includes contextual data, which
+    /// can be produced by analyze_basic_blocks
+    ///
+    /// # Returns
+    ///
+    /// An `Option` containing a tuple:
+    ///
+    /// * `usize`: The size of the decoded instruction in bytes. Is used to advance to the next instruction.
+    /// * `Vec<InstructionTextToken>`: A list of text tokens representing the instruction.
+    ///
+    /// Returns `None` if the bytes do not form a valid instruction.
+    fn instruction_text_with_context(
+        &self,
+        data: &[u8],
+        addr: u64,
+        _context: Option<NonNull<c_void>>,
+    ) -> Option<(usize, Vec<InstructionTextToken>)> {
+        self.instruction_text(data, addr)
+    }
+
     // TODO: Why do we need to return a boolean here? Does `None` not represent the same thing?
     /// Appends arbitrary low-level il instructions to `il`.
     ///
@@ -225,6 +251,12 @@ pub trait Architecture: 'static + Sized + AsRef<CoreArchitecture> {
     ) -> bool {
         unsafe { BNArchitectureDefaultLiftFunction(function.handle, context.handle) }
     }
+
+    /// Free the function architecture context
+    ///
+    /// NOTE: Only implement this method in architecture plugins that allocate a context in
+    /// analyze_basic_blocks
+    fn free_function_arch_context(&self, _context: Option<NonNull<c_void>>) {}
 
     /// Fallback flag value calculation path. This method is invoked when the core is unable to
     /// recover the flag using semantics and resorts to emitting instructions that explicitly set each
@@ -705,6 +737,38 @@ impl Architecture for CoreArchitecture {
         }
     }
 
+    fn instruction_text_with_context(
+        &self,
+        data: &[u8],
+        addr: u64,
+        context: Option<NonNull<c_void>>,
+    ) -> Option<(usize, Vec<InstructionTextToken>)> {
+        let mut consumed = data.len();
+        let mut count: usize = 0;
+        let mut result: *mut BNInstructionTextToken = std::ptr::null_mut();
+        let ctx_ptr: *mut c_void = context.map_or(std::ptr::null_mut(), |p| p.as_ptr());
+        unsafe {
+            if BNGetInstructionTextWithContext(
+                self.handle,
+                data.as_ptr(),
+                addr,
+                &mut consumed,
+                ctx_ptr,
+                &mut result,
+                &mut count,
+            ) {
+                let instr_text_tokens = std::slice::from_raw_parts(result, count)
+                    .iter()
+                    .map(InstructionTextToken::from_raw)
+                    .collect();
+                BNFreeInstructionText(result, count);
+                Some((consumed, instr_text_tokens))
+            } else {
+                None
+            }
+        }
+    }
+
     fn instruction_llil(
         &self,
         data: &[u8],
@@ -752,6 +816,8 @@ impl Architecture for CoreArchitecture {
     ) -> bool {
         unsafe { BNArchitectureLiftFunction(self.handle, function.handle, context.handle) }
     }
+
+    fn free_function_arch_context(&self, _context: Option<NonNull<c_void>>) {}
 
     fn flag_write_llil<'a>(
         &self,
@@ -1419,6 +1485,43 @@ where
         true
     }
 
+    pub unsafe extern "C" fn cb_get_instruction_text_with_context<A>(
+        ctxt: *mut c_void,
+        data: *const u8,
+        addr: u64,
+        len: *mut usize,
+        context: *mut c_void,
+        result: *mut *mut BNInstructionTextToken,
+        count: *mut usize,
+    ) -> bool
+    where
+        A: 'static + Architecture<Handle = CustomArchitectureHandle<A>> + Send + Sync,
+    {
+        let custom_arch = unsafe { &*(ctxt as *mut A) };
+        let data = unsafe { std::slice::from_raw_parts(data, *len) };
+        let result = unsafe { &mut *result };
+        let context = NonNull::new(context);
+
+        let Some((res_size, res_tokens)) =
+            custom_arch.instruction_text_with_context(data, addr, context)
+        else {
+            return false;
+        };
+
+        let res_tokens: Box<[BNInstructionTextToken]> = res_tokens
+            .into_iter()
+            .map(InstructionTextToken::into_raw)
+            .collect();
+        unsafe {
+            // NOTE: Freed with `cb_free_instruction_text`
+            let res_tokens = Box::leak(res_tokens);
+            *result = res_tokens.as_mut_ptr();
+            *count = res_tokens.len();
+            *len = res_size;
+        }
+        true
+    }
+
     extern "C" fn cb_free_instruction_text(tokens: *mut BNInstructionTextToken, count: usize) {
         unsafe {
             let raw_tokens = std::slice::from_raw_parts_mut(tokens, count);
@@ -1483,6 +1586,15 @@ where
         let mut context: FunctionLifterContext =
             unsafe { FunctionLifterContext::from_raw(context) };
         custom_arch.lift_function(function, &mut context)
+    }
+
+    extern "C" fn cb_free_function_arch_context<A>(ctxt: *mut c_void, context: *mut c_void)
+    where
+        A: 'static + Architecture<Handle = CustomArchitectureHandle<A>> + Send + Sync,
+    {
+        let custom_arch = unsafe { &*(ctxt as *mut A) };
+        let context = NonNull::new(context);
+        custom_arch.free_function_arch_context(context);
     }
 
     extern "C" fn cb_reg_name<A>(ctxt: *mut c_void, reg: u32) -> *mut c_char
@@ -2401,10 +2513,12 @@ where
         getAssociatedArchitectureByAddress: Some(cb_associated_arch_by_addr::<A>),
         getInstructionInfo: Some(cb_instruction_info::<A>),
         getInstructionText: Some(cb_get_instruction_text::<A>),
+        getInstructionTextWithContext: Some(cb_get_instruction_text_with_context::<A>),
         freeInstructionText: Some(cb_free_instruction_text),
         getInstructionLowLevelIL: Some(cb_instruction_llil::<A>),
         analyzeBasicBlocks: Some(cb_analyze_basic_blocks::<A>),
         liftFunction: Some(cb_lift_function::<A>),
+        freeFunctionArchContext: Some(cb_free_function_arch_context::<A>),
 
         getRegisterName: Some(cb_reg_name::<A>),
         getFlagName: Some(cb_flag_name::<A>),

--- a/rust/src/architecture.rs
+++ b/rust/src/architecture.rs
@@ -252,12 +252,6 @@ pub trait Architecture: 'static + Sized + AsRef<CoreArchitecture> {
         unsafe { BNArchitectureDefaultLiftFunction(function.handle, context.handle) }
     }
 
-    /// Free the function architecture context
-    ///
-    /// NOTE: Only implement this method in architecture plugins that allocate a context in
-    /// analyze_basic_blocks
-    fn free_function_arch_context(&self, _context: Option<NonNull<c_void>>) {}
-
     /// Fallback flag value calculation path. This method is invoked when the core is unable to
     /// recover the flag using semantics and resorts to emitting instructions that explicitly set each
     /// observed flag to the value of an expression returned by this function.
@@ -583,10 +577,7 @@ pub trait Architecture: 'static + Sized + AsRef<CoreArchitecture> {
 }
 
 pub trait ArchitectureWithFunctionContext: Architecture {
-    type FunctionArchContext: 'static;
-
-    #[allow(clippy::boxed_local)]
-    fn free_typed_function_arch_context(&self, _context: Box<Self::FunctionArchContext>) {}
+    type FunctionArchContext: Send + Sync + 'static;
 
     fn instruction_text_with_typed_context(
         &self,
@@ -846,8 +837,6 @@ impl Architecture for CoreArchitecture {
     ) -> bool {
         unsafe { BNArchitectureLiftFunction(self.handle, function.handle, context.handle) }
     }
-
-    fn free_function_arch_context(&self, _context: Option<NonNull<c_void>>) {}
 
     fn flag_write_llil<'a>(
         &self,
@@ -1625,15 +1614,6 @@ where
         let mut context: FunctionLifterContext =
             unsafe { FunctionLifterContext::from_raw(context) };
         custom_arch.lift_function(function, &mut context)
-    }
-
-    extern "C" fn cb_free_function_arch_context<A>(ctxt: *mut c_void, context: *mut c_void)
-    where
-        A: 'static + Architecture<Handle = CustomArchitectureHandle<A>> + Send + Sync,
-    {
-        let custom_arch = unsafe { &*(ctxt as *mut A) };
-        let context = NonNull::new(context);
-        custom_arch.free_function_arch_context(context);
     }
 
     extern "C" fn cb_reg_name<A>(ctxt: *mut c_void, reg: u32) -> *mut c_char
@@ -2557,7 +2537,7 @@ where
         getInstructionLowLevelIL: Some(cb_instruction_llil::<A>),
         analyzeBasicBlocks: Some(cb_analyze_basic_blocks::<A>),
         liftFunction: Some(cb_lift_function::<A>),
-        freeFunctionArchContext: Some(cb_free_function_arch_context::<A>),
+        freeFunctionArchContext: None,
 
         getRegisterName: Some(cb_reg_name::<A>),
         getFlagName: Some(cb_flag_name::<A>),
@@ -2645,7 +2625,7 @@ where
     F: FnOnce(CustomArchitectureHandle<A>, CoreArchitecture) -> A,
 {
     unsafe extern "C" fn cb_free_function_arch_context_typed<A>(
-        ctxt: *mut c_void,
+        _ctxt: *mut c_void,
         context: *mut c_void,
     ) where
         A: 'static
@@ -2656,9 +2636,9 @@ where
         if context.is_null() {
             return;
         }
-        let custom_arch = unsafe { &*(ctxt as *mut A) };
-        let boxed = unsafe { Box::from_raw(context as *mut A::FunctionArchContext) };
-        custom_arch.free_typed_function_arch_context(boxed);
+        // The context was allocated via Box::into_raw in set_function_arch_context,
+        // so we reconstruct the Box here and let it drop.
+        let _ = unsafe { Box::from_raw(context as *mut A::FunctionArchContext) };
     }
 
     unsafe extern "C" fn cb_get_instruction_text_with_context_typed<A>(

--- a/rust/src/architecture.rs
+++ b/rust/src/architecture.rs
@@ -582,6 +582,22 @@ pub trait Architecture: 'static + Sized + AsRef<CoreArchitecture> {
     fn handle(&self) -> Self::Handle;
 }
 
+pub trait ArchitectureWithFunctionContext: Architecture {
+    type FunctionArchContext: 'static;
+
+    #[allow(clippy::boxed_local)]
+    fn free_typed_function_arch_context(&self, _context: Box<Self::FunctionArchContext>) {}
+
+    fn instruction_text_with_typed_context(
+        &self,
+        data: &[u8],
+        addr: u64,
+        _context: Option<&Self::FunctionArchContext>,
+    ) -> Option<(usize, Vec<InstructionTextToken>)> {
+        self.instruction_text(data, addr)
+    }
+}
+
 pub struct FunctionLifterContext {
     pub(crate) handle: *mut BNFunctionLifterContext,
 }
@@ -591,6 +607,20 @@ impl FunctionLifterContext {
         debug_assert!(!handle.is_null());
 
         FunctionLifterContext { handle }
+    }
+
+    pub fn get_function_arch_context<A: ArchitectureWithFunctionContext>(
+        &self,
+        _arch: &A,
+    ) -> Option<&A::FunctionArchContext> {
+        unsafe {
+            let ptr = (*self.handle).functionArchContext;
+            if ptr.is_null() {
+                None
+            } else {
+                Some(&*(ptr as *const A::FunctionArchContext))
+            }
+        }
     }
 }
 
@@ -1339,6 +1369,15 @@ pub fn register_architecture<A, F>(name: &str, func: F) -> &'static A
 where
     A: 'static + Architecture<Handle = CustomArchitectureHandle<A>> + Send + Sync + Sized,
     F: FnOnce(CustomArchitectureHandle<A>, CoreArchitecture) -> A,
+{
+    register_architecture_impl(name, func, |_| {})
+}
+
+fn register_architecture_impl<A, F, C>(name: &str, func: F, customize: C) -> &'static A
+where
+    A: 'static + Architecture<Handle = CustomArchitectureHandle<A>> + Send + Sync + Sized,
+    F: FnOnce(CustomArchitectureHandle<A>, CoreArchitecture) -> A,
+    C: FnOnce(&mut BNCustomArchitecture),
 {
     #[repr(C)]
     struct ArchitectureBuilder<A, F>
@@ -2585,6 +2624,8 @@ where
         skipAndReturnValue: Some(cb_skip_and_return_value::<A>),
     };
 
+    customize(&mut custom_arch);
+
     unsafe {
         let res = BNRegisterArchitecture(name.as_ptr(), &mut custom_arch as *mut _);
 
@@ -2592,6 +2633,82 @@ where
 
         (*raw).arch.assume_init_mut()
     }
+}
+
+pub fn register_architecture_with_function_context<A, F>(name: &str, func: F) -> &'static A
+where
+    A: 'static
+        + ArchitectureWithFunctionContext<Handle = CustomArchitectureHandle<A>>
+        + Send
+        + Sync
+        + Sized,
+    F: FnOnce(CustomArchitectureHandle<A>, CoreArchitecture) -> A,
+{
+    unsafe extern "C" fn cb_free_function_arch_context_typed<A>(
+        ctxt: *mut c_void,
+        context: *mut c_void,
+    ) where
+        A: 'static
+            + ArchitectureWithFunctionContext<Handle = CustomArchitectureHandle<A>>
+            + Send
+            + Sync,
+    {
+        if context.is_null() {
+            return;
+        }
+        let custom_arch = unsafe { &*(ctxt as *mut A) };
+        let boxed = unsafe { Box::from_raw(context as *mut A::FunctionArchContext) };
+        custom_arch.free_typed_function_arch_context(boxed);
+    }
+
+    unsafe extern "C" fn cb_get_instruction_text_with_context_typed<A>(
+        ctxt: *mut c_void,
+        data: *const u8,
+        addr: u64,
+        len: *mut usize,
+        context: *mut c_void,
+        result: *mut *mut BNInstructionTextToken,
+        count: *mut usize,
+    ) -> bool
+    where
+        A: 'static
+            + ArchitectureWithFunctionContext<Handle = CustomArchitectureHandle<A>>
+            + Send
+            + Sync,
+    {
+        let custom_arch = unsafe { &*(ctxt as *mut A) };
+        let data = unsafe { std::slice::from_raw_parts(data, *len) };
+        let result = unsafe { &mut *result };
+        let typed_context: Option<&A::FunctionArchContext> = if context.is_null() {
+            None
+        } else {
+            Some(unsafe { &*(context as *const A::FunctionArchContext) })
+        };
+
+        let Some((res_size, res_tokens)) =
+            custom_arch.instruction_text_with_typed_context(data, addr, typed_context)
+        else {
+            return false;
+        };
+
+        let res_tokens: Box<[BNInstructionTextToken]> = res_tokens
+            .into_iter()
+            .map(InstructionTextToken::into_raw)
+            .collect();
+        unsafe {
+            let res_tokens = Box::leak(res_tokens);
+            *result = res_tokens.as_mut_ptr();
+            *count = res_tokens.len();
+            *len = res_size;
+        }
+        true
+    }
+
+    register_architecture_impl(name, func, |custom_arch| {
+        custom_arch.freeFunctionArchContext = Some(cb_free_function_arch_context_typed::<A>);
+        custom_arch.getInstructionTextWithContext =
+            Some(cb_get_instruction_text_with_context_typed::<A>);
+    })
 }
 
 #[derive(Debug)]

--- a/rust/src/architecture/basic_block.rs
+++ b/rust/src/architecture/basic_block.rs
@@ -328,8 +328,6 @@ impl BasicBlockAnalysisContext {
         if self.contextual_returns_dirty {
             self.update_contextual_returns();
         }
-
-        unsafe { BNAnalyzeBasicBlocksContextFinalize(self.handle) };
     }
 }
 

--- a/rust/src/architecture/basic_block.rs
+++ b/rust/src/architecture/basic_block.rs
@@ -1,4 +1,4 @@
-use crate::architecture::{CoreArchitecture, IndirectBranchInfo};
+use crate::architecture::{ArchitectureWithFunctionContext, CoreArchitecture, IndirectBranchInfo};
 use crate::basic_block::BasicBlock;
 use crate::function::{Function, Location, NativeBlock};
 use crate::rc::Ref;
@@ -178,6 +178,34 @@ impl BasicBlockAnalysisContext {
 
     pub fn add_inlined_unresolved_indirect_branch(&mut self, loc: impl Into<Location>) {
         self.inlined_unresolved_indirect_branches.insert(loc.into());
+    }
+
+    pub fn set_function_arch_context<A: ArchitectureWithFunctionContext>(
+        &mut self,
+        _arch: &A,
+        context: Box<A::FunctionArchContext>,
+    ) -> bool {
+        unsafe {
+            if !(*self.handle).functionArchContext.is_null() {
+                return false;
+            }
+            (*self.handle).functionArchContext = Box::into_raw(context) as *mut std::ffi::c_void;
+        }
+        true
+    }
+
+    pub fn get_function_arch_context<A: ArchitectureWithFunctionContext>(
+        &self,
+        _arch: &A,
+    ) -> Option<&A::FunctionArchContext> {
+        unsafe {
+            let ptr = (*self.handle).functionArchContext;
+            if ptr.is_null() {
+                None
+            } else {
+                Some(&*(ptr as *const A::FunctionArchContext))
+            }
+        }
     }
 
     /// Creates a new [`BasicBlock`] at the specified address for the given [`CoreArchitecture`].


### PR DESCRIPTION
Adds a GetInstructionTextWithContext callback to the architecture class that can be used to pass data from AnalyzeBasicBlocks. This same context is also supplied to LiftFunction and allows for supplying shared function and/or binary view level information across basic block analysis, function lifting, and disassembly text rendering