### PR TITLE
[DSC] Process Objective-C metadata when loading view from .bndb

### DIFF
--- a/view/sharedcache/core/SharedCacheController.cpp
+++ b/view/sharedcache/core/SharedCacheController.cpp
@@ -292,3 +292,27 @@ void SharedCacheController::LoadMetadata(const Metadata& metadata)
 			m_loadedImages.insert(region);
 	}
 }
+
+
+void SharedCacheController::ProcessObjCForLoadedImages(BinaryView& view)
+{
+	if (!m_processObjC || m_loadedImages.empty())
+		return;
+
+	for (const auto& headerAddress : m_loadedImages)
+	{
+		auto image = m_cache.GetImageAt(headerAddress);
+		if (!image)
+			continue;
+
+		auto objcProcessor = DSCObjC::SharedCacheObjCProcessor(&view, image->headerAddress);
+		try
+		{
+			objcProcessor.ProcessObjCData();
+		}
+		catch (std::exception& e)
+		{
+			m_logger->LogErrorForExceptionF(e, "Failed to restore ObjC metadata for image at {:#x}: {}", headerAddress, e.what());
+		}
+	}
+}

--- a/view/sharedcache/core/SharedCacheController.h
+++ b/view/sharedcache/core/SharedCacheController.h
@@ -63,5 +63,8 @@ namespace BinaryNinja::DSC {
 		Ref<Metadata> GetMetadata() const;
 
 		void LoadMetadata(const Metadata& metadata);
+
+		// Re-run the ObjC processor for loaded images to restore Objective-C metadata.
+		void ProcessObjCForLoadedImages(BinaryView& view);
 	};
 }  // namespace BinaryNinja::DSC

--- a/view/sharedcache/core/SharedCacheView.cpp
+++ b/view/sharedcache/core/SharedCacheView.cpp
@@ -981,6 +981,14 @@ bool SharedCacheView::InitController()
 	return true;
 }
 
+
+void SharedCacheView::OnAfterSnapshotDataApplied()
+{
+	if (auto controller = SharedCacheController::FromView(*this))
+		controller->ProcessObjCForLoadedImages(*this);
+}
+
+
 void SharedCacheView::SetPrimaryFileName(std::string primaryFileName)
 {
 	m_primaryFileName = std::move(primaryFileName);

--- a/view/sharedcache/core/SharedCacheView.h
+++ b/view/sharedcache/core/SharedCacheView.h
@@ -25,6 +25,7 @@ public:
 	~SharedCacheView() override = default;
 
 	bool Init() override;
+	void OnAfterSnapshotDataApplied() override;
 
 	// Initialized the shared cache controller for this view. This is what allows us to load images and regions.
 	bool InitController();


### PR DESCRIPTION
The processed Objective-C metadata is not saved to the .bdnb. It must be recomputed when the view is loaded.

Fixes https://github.com/Vector35/binaryninja-api/issues/8030.