### PR TITLE
Make snippets submodule load over HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/intelxed/mbuild.git
 [submodule "plugins/snippets"]
 	path = plugins/snippets
-	url = git@github.com:Vector35/snippets.git
+	url = https://github.com/Vector35/snippets.git


### PR DESCRIPTION
Loading over SSH breaks GitHub Actions, which does not have an SSH key configured