### PR TITLE
Fix stack adjustment for x86 pop r16

### DIFF
--- a/arch/x86/il.cpp
+++ b/arch/x86/il.cpp
@@ -3141,6 +3141,15 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 		break;
 
 	case XED_ICLASS_POP:
+	{
+		const unsigned int stackAdjustment = xed_decoded_inst_get_memory_operand_length(xedd, 0);
+		auto expr = il.Pop(stackAdjustment);
+		il.AddInstruction(WriteILOperand(il, xedd, addr, 0, 0,
+			opOneLen == stackAdjustment ? expr :
+				il.LowPart(opOneLen, expr)));
+		break;
+	}
+
 	case XED_ICLASS_POPP:
 		il.AddInstruction(
 			WriteILOperand(il, xedd, addr, 0, 0,
@@ -3287,17 +3296,10 @@ bool GetLowLevelILForInstruction(Architecture* arch, const uint64_t addr, LowLev
 		// https://stackoverflow.com/questions/43435764/64-bit-mode-does-not-support-32-bit-push-and-pop-instructions
 		// for more details
 		const unsigned int stackAdjustment = xed_decoded_inst_get_memory_operand_length(xedd, 0);
-		if (opOneLen != stackAdjustment)
-		{
-			il.AddInstruction(
-				il.Push(stackAdjustment,
-					il.ZeroExtend(stackAdjustment,
-						ReadILOperand(il, xedd, addr, 0, 0))));
-		}
-		else
-			il.AddInstruction(
-				il.Push(stackAdjustment,
-					ReadILOperand(il, xedd, addr, 0, 0)));
+		auto expr = ReadILOperand(il, xedd, addr, 0, 0);
+		il.AddInstruction(il.Push(stackAdjustment,
+			opOneLen == stackAdjustment ? expr :
+				il.ZeroExtend(stackAdjustment, expr)));
 		break;
 	}
 


### PR DESCRIPTION
Related to https://github.com/Vector35/binaryninja-api/issues/4028

`pop r16` is lifted incorrectly and adjusts the stack by the wrong size:
<img width="582" height="94" alt="image" src="https://github.com/user-attachments/assets/3cc18357-d226-407d-90e2-fe5a349f7b52" />

This PR changes the lifting to always pop the memory operand size and insert a `LLIL_LOW_PART` if the destination register size is different:

<img width="582" height="94" alt="image" src="https://github.com/user-attachments/assets/b6b73529-8ace-4ceb-a39f-93dd5ae2b313" />
