### PR TITLE
[RTTI] Fix Itanium RTTI scan failing to symbolize objects with extern typeinfo

### DIFF
--- a/plugins/rtti/itanium.cpp
+++ b/plugins/rtti/itanium.cpp
@@ -446,9 +446,11 @@ std::optional<ClassInfo> ItaniumRTTIProcessor::ProcessRTTI(uint64_t objectAddr)
             return std::nullopt;
         auto symName = sym->GetShortName();
         // Remove type info prefix.
-        if (symName.rfind("_typeinfo_for_", 0) != 0)
-            return std::nullopt;
-        return symName.substr(14);
+        if (symName.rfind("_typeinfo_for_", 0) == 0)
+            return symName.substr(14);
+        if (symName.rfind("typeinfo_for_", 0) == 0)
+            return symName.substr(13);
+        return std::nullopt;
     };
 
     if (typeInfoVariant == TIVSIClass)


### PR DESCRIPTION
The issue stems from the gnu3 demangler changing in https://github.com/Vector35/binaryninja-api/commit/260ca61d94134b6743807e29f64b5ce4f6918d73

Fixes https://github.com/Vector35/binaryninja-api/issues/8080