### PR TITLE
[Rust] Fix off-by-one accesses to operand lists within MediumLevelILInstruction::lift

### DIFF
--- a/rust/src/medium_level_il/instruction.rs
+++ b/rust/src/medium_level_il/instruction.rs
@@ -851,7 +851,7 @@ impl MediumLevelILInstruction {
             MemPhi(op) => Lifted::MemPhi(LiftedMemPhi {
                 dest_memory: op.dest_memory,
                 // TODO: Make a stronger type for this.
-                src_memory: self.get_operand_list(0),
+                src_memory: self.get_operand_list(1),
             }),
             VarSplit(op) => Lifted::VarSplit(op),
             SetVarSplit(op) => Lifted::SetVarSplit(LiftedSetVarSplit {
@@ -977,7 +977,7 @@ impl MediumLevelILInstruction {
                 )
                 .expect("Valid intrinsic"),
                 params: self
-                    .get_expr_list(3)
+                    .get_expr_list(2)
                     .iter()
                     .map(|expr| expr.lift())
                     .collect(),


### PR DESCRIPTION
This could result in a crash or incorrect data being read.

Fixes https://github.com/Vector35/binaryninja-api/issues/8155.

---

The crash report in #8155 was due to the `MemPhi` case. I found the `MemoryIntrinsicSsa` case while reviewing the other instructions that have operand lists.