### PR TITLE
[Rust] impl Send and Sync to CoreLanguageRepresentationFunctionType

### DIFF
--- a/rust/src/language_representation.rs
+++ b/rust/src/language_representation.rs
@@ -123,6 +123,9 @@ pub struct CoreLanguageRepresentationFunctionType {
     handle: NonNull<BNLanguageRepresentationFunctionType>,
 }
 
+unsafe impl Send for CoreLanguageRepresentationFunctionType {}
+unsafe impl Sync for CoreLanguageRepresentationFunctionType {}
+
 impl CoreLanguageRepresentationFunctionType {
     pub(crate) unsafe fn from_raw(handle: NonNull<BNLanguageRepresentationFunctionType>) -> Self {
         Self { handle }


### PR DESCRIPTION
To implement the trait `LanguageRepresentationFunctionType` it's necessary to store `CoreLanguageRepresentationFunctionType` inside the struct, but because that trait requires `Sync + Sync` the `CoreLanguageRepresentationFunctionType` its required to also implement it.