### PR TITLE
Add a hook to allow BinaryView subclasses to run code after snapshot data is applied

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -5773,6 +5773,15 @@ namespace BinaryNinja {
 		void PerformDefineRelocation(Architecture* arch, BNRelocationInfo& info, uint64_t target, uint64_t reloc);
 		void PerformDefineRelocation(Architecture* arch, BNRelocationInfo& info, Ref<Symbol> sym, uint64_t reloc);
 
+		/*! OnAfterSnapshotDataApplied is called when loading a view from a database, after snapshot data has been applied to it.
+		
+		    \note This method **may** be overridden by custom BinaryViews.
+
+			\warning This method **must not** be called directly.
+
+		*/
+		virtual void OnAfterSnapshotDataApplied() {}
+
 	  public:
 		void NotifyDataWritten(uint64_t offset, size_t len);
 		void NotifyDataInserted(uint64_t offset, size_t len);
@@ -5780,6 +5789,7 @@ namespace BinaryNinja {
 
 	  private:
 		static bool InitCallback(void* ctxt);
+		static void OnAfterSnapshotDataAppliedCallback(void* ctxt);
 		static void FreeCallback(void* ctxt);
 		static size_t ReadCallback(void* ctxt, void* dest, uint64_t offset, size_t len);
 		static size_t WriteCallback(void* ctxt, uint64_t offset, const void* src, size_t len);

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -37,14 +37,14 @@
 // Current ABI version for linking to the core. This is incremented any time
 // there are changes to the API that affect linking, including new functions,
 // new types, or modifications to existing functions or types.
-#define BN_CURRENT_CORE_ABI_VERSION 162
+#define BN_CURRENT_CORE_ABI_VERSION 163
 
 // Minimum ABI version that is supported for loading of plugins. Plugins that
 // are linked to an ABI version less than this will not be able to load and
 // will require rebuilding. The minimum version is increased when there are
 // incompatible changes that break binary compatibility, such as changes to
 // existing types or functions.
-#define BN_MINIMUM_CORE_ABI_VERSION 161
+#define BN_MINIMUM_CORE_ABI_VERSION 163
 
 #ifdef __GNUC__
 	#ifdef BINARYNINJACORE_LIBRARY
@@ -1847,6 +1847,7 @@ extern "C"
 		bool (*isRelocatable)(void* ctxt);
 		size_t (*getAddressSize)(void* ctxt);
 		bool (*save)(void* ctxt, BNFileAccessor* accessor);
+		void (*onAfterSnapshotDataApplied)(void* ctxt);
 	} BNCustomBinaryView;
 
 	typedef struct BNCustomBinaryViewType

--- a/binaryview.cpp
+++ b/binaryview.cpp
@@ -1365,6 +1365,7 @@ BinaryView::BinaryView(const std::string& typeName, FileMetadata* file, BinaryVi
 	view.isRelocatable = IsRelocatableCallback;
 	view.getAddressSize = GetAddressSizeCallback;
 	view.save = SaveCallback;
+	view.onAfterSnapshotDataApplied = OnAfterSnapshotDataAppliedCallback;
 	m_file = file;
 	AddRefForRegistration();
 	m_object = BNCreateCustomBinaryView(
@@ -1385,6 +1386,13 @@ bool BinaryView::InitCallback(void* ctxt)
 {
 	CallbackRef<BinaryView> view(ctxt);
 	return view->Init();
+}
+
+
+void BinaryView::OnAfterSnapshotDataAppliedCallback(void* ctxt)
+{
+	CallbackRef<BinaryView> view(ctxt);
+	view->OnAfterSnapshotDataApplied();
 }
 
 

--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -3173,6 +3173,7 @@ class BinaryView:
 			self._cb.isRelocatable = self._cb.isRelocatable.__class__(self._is_relocatable)
 			self._cb.getAddressSize = self._cb.getAddressSize.__class__(self._get_address_size)
 			self._cb.save = self._cb.save.__class__(self._save)
+			self._cb.onAfterSnapshotDataApplied = self._cb.onAfterSnapshotDataApplied.__class__(self._on_after_snapshot_data_applied)
 			if file_metadata is None:
 				raise Exception("Attempting to create a BinaryView with FileMetadata which is None")
 			self._file = file_metadata
@@ -4481,6 +4482,15 @@ class BinaryView:
 		except:
 			log_error_for_exception("Unhandled Python exception in BinaryView._save")
 			return False
+
+	def _on_after_snapshot_data_applied(self, ctxt):
+		try:
+			self.perform_on_after_snapshot_data_applied()
+		except:
+			log_error_for_exception("Unhandled Python exception in BinaryView._on_after_snapshot_data_applied")
+
+	def perform_on_after_snapshot_data_applied(self) -> None:
+		pass
 
 	def init(self) -> bool:
 		return True

--- a/rust/src/custom_binary_view.rs
+++ b/rust/src/custom_binary_view.rs
@@ -460,6 +460,7 @@ pub unsafe trait CustomBinaryView: 'static + BinaryViewBase + Sync + Sized {
 
     fn new(handle: &BinaryView, args: &Self::Args) -> Result<Self>;
     fn init(&mut self, args: Self::Args) -> Result<()>;
+    fn on_after_snapshot_data_applied(&mut self) {}
 }
 
 /// Represents a partially initialized custom `BinaryView` that should be returned to the core
@@ -596,6 +597,18 @@ impl<'a, T: CustomBinaryViewType> CustomViewBuilder<'a, T> {
                         tracing::error!("CustomBinaryView::new failed; custom view returned Err");
                         false
                     }
+                }
+            })
+        }
+
+        extern "C" fn cb_on_after_snapshot_data_applied<V>(ctxt: *mut c_void)
+        where
+            V: CustomBinaryView,
+        {
+            ffi_wrap!("BinaryViewBase::onAfterSnapshotDataApplied", unsafe {
+                let context = &mut *(ctxt as *mut CustomViewContext<V>);
+                if let CustomViewContextState::Initialized { view } = &mut context.state {
+                    view.on_after_snapshot_data_applied();
                 }
             })
         }
@@ -890,6 +903,7 @@ impl<'a, T: CustomBinaryViewType> CustomViewBuilder<'a, T> {
             isRelocatable: Some(cb_relocatable::<V>),
             getAddressSize: Some(cb_address_size::<V>),
             save: Some(cb_save::<V>),
+            onAfterSnapshotDataApplied: Some(cb_on_after_snapshot_data_applied::<V>),
         };
 
         let view_name = view_name.to_cstr();


### PR DESCRIPTION
Snapshot data is applied when loading from a database, rebasing the view, etc.