### PR TITLE
[Arm64, Apple] Added X1 as a second syscall retval register

### DIFF
--- a/arch/arm64/arch_arm64.cpp
+++ b/arch/arm64/arch_arm64.cpp
@@ -2749,7 +2749,7 @@ class AppleArm64SystemCallConvention : public CallingConvention
 	}
 
 
-	virtual vector<uint32_t> GetCallerSavedRegisters() override { return vector<uint32_t> {REG_X0}; }
+	virtual vector<uint32_t> GetCallerSavedRegisters() override { return vector<uint32_t> {REG_X0, REG_X1}; }
 
 
 	virtual vector<uint32_t> GetCalleeSavedRegisters() override
@@ -2760,6 +2760,8 @@ class AppleArm64SystemCallConvention : public CallingConvention
 
 
 	virtual uint32_t GetIntegerReturnValueRegister() override { return REG_X0; }
+
+	virtual uint32_t GetHighIntegerReturnValueRegister() override { return REG_X1; }
 
 
 	virtual bool IsEligibleForHeuristics() override { return false; }


### PR DESCRIPTION
As on darwin there is actually two registers used as return values X0 and X1, along with both of them considered clobbered (as mostly all of the system calls on darwin scratch this registers even if only X0 is used as return value).