### PR TITLE
Fixes crash with native architecture hooks

### DIFF
--- a/architecture.cpp
+++ b/architecture.cpp
@@ -483,7 +483,7 @@ FunctionLifterContext::FunctionLifterContext(LowLevelILFunction* func, BNFunctio
 	m_blocks.reserve(context->basicBlockCount);
 	for (size_t i = 0; i < context->basicBlockCount; i++)
 	{
-		m_blocks.emplace_back(new BasicBlock(context->basicBlocks[i]));
+		m_blocks.emplace_back(new BasicBlock(BNNewBasicBlockReference(context->basicBlocks[i])));
 	}
 
 	for (size_t i = 0; i < context->noReturnCallsCount; i++)

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -37,14 +37,14 @@
 // Current ABI version for linking to the core. This is incremented any time
 // there are changes to the API that affect linking, including new functions,
 // new types, or modifications to existing functions or types.
-#define BN_CURRENT_CORE_ABI_VERSION 163
+#define BN_CURRENT_CORE_ABI_VERSION 164
 
 // Minimum ABI version that is supported for loading of plugins. Plugins that
 // are linked to an ABI version less than this will not be able to load and
 // will require rebuilding. The minimum version is increased when there are
 // incompatible changes that break binary compatibility, such as changes to
 // existing types or functions.
-#define BN_MINIMUM_CORE_ABI_VERSION 163
+#define BN_MINIMUM_CORE_ABI_VERSION 164
 
 #ifdef __GNUC__
 	#ifdef BINARYNINJACORE_LIBRARY

--- a/python/architecture.py
+++ b/python/architecture.py
@@ -3057,6 +3057,9 @@ class CoreArchitecture(Architecture):
 			elif isinstance(operand, lowlevelil.ILRegister):
 				operand_list[i].constant = False
 				operand_list[i].reg = operand.index
+			elif isinstance(operand, lowlevelil.ILFlag):
+				operand_list[i].constant = False
+				operand_list[i].reg = operand.index
 			else:
 				operand_list[i].constant = True
 				operand_list[i].value = operand


### PR DESCRIPTION
Broke into two separate commits
* Fix for https://github.com/Vector35/binaryninja-api/issues/7974
* Fix for spammed Python exception when a Python architecture hook is used