### PR TITLE
Increment SESSION_COUNT when cloning a Session

### DIFF
--- a/rust/src/headless.rs
+++ b/rust/src/headless.rs
@@ -295,7 +295,7 @@ pub fn license_location() -> Option<LicenseLocation> {
 }
 
 /// Wrapper for [`init`] and [`shutdown`]. Instantiating this at the top of your script will initialize everything correctly and then clean itself up at exit as well.
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, PartialEq, Eq, Hash)]
 pub struct Session {
     license_duration: Option<Duration>,
 }
@@ -419,6 +419,15 @@ impl Session {
             options,
             progress,
         )
+    }
+}
+
+impl Clone for Session {
+    fn clone(&self) -> Self {
+        SESSION_COUNT.fetch_add(1, SeqCst);
+        Self {
+            license_duration: self.license_duration,
+        }
     }
 }
 


### PR DESCRIPTION
I believe this would fix #8166. It's pretty tricky to figure out what's going on, but the user gave me a minimal test case that looks something like:

```rust
let session = Session::new().expect("failed to initialize headless session");
{
    let session = session.clone();
    // ...
    let result = tokio::task::spawn_blocking(move || {
        let bv = session.load_with_progress(&input, |_, _| true)
```

I think what's happening is that the `session.clone()` is making a new `Session` while bypassing the registration so `SESSION_COUNT` is never actually incremented. Then, later, when another `Session` has `Drop` called on it, we call `shutdown()` prematurely and that ruins everything else.

It's not clear to me if this solution is the right way to go, or if we should instead just remove `Clone` from `Session` altogether, or if there's a third option that would be better. But, I believe this would at least fix the issue at hand.