### PR TITLE
[Rust] add the process step for the creation of a custom binary view

### DIFF
--- a/rust/src/custom_binary_view.rs
+++ b/rust/src/custom_binary_view.rs
@@ -460,6 +460,7 @@ pub unsafe trait CustomBinaryView: 'static + BinaryViewBase + Sync + Sized {
 
     fn new(handle: &BinaryView, args: &Self::Args) -> Result<Self>;
     fn init(&mut self, args: Self::Args) -> Result<()>;
+    fn process(&self) -> Result<()>;
     fn on_after_snapshot_data_applied(&mut self) {}
 }
 
@@ -584,7 +585,7 @@ impl<'a, T: CustomBinaryViewType> CustomViewBuilder<'a, T> {
                         Ok(_) => {
                             // put the initialized state
                             context.state = CustomViewContextState::Initialized { view };
-                            true
+                            context.assume_init_ref().process().is_ok()
                         }
                         Err(_) => {
                             tracing::error!(


### PR DESCRIPTION
This allows custom implementations of CustomBinaryView to call `self.*` function related to `BinaryView`. 

Currently calling something like `add_segment` inside the `init` function will cause a panic because the `context.state` had being initialized with `CustomViewContextState::Initialized` yet, eg minidump does it:
https://github.com/Vector35/binaryninja-api/blob/e1efc289bfccf86afa8a4bda02ded1674ba018d0/view/minidump/src/view.rs#L261-L265) 