### PR TITLE
[ObjC] Name __objc_ivar offset globals

### DIFF
--- a/objectivec/objc.cpp
+++ b/objectivec/objc.cpp
@@ -1104,6 +1104,16 @@ void ObjCProcessor::ReadIvarList(ObjCReader* reader, ClassBase& cls, std::string
 			DefineObjCSymbol(DataSymbol, Type::ArrayType(Type::IntegerType(1, true), ivar.type.size() + 1),
 				"ivarType_" + ivar.name, ivarStruct.type, true);
 
+			if (ivarStruct.offset)
+			{
+				size_t ivarOffsetSize =
+					m_data->GetDefaultArchitecture()->GetName() == "aarch64" ? 4 : addressSize;
+				TypeBuilder ivarOffsetTypeBuilder(Type::IntegerType(ivarOffsetSize, false));
+				ivarOffsetTypeBuilder.SetConst(true);
+				DefineObjCSymbol(DataSymbol, ivarOffsetTypeBuilder.Finalize(),
+					"ivarOffset_" + std::string(name) + "_" + ivar.name, ivarStruct.offset, true);
+			}
+
 			cls.ivarList[cursor] = ivar;
 		}
 		catch (...)


### PR DESCRIPTION
Define an Objective-C symbol for each entry in __objc_ivar in the form `ivarOffset_<class>_<ivar>`. An entry is read on every ivar access, so the symbolication improves the readability of the disassembly and ILs.