### PR TITLE
Fix aarch64 disassembler Makefiles

### DIFF
--- a/arch/arm64/disassembler/Makefile-asan
+++ b/arch/arm64/disassembler/Makefile-asan
@@ -2,7 +2,7 @@ DECODE_OBJS = pcode.o decode.o decode0.o decode1.o decode2.o decode_fields32.o d
 
 FORMAT_OBJS = format.o encodings_fmt.o operations.o sysregs_gen.o sysregs_fmt_gen.o regs.o
 
-HEADERS = decode.h decode1.h decode2.h format.h pcode.h operations.h sysregs.h decode_fields32.h encodings_dec.h encodings_fmt.h regs.h
+HEADERS = decode.h decode1.h decode2.h format.h pcode.h operations.h sysregs_gen.h sysregs_fmt_gen.h decode_fields32.h encodings_dec.h encodings_fmt.h regs.h
 
 CFLAGS = -O2 -fsanitize=address -ggdb
 

--- a/arch/arm64/disassembler/Makefile-local
+++ b/arch/arm64/disassembler/Makefile-local
@@ -4,7 +4,7 @@ DECODE_OBJS = pcode.o decode.o decode0.o decode1.o decode2.o decode_fields32.o d
 
 FORMAT_OBJS = format.o encodings_fmt.o operations.o sysregs_gen.o sysregs_fmt_gen.o regs.o
 
-HEADERS = decode.h decode1.h decode2.h format.h pcode.h operations.h sysregs.h decode_fields32.h encodings_dec.h encodings_fmt.h regs.h
+HEADERS = decode.h decode1.h decode2.h format.h pcode.h operations.h sysregs_gen.h sysregs_fmt_gen.h decode_fields32.h encodings_dec.h encodings_fmt.h regs.h
 
 #CFLAGS = -g -Wunused
 CFLAGS = -Os


### PR DESCRIPTION
Both Makefile have the HEADERS variable with wrong filename for the updated sysregs* files from last commit on this file.

Make was skipping the configured target and using the default because of this.