### PR TITLE
Python: Replace NotImplemented with default values or errors

### DIFF
--- a/python/architecture.py
+++ b/python/architecture.py
@@ -2400,7 +2400,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			b'\\x0f\\x84\\x04\\x00\\x00\\x00'
 			>>>
 		"""
-		return NotImplemented
+		raise NotImplementedError
 
 	def is_never_branch_patch_available(self, data: bytes, addr: int = 0) -> bool:
 		"""
@@ -2420,7 +2420,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			False
 			>>>
 		"""
-		return NotImplemented
+		return False
 
 	def is_always_branch_patch_available(self, data: bytes, addr: int = 0) -> bool:
 		"""
@@ -2441,7 +2441,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			False
 			>>>
 		"""
-		return NotImplemented
+		return False
 
 	def is_invert_branch_patch_available(self, data: bytes, addr: int = 0) -> bool:
 		"""
@@ -2461,7 +2461,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			False
 			>>>
 		"""
-		return NotImplemented
+		return False
 
 	def is_skip_and_return_zero_patch_available(self, data: bytes, addr: int = 0) -> bool:
 		"""
@@ -2484,7 +2484,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			False
 			>>>
 		"""
-		return NotImplemented
+		return False
 
 	def is_skip_and_return_value_patch_available(self, data: bytes, addr: int = 0) -> bool:
 		"""
@@ -2505,7 +2505,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			False
 			>>>
 		"""
-		return NotImplemented
+		return False
 
 	def convert_to_nop(self, data: bytes, addr: int = 0) -> Optional[bytes]:
 		"""
@@ -2524,7 +2524,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			b'\\x90\\x90'
 			>>>
 		"""
-		return NotImplemented
+		raise NotImplementedError
 
 	def always_branch(self, data: bytes, addr: int = 0) -> Optional[bytes]:
 		"""
@@ -2546,7 +2546,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			(['jmp', '     ', '0x9'], 5)
 			>>>
 		"""
-		return NotImplemented
+		raise NotImplementedError
 
 	def invert_branch(self, data: bytes, addr: int = 0) -> Optional[bytes]:
 		"""
@@ -2569,7 +2569,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			(['jl', '      ', '0xa'], 6)
 			>>>
 		"""
-		return NotImplemented
+		raise NotImplementedError
 
 	def skip_and_return_value(self, data: bytes, addr: int, value: int) -> Optional[bytes]:
 		"""
@@ -2588,7 +2588,7 @@ class Architecture(metaclass=_ArchitectureMetaClass):
 			(['mov', '     ', 'eax', ', ', '0x0'], 5)
 			>>>
 		"""
-		return NotImplemented
+		raise NotImplementedError
 
 	def register_calling_convention(self, cc: 'callingconvention.CallingConvention') -> None:
 		"""

--- a/python/fileaccessor.py
+++ b/python/fileaccessor.py
@@ -35,13 +35,13 @@ class FileAccessor:
 		self._cb.write = self._cb.write.__class__(self._write)
 
 	def get_length(self):
-		return NotImplemented
+		raise NotImplementedError
 
 	def read(self, offset, length):
-		return NotImplemented
+		raise NotImplementedError
 
 	def write(self, offset: int, data: bytes):
-		return NotImplemented
+		raise NotImplementedError
 
 	def __len__(self):
 		return self.get_length()

--- a/python/filemetadata.py
+++ b/python/filemetadata.py
@@ -70,13 +70,13 @@ class NavigationHandler:
 			return False
 
 	def get_current_view(self) -> str:
-		return NotImplemented
+		raise NotImplementedError
 
 	def get_current_offset(self) -> int:
-		return NotImplemented
+		raise NotImplementedError
 
 	def navigate(self, view: ViewName, offset: int) -> bool:
-		return NotImplemented
+		raise NotImplementedError
 
 
 class SaveSettings:

--- a/python/interaction.py
+++ b/python/interaction.py
@@ -833,7 +833,7 @@ class InteractionHandler:
 		pass
 
 	def get_text_line_input(self, prompt, title):
-		return NotImplemented
+		raise NotImplementedError
 
 	def get_int_input(self, prompt, title):
 		while True:
@@ -849,10 +849,10 @@ class InteractionHandler:
 		return get_int_input(prompt, title)
 
 	def get_choice_input(self, prompt, title, choices):
-		return NotImplemented
+		raise NotImplementedError
 
 	def get_large_choice_input(self, prompt, title, choices):
-		return NotImplemented
+		raise NotImplementedError
 
 	def get_open_filename_input(self, prompt, ext):
 		return get_text_line_input(prompt, "Open File")


### PR DESCRIPTION
In the python API the builtin value [NotImplemented](https://docs.python.org/3/library/constants.html#NotImplemented) is sometimes used as return value. This is intended for operator implementations like `__eq__`, but may cause problems in other contexts. This PR only touches `NotImplemented` outside of operator implementations.

As an example why the current implementation might be problematic: The base `Architecture` class currently returns `NotImplemented` for patching methods. This leads to boolean evaluation of `NotImplemented` for `is_xy_patch_available` (evaluated to True). For that reason, all patches are listed as available, but their execution will finally fail because `NotImplemented` as return value for the patch methods is not of type `Optional[bytes]`.

For unimplemented methods in API base classes `NotImplementedError` seems like a better solution if there are no good default values / default implementations available. 