### PR TITLE
Re-add license text tab and field to API. 

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -19201,6 +19201,7 @@ namespace BinaryNinja {
 		std::string GetPluginDirectory() const;
 		std::string GetAuthor() const;
 		std::string GetDescription() const;
+		std::string GetLicenseText() const;
 		std::string GetName() const;
 		std::vector<PluginType> GetPluginTypes() const;
 		std::string GetPackageUrl() const;

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -7970,6 +7970,7 @@ extern "C"
 	BINARYNINJACOREAPI char** BNPluginGetApis(BNPlugin* p, size_t* count);
 	BINARYNINJACOREAPI const char* BNPluginGetAuthor(BNPlugin* p);
 	BINARYNINJACOREAPI const char* BNPluginGetDescription(BNPlugin* p);
+	BINARYNINJACOREAPI const char* BNPluginGetLicenseText(BNPlugin* p);
 	BINARYNINJACOREAPI BNVersionInfo BNPluginGetMinimumVersionInfo(BNPlugin* p);
 	BINARYNINJACOREAPI BNVersionInfo BNPluginGetMaximumVersionInfo(BNPlugin* p);
 	BINARYNINJACOREAPI BNVersionInfo BNParseVersionString(const char* v);

--- a/pluginmanager.cpp
+++ b/pluginmanager.cpp
@@ -70,6 +70,11 @@ string Extension::GetDescription() const
 	RETURN_STRING(BNPluginGetDescription(m_object));
 }
 
+string Extension::GetLicenseText() const
+{
+	RETURN_STRING(BNPluginGetLicenseText(m_object));
+}
+
 static VersionInfo ConvertVersionInfo(const BNVersionInfo& coreInfo)
 {
 	VersionInfo result;

--- a/python/pluginmanager.py
+++ b/python/pluginmanager.py
@@ -154,7 +154,7 @@ class Extension:
 	@deprecation.deprecated(deprecated_in="5.3", details='This field will be removed.')
 	def license_text(self) -> Optional[str]:
 		"""String complete license text for the given plugin"""
-		return ''
+		return core.BNPluginGetLicenseText(self.handle)
 
 	@property
 	def long_description(self) -> Optional[str]:

--- a/rust/src/repository/plugin.rs
+++ b/rust/src/repository/plugin.rs
@@ -103,6 +103,13 @@ impl Extension {
         unsafe { BnString::into_string(result as *mut c_char) }
     }
 
+    /// String complete license text for the given plugin
+    pub fn license_text(&self) -> String {
+        let result = unsafe { BNPluginGetLicenseText(self.handle.as_ptr()) };
+        assert!(!result.is_null());
+        unsafe { BnString::into_string(result as *mut c_char) }
+    }
+
     /// Minimum version info the plugin was tested on
     pub fn minimum_version_info(&self) -> VersionInfo {
         let result = unsafe { BNPluginGetMinimumVersionInfo(self.handle.as_ptr()) };

--- a/rust/tests/repository.rs
+++ b/rust/tests/repository.rs
@@ -20,6 +20,7 @@ fn test_list() {
     for plugin in &plugins {
         let plugin_path = plugin.path();
         let plugin_by_path = repository.plugin_by_path(&plugin_path).unwrap();
+        let _license_text = plugin.license_text();
         assert_eq!(plugin.package_url(), plugin_by_path.package_url());
     }
 }


### PR DESCRIPTION
Re-adds the license text field to API as it was on previous stable. 

Re-adds (from development) the license tab to the extension viewer and populates it with the license text. 
<img width="908" height="402" alt="Screenshot 2026-04-25 at 3 22 34 PM" src="https://github.com/user-attachments/assets/d21fb588-e837-4922-a4ff-321b951931ea" />

This can be tested by turning on the staging servers `pluginManager.debug`, checking for updates, and opening the plugin manager once that is completed. 