### PR TITLE
Minor Python bugfixes and type issues

### DIFF
--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -88,6 +88,7 @@ PathType = Union[str, os.PathLike]
 InstructionsType = Generator[Tuple[List['_function.InstructionTextToken'], int], None, None]
 ProgressFuncType = Callable[[int, int], bool]
 DataMatchCallbackType = Callable[[int, 'databuffer.DataBuffer'], bool]
+TextMatchCallbackType = Callable[[int, str, 'lineardisassembly.LinearDisassemblyLine'], bool]
 LineMatchCallbackType = Callable[[int, 'lineardisassembly.LinearDisassemblyLine'], bool]
 StringOrType = Union[str, '_types.Type', '_types.TypeBuilder']
 
@@ -9535,6 +9536,18 @@ to a the type "tagRECT" found in the typelibrary "winX64common"
 				if (not self.thread.is_alive()) and self.results.empty():
 					raise StopIteration
 
+	@overload
+	def find_all_data(
+	    self, start: int, end: int, data: bytes, flags: FindFlag = FindFlag.FindCaseSensitive,
+	    progress_func: Optional[ProgressFuncType] = None, match_callback: None = None
+	) -> QueueGenerator: ...
+
+	@overload
+	def find_all_data(
+	    self, start: int, end: int, data: bytes, flags: FindFlag = FindFlag.FindCaseSensitive,
+	    progress_func: Optional[ProgressFuncType] = None, match_callback: DataMatchCallbackType = None
+	) -> bool: ...
+
 	def find_all_data(
 	    self, start: int, end: int, data: bytes, flags: FindFlag = FindFlag.FindCaseSensitive,
 	    progress_func: Optional[ProgressFuncType] = None, match_callback: Optional[DataMatchCallbackType] = None
@@ -9610,10 +9623,24 @@ to a the type "tagRECT" found in the typelibrary "winX64common"
 		core.BNFreeLinearDisassemblyLines(lines, 1)
 		return line
 
+	@overload
 	def find_all_text(
 	    self, start: int, end: int, text: str, settings: Optional[_function.DisassemblySettings] = None,
 	    flags=FindFlag.FindCaseSensitive, graph_type: _function.FunctionViewTypeOrName = FunctionGraphType.NormalFunctionGraph, progress_func=None,
-	    match_callback=None
+	    match_callback: None = None
+	) -> QueueGenerator: ...
+
+	@overload
+	def find_all_text(
+	    self, start: int, end: int, text: str, settings: Optional[_function.DisassemblySettings] = None,
+	    flags=FindFlag.FindCaseSensitive, graph_type: _function.FunctionViewTypeOrName = FunctionGraphType.NormalFunctionGraph, progress_func=None,
+	    match_callback: TextMatchCallbackType = None
+	) -> bool: ...
+
+	def find_all_text(
+	    self, start: int, end: int, text: str, settings: Optional[_function.DisassemblySettings] = None,
+	    flags=FindFlag.FindCaseSensitive, graph_type: _function.FunctionViewTypeOrName = FunctionGraphType.NormalFunctionGraph, progress_func=None,
+	    match_callback: Optional[TextMatchCallbackType] = None
 	) -> Union[QueueGenerator, bool]:
 		"""
 		``find_all_text`` searches for string ``text`` occurring in the linear view output starting
@@ -9679,7 +9706,7 @@ to a the type "tagRECT" found in the typelibrary "winX64common"
 			    ctypes.POINTER(core.BNLinearDisassemblyLine)
 			)(
 			    lambda ctxt, addr, match, line:
-			    not match_callback(addr, match, self._LinearDisassemblyLine_convertor(line)) is False
+			    not match_callback(addr, core.pyNativeStr(match), self._LinearDisassemblyLine_convertor(line)) is False
 			)
 
 			return core.BNFindAllTextWithProgress(
@@ -9692,7 +9719,7 @@ to a the type "tagRECT" found in the typelibrary "winX64common"
 			    ctypes.c_bool, ctypes.c_void_p, ctypes.c_ulonglong, ctypes.c_char_p,
 			    ctypes.POINTER(core.BNLinearDisassemblyLine)
 			)(
-			    lambda ctxt, addr, match, line: results.put((addr, match, self._LinearDisassemblyLine_convertor(line)))
+			    lambda ctxt, addr, match, line: results.put((addr, core.pyNativeStr(match), self._LinearDisassemblyLine_convertor(line)))
 			    or True
 			)
 
@@ -9704,6 +9731,20 @@ to a the type "tagRECT" found in the typelibrary "winX64common"
 			)
 
 			return self.QueueGenerator(t, results)
+
+	@overload
+	def find_all_constant(
+	    self, start: int, end: int, constant: int, settings: Optional[_function.DisassemblySettings] = None,
+	    graph_type: _function.FunctionViewTypeOrName = FunctionGraphType.NormalFunctionGraph, progress_func: Optional[ProgressFuncType] = None,
+	    match_callback: None = None
+	) -> QueueGenerator: ...
+
+	@overload
+	def find_all_constant(
+	    self, start: int, end: int, constant: int, settings: Optional[_function.DisassemblySettings] = None,
+	    graph_type: _function.FunctionViewTypeOrName = FunctionGraphType.NormalFunctionGraph, progress_func: Optional[ProgressFuncType] = None,
+	    match_callback: LineMatchCallbackType = None
+	) -> bool: ...
 
 	def find_all_constant(
 	    self, start: int, end: int, constant: int, settings: Optional[_function.DisassemblySettings] = None,
@@ -11496,6 +11537,12 @@ class TypedDataAccessor:
 
 		for i in range(_type.count):
 			yield self[i]
+
+	@overload
+	def __getitem__(self, key: Union[str, int]) -> 'TypedDataAccessor': ...
+
+	@overload
+	def __getitem__(self, key: slice) -> List['TypedDataAccessor']: ...
 
 	def __getitem__(self, key: Union[str, int, slice]) -> Union['TypedDataAccessor', List['TypedDataAccessor']]:
 		_type = self.type

--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -30,7 +30,7 @@ import pprint
 import inspect
 import os
 import uuid
-from typing import Callable, Generator, Optional, Union, Tuple, List, Mapping, Any, \
+from typing import Callable, Generator, Optional, Union, Tuple, List, Sequence, Mapping, Any, \
 	Iterator, Iterable, KeysView, ItemsView, ValuesView, Dict, overload
 from dataclasses import dataclass
 from enum import IntFlag
@@ -8561,7 +8561,7 @@ class BinaryView:
 		type_obj = type_obj.immutable_copy()
 		core.BNDefineUserAnalysisType(self.handle, _name, type_obj.handle)
 
-	def define_types(self, types: List[Tuple[str, Optional['_types.QualifiedNameType'], StringOrType]], progress_func: Optional[ProgressFuncType]) -> Mapping[str, '_types.QualifiedName']:
+	def define_types(self, types: Sequence[Tuple[str, Optional['_types.QualifiedNameType'], StringOrType]], progress_func: Optional[ProgressFuncType]) -> Mapping[str, '_types.QualifiedName']:
 		"""
 		``define_types`` registers multiple types as though calling :py:func:`define_type` multiple times.
 		The difference with this plural version is that it is optimized for adding many types
@@ -8613,7 +8613,7 @@ class BinaryView:
 			core.BNFreeStringList(result_ids, result_count)
 			core.BNFreeTypeNameList(result_names, result_count)
 
-	def define_user_types(self, types: List[Tuple[Optional['_types.QualifiedNameType'], StringOrType]], progress_func: Optional[ProgressFuncType]):
+	def define_user_types(self, types: Sequence[Tuple[Optional['_types.QualifiedNameType'], StringOrType]], progress_func: Optional[ProgressFuncType]):
 		"""
 		``define_user_types`` registers multiple types as though calling :py:func:`define_user_type` multiple times.
 		The difference with this plural version is that it is optimized for adding many types

--- a/python/callingconvention.py
+++ b/python/callingconvention.py
@@ -447,11 +447,11 @@ class CallingConvention:
 		result[0].state = api_obj.state
 		result[0].value = api_obj.value
 
-	def _get_incoming_flag_value(self, ctxt, reg, func, result):
+	def _get_incoming_flag_value(self, ctxt, flag, func, result):
 		try:
 			func_obj = function.Function(handle=core.BNNewFunctionReference(func))
-			reg_name = self.arch.get_reg_name(reg)
-			api_obj = self.perform_get_incoming_flag_value(reg_name, func_obj)._to_core_struct()
+			flag_name = self.arch.get_reg_name(flag)
+			api_obj = self.perform_get_incoming_flag_value(flag_name, func_obj)._to_core_struct()
 		except:
 			log_error_for_exception("Unhandled Python exception in CallingConvention._get_incoming_flag_value")
 			api_obj = variable.Undetermined()._to_core_struct()
@@ -502,7 +502,7 @@ class CallingConvention:
 		return variable.Undetermined()
 
 	def perform_get_incoming_flag_value(
-	    self, reg: 'architecture.RegisterName', func: 'function.Function'
+	    self, flag: 'architecture.FlagName', func: 'function.Function'
 	) -> 'variable.RegisterValue':
 		return variable.Undetermined()
 
@@ -535,14 +535,14 @@ class CallingConvention:
 		)
 
 	def get_incoming_flag_value(
-	    self, flag: 'architecture.FlagIndex', func: 'function.Function'
+	    self, flag: 'architecture.FlagType', func: 'function.Function'
 	) -> 'variable.RegisterValue':
-		reg_num = self.arch.get_flag_index(flag)
+		flag_index = self.arch.get_flag_index(flag)
 		func_handle = None
 		if func is not None:
 			func_handle = func.handle
 		return variable.RegisterValue.from_BNRegisterValue(
-		    core.BNGetIncomingFlagValue(self.handle, reg_num, func_handle), self.arch
+		    core.BNGetIncomingFlagValue(self.handle, flag_index, func_handle), self.arch
 		)
 
 	def get_incoming_var_for_parameter_var(

--- a/python/callingconvention.py
+++ b/python/callingconvention.py
@@ -450,7 +450,7 @@ class CallingConvention:
 	def _get_incoming_flag_value(self, ctxt, flag, func, result):
 		try:
 			func_obj = function.Function(handle=core.BNNewFunctionReference(func))
-			flag_name = self.arch.get_reg_name(flag)
+			flag_name = self.arch.get_flag_name(flag)
 			api_obj = self.perform_get_incoming_flag_value(flag_name, func_obj)._to_core_struct()
 		except:
 			log_error_for_exception("Unhandled Python exception in CallingConvention._get_incoming_flag_value")

--- a/python/typeprinter.py
+++ b/python/typeprinter.py
@@ -21,7 +21,7 @@ import abc
 import ctypes
 import dataclasses
 from json import dumps
-from typing import List, Tuple, Optional, Any
+from typing import List, Sequence, Tuple, Optional, Any
 
 import sys
 import traceback
@@ -305,7 +305,7 @@ class TypePrinter(metaclass=_TypePrinterMetaclass):
 			log_error_for_exception("Unhandled Python exception in TypePrinter._free_lines")
 			return False
 
-	def _default_print_all_types(self, types_: List[Tuple[types.QualifiedNameType, types.Type]], data: binaryview.BinaryView, padding_cols = 64, escaping: TokenEscapingType = TokenEscapingType.BackticksTokenEscapingType) -> str:
+	def _default_print_all_types(self, types_: Sequence[Tuple[types.QualifiedNameType, types.Type]], data: binaryview.BinaryView, padding_cols = 64, escaping: TokenEscapingType = TokenEscapingType.BackticksTokenEscapingType) -> str:
 		cpp_names = (core.BNQualifiedName * len(types_))()
 		cpp_types = (ctypes.POINTER(core.BNType) * len(types_))()
 
@@ -427,7 +427,7 @@ class TypePrinter(metaclass=_TypePrinterMetaclass):
 		"""
 		raise NotImplementedError()
 
-	def print_all_types(self, types: List[Tuple[types.QualifiedNameType, types.Type]], data: binaryview.BinaryView, padding_cols = 64, escaping: TokenEscapingType = TokenEscapingType.BackticksTokenEscapingType) -> str:
+	def print_all_types(self, types: Sequence[Tuple[types.QualifiedNameType, types.Type]], data: binaryview.BinaryView, padding_cols = 64, escaping: TokenEscapingType = TokenEscapingType.BackticksTokenEscapingType) -> str:
 		"""
 		Print all types to a single big string, including headers, sections, etc
 
@@ -541,7 +541,7 @@ class CoreTypePrinter(TypePrinter):
 		core.BNFreeTypeDefinitionLineList(core_lines, count.value)
 		return lines
 
-	def print_all_types(self, types_: List[Tuple[types.QualifiedNameType, types.Type]], data: binaryview.BinaryView, padding_cols = 64, escaping: TokenEscapingType = TokenEscapingType.BackticksTokenEscapingType) -> str:
+	def print_all_types(self, types_: Sequence[Tuple[types.QualifiedNameType, types.Type]], data: binaryview.BinaryView, padding_cols = 64, escaping: TokenEscapingType = TokenEscapingType.BackticksTokenEscapingType) -> str:
 		cpp_names = (core.BNQualifiedName * len(types_))()
 		cpp_types = (ctypes.POINTER(core.BNType) * len(types_))()
 

--- a/python/types.py
+++ b/python/types.py
@@ -85,7 +85,7 @@ def convert_integer(value: ctypes.c_uint64, signed: bool, width: int) -> int:
 	return func[bool(signed)][width](value).value
 
 class QualifiedName:
-	def __init__(self, name: Optional[QualifiedNameType] = None, separator: str = "::"):
+	def __init__(self, name: Optional[QualifiedNameType] = None, join: str = "::"):
 		self._name: List[str] = []
 		if isinstance(name, str):
 			self._name = [name]
@@ -99,10 +99,10 @@ class QualifiedName:
 					self._name.append(i.decode("utf-8"))
 				else:
 					self._name.append(str(i))
-		self._separator = separator
+		self._join = join
 
 	def __str__(self):
-		return self.separator.join(self.name)
+		return self.join.join(self.name)
 
 	def __repr__(self):
 		return repr(str(self))
@@ -116,7 +116,7 @@ class QualifiedName:
 		elif isinstance(other, list):
 			return self.name == other
 		elif isinstance(other, self.__class__):
-			return self.name == other.name and self.separator == other.separator
+			return self.name == other.name and self.join == other.join
 		return NotImplemented
 
 	def __ne__(self, other):
@@ -164,7 +164,7 @@ class QualifiedName:
 			name_list[i] = self.name[i].encode("utf-8")
 		result.name = name_list
 		result.nameCount = len(self.name)
-		result.join = self.separator.encode("utf-8")
+		result.join = self.join.encode("utf-8")
 		return result
 
 	@staticmethod
@@ -183,12 +183,12 @@ class QualifiedName:
 		self._name = value
 
 	@property
-	def separator(self) -> str:
-		return self._separator
+	def join(self) -> str:
+		return self._join
 
-	@separator.setter
-	def separator(self, value: str) -> None:
-		self._separator = value
+	@join.setter
+	def join(self, value: str) -> None:
+		self._join = value
 
 	@staticmethod
 	def escape(name: QualifiedNameType, escaping: TokenEscapingType) -> str:

--- a/python/types.py
+++ b/python/types.py
@@ -172,7 +172,7 @@ class QualifiedName:
 		result = []
 		for i in range(0, name.nameCount):
 			result.append(name.name[i].decode("utf-8"))
-		return QualifiedName(result)
+		return QualifiedName(result, name.join.decode("utf-8"))
 
 	@property
 	def name(self) -> List[str]:

--- a/python/types.py
+++ b/python/types.py
@@ -164,7 +164,7 @@ class QualifiedName:
 			name_list[i] = self.name[i].encode("utf-8")
 		result.name = name_list
 		result.nameCount = len(self.name)
-		result.join = self.join.encode("utf-8")
+		result.join = self.join
 		return result
 
 	@staticmethod
@@ -172,7 +172,7 @@ class QualifiedName:
 		result = []
 		for i in range(0, name.nameCount):
 			result.append(name.name[i].decode("utf-8"))
-		return QualifiedName(result, name.join.decode("utf-8"))
+		return QualifiedName(result, name.join)
 
 	@property
 	def name(self) -> List[str]:
@@ -216,16 +216,14 @@ class TypeReferenceSource:
 
 
 class NameSpace(QualifiedName):
-	def __str__(self):
-		return ":".join(self.name)
-
 	def _to_core_struct(self) -> core.BNNameSpace:
 		result = core.BNNameSpace()
 		name_list = (ctypes.c_char_p * len(self.name))()
 		for i in range(0, len(self.name)):
-			name_list[i] = self.name[i].encode('charmap')
+			name_list[i] = self.name[i].encode('utf-8')
 		result.name = name_list
 		result.nameCount = len(self.name)
+		result.join = self.join
 		return result
 
 	@staticmethod
@@ -233,7 +231,7 @@ class NameSpace(QualifiedName):
 		result = []
 		for i in range(0, name.nameCount):
 			result.append(name.name[i].decode("utf-8"))
-		return NameSpace(result)
+		return NameSpace(result, name.join)
 
 	@staticmethod
 	def get_core_struct(name: Optional[Union[str, List[str], 'NameSpace']]) -> Optional[core.BNNameSpace]:

--- a/python/types.py
+++ b/python/types.py
@@ -85,7 +85,7 @@ def convert_integer(value: ctypes.c_uint64, signed: bool, width: int) -> int:
 	return func[bool(signed)][width](value).value
 
 class QualifiedName:
-	def __init__(self, name: Optional[QualifiedNameType] = None):
+	def __init__(self, name: Optional[QualifiedNameType] = None, separator: str = "::"):
 		self._name: List[str] = []
 		if isinstance(name, str):
 			self._name = [name]
@@ -99,9 +99,10 @@ class QualifiedName:
 					self._name.append(i.decode("utf-8"))
 				else:
 					self._name.append(str(i))
+		self._separator = separator
 
 	def __str__(self):
-		return "::".join(self.name)
+		return self.separator.join(self.name)
 
 	def __repr__(self):
 		return repr(str(self))
@@ -115,7 +116,7 @@ class QualifiedName:
 		elif isinstance(other, list):
 			return self.name == other
 		elif isinstance(other, self.__class__):
-			return self.name == other.name
+			return self.name == other.name and self.separator == other.separator
 		return NotImplemented
 
 	def __ne__(self, other):
@@ -163,7 +164,7 @@ class QualifiedName:
 			name_list[i] = self.name[i].encode("utf-8")
 		result.name = name_list
 		result.nameCount = len(self.name)
-		result.join = "::".encode("utf-8")
+		result.join = self.separator.encode("utf-8")
 		return result
 
 	@staticmethod
@@ -180,6 +181,14 @@ class QualifiedName:
 	@name.setter
 	def name(self, value: List[str]) -> None:
 		self._name = value
+
+	@property
+	def separator(self) -> str:
+		return self._separator
+
+	@separator.setter
+	def separator(self, value: str) -> None:
+		self._separator = value
 
 	@staticmethod
 	def escape(name: QualifiedNameType, escaping: TokenEscapingType) -> str:

--- a/python/types.py
+++ b/python/types.py
@@ -20,7 +20,7 @@
 
 import ctypes
 import typing
-from typing import Generator, List, Union, Tuple, Optional, Iterable, Dict, Generic, TypeVar, Callable
+from typing import Generator, List, Union, Tuple, Optional, Iterable, Dict, Generic, TypeVar, Callable, overload
 from dataclasses import dataclass
 import uuid
 
@@ -728,7 +728,7 @@ class TypeBuilder:
 
 	@staticmethod
 	def named_type_from_type_and_id(
-	    type_id: str, name: QualifiedNameType, type: Optional['Type'] = None
+	    type_id: str, name: QualifiedNameType, type: Optional[SomeType] = None
 	) -> 'NamedTypeReferenceBuilder':
 		return NamedTypeReferenceBuilder.named_type_from_type_and_id(type_id, name, type)
 
@@ -740,7 +740,7 @@ class TypeBuilder:
 
 	@staticmethod
 	def pointer(
-	    arch: 'architecture.Architecture', type: 'Type', const: BoolWithConfidenceType = BoolWithConfidence(False),
+	    arch: 'architecture.Architecture', type: SomeType, const: BoolWithConfidenceType = BoolWithConfidence(False),
 	    volatile: BoolWithConfidenceType = BoolWithConfidence(False),
 	    ref_type: ReferenceType = ReferenceType.PointerReferenceType
 	) -> 'PointerBuilder':
@@ -748,19 +748,19 @@ class TypeBuilder:
 
 	@staticmethod
 	def pointer_of_width(
-	    width: _int, type: 'Type', const: BoolWithConfidenceType = BoolWithConfidence(False),
+	    width: _int, type: SomeType, const: BoolWithConfidenceType = BoolWithConfidence(False),
 	    volatile: BoolWithConfidenceType = BoolWithConfidence(False),
 	    ref_type: ReferenceType = ReferenceType.PointerReferenceType
 	) -> 'PointerBuilder':
 		return PointerBuilder.create(type, width, None, const, volatile, ref_type)
 
 	@staticmethod
-	def array(type: 'Type', count: _int) -> 'ArrayBuilder':
+	def array(type: SomeType, count: _int) -> 'ArrayBuilder':
 		return ArrayBuilder.create(type, count)
 
 	@staticmethod
 	def function(
-	    ret: Optional['Type'] = None, params: Optional[ParamsType] = None,
+	    ret: Optional[SomeType] = None, params: Optional[ParamsType] = None,
 	    calling_convention: Optional['callingconvention.CallingConvention'] = None,
 	    variable_arguments: Optional[BoolWithConfidenceType] = None,
 	    stack_adjust: Optional[OffsetWithConfidenceType] = None
@@ -998,7 +998,7 @@ class WideCharBuilder(TypeBuilder):
 class PointerBuilder(TypeBuilder):
 	@classmethod
 	def create(
-	    cls, type: 'Type', width: int = 4, arch: Optional['architecture.Architecture'] = None,
+	    cls, type: SomeType, width: int = 4, arch: Optional['architecture.Architecture'] = None,
 	    const: BoolWithConfidenceType = False, volatile: BoolWithConfidenceType = False,
 	    ref_type: ReferenceType = ReferenceType.PointerReferenceType, platform: Optional['_platform.Platform'] = None,
 	    confidence: int = core.max_confidence
@@ -1811,7 +1811,13 @@ class EnumerationBuilder(TypeBuilder):
 		for member in self.members:
 			yield member
 
-	def __getitem__(self, value: Union[str, int, slice]):
+	@overload
+	def __getitem__(self, value: Union[str, int]) -> EnumerationMember: ...
+
+	@overload
+	def __getitem__(self, value: slice) -> List[EnumerationMember]: ...
+
+	def __getitem__(self, value: Union[str, int, slice]) -> EnumerationMember:
 		if isinstance(value, str):
 			for member in self.members:
 				if member.name == value:
@@ -1911,7 +1917,7 @@ class NamedTypeReferenceBuilder(TypeBuilder):
 
 	@staticmethod
 	def named_type_from_type_and_id(
-	    type_id: str, name: QualifiedNameType, type: Optional['Type'] = None
+	    type_id: str, name: QualifiedNameType, type: Optional[SomeType] = None
 	) -> 'NamedTypeReferenceBuilder':
 		if type is None:
 			return NamedTypeReferenceBuilder.create(NamedTypeReferenceClass.UnknownNamedTypeClass, type_id, name)
@@ -2418,12 +2424,12 @@ class Type:
 		return result
 
 	@staticmethod
-	def named_type_from_type(name: QualifiedNameType, type: 'Type') -> 'NamedTypeReferenceType':
+	def named_type_from_type(name: QualifiedNameType, type: SomeType) -> 'NamedTypeReferenceType':
 		return NamedTypeReferenceType.create_from_type(name, type)
 
 	@staticmethod
 	def named_type_from_type_and_id(
-	    type_id: str, name: QualifiedNameType, type: Optional['Type'] = None
+	    type_id: str, name: QualifiedNameType, type: Optional[SomeType] = None
 	) -> 'NamedTypeReferenceType':
 		return NamedTypeReferenceType.create_from_type(name, type, type_id)
 
@@ -2443,7 +2449,7 @@ class Type:
 
 	@staticmethod
 	def pointer(
-	    arch: 'architecture.Architecture', type: 'Type', const: BoolWithConfidenceType = BoolWithConfidence(False),
+	    arch: 'architecture.Architecture', type: SomeType, const: BoolWithConfidenceType = BoolWithConfidence(False),
 	    volatile: BoolWithConfidenceType = BoolWithConfidence(False),
 	    ref_type: ReferenceType = ReferenceType.PointerReferenceType, width: _int = None
 	) -> 'PointerType':
@@ -2456,7 +2462,7 @@ class Type:
 
 	@staticmethod
 	def pointer_of_width(
-	    width: _int, type: 'Type', const: BoolWithConfidenceType = False, volatile: BoolWithConfidenceType = False,
+	    width: _int, type: SomeType, const: BoolWithConfidenceType = False, volatile: BoolWithConfidenceType = False,
 	    ref_type: ReferenceType = ReferenceType.PointerReferenceType
 	) -> 'PointerType':
 		return PointerType.create_with_width(width, type, const, volatile, ref_type)
@@ -3361,7 +3367,7 @@ class NamedTypeReferenceType(Type):
 
 	@classmethod
 	def create_from_type(
-	    cls, name: QualifiedNameType, type: Optional[Type], guid: Optional[str] = None,
+	    cls, name: QualifiedNameType, type: Optional[SomeType], guid: Optional[str] = None,
 	    platform: Optional['_platform.Platform'] = None, confidence: int = core.max_confidence,
 	    const: BoolWithConfidenceType = False, volatile: BoolWithConfidenceType = False
 	) -> 'NamedTypeReferenceType':


### PR DESCRIPTION
- Fixed parameters for `get_incoming_flag_value`
- Disambiguated return type for `TypedDataAccessor.__getitem__` (previously `TypedDataAcccessor | List[TypedDataAccessor]` no matter the type for `key`)
- Fixed parameter type conflicts in `types`, primarily in `TypeBuilder`s
- Disambiguated return type for data/text/line searchers in a BinaryView
- Specify callback type and convert `match` callback param for `BinaryView.find_all_text`
- Allow user-specified joins for a Python `QualifiedName`
- Fix narrowed sequence elements passed into some functions causing a type mismatch
  - `List` is invariant, but `Sequence` is covariant