### PR TITLE
[Python] Fix handling of zero-width types returned by a custom Demangler

### DIFF
--- a/python/demangle.py
+++ b/python/demangle.py
@@ -408,7 +408,7 @@ class Demangler(metaclass=_DemanglerMetaclass):
 				var_name = types.QualifiedName(var_name)
 
 			Demangler._cached_name = var_name._to_core_struct()
-			if type:
+			if type is not None:
 				out_type[0] = core.BNNewTypeReference(type.handle)
 			else:
 				out_type[0] = None


### PR DESCRIPTION
Explicitly test the type against `None` rather than testing for truthiness. This ensures that zero-width types returned by a custom demangler will be applied.

Fixes #8099.

---

For some reason `Type` implements `__len__` and returns `self.width`. This causes zero-width types, such as function types, to be considered False. This is somewhere on the spectrum of unnecessarily confusing and just plain wrong.
