### PR TITLE
[FFI] Make binaryninjacore.h parseable with default xcode clang

### DIFF
--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -100,8 +100,10 @@
 // BN_ENUM macro for defining enums with explicit size in a C-compatible way
 // In C++, use an explicitly sized enum directly.
 // In C, add a typedef to the underlying type and use an unnamed enum to define the values.
-#if defined(__cplusplus) || __has_extension(c_fixed_enum)
+#if defined(__cplusplus)
 	#define BN_ENUM(type, name) enum __BN_ENUM_ATTRIBUTES name : type
+#elif __has_extension(c_fixed_enum)
+  #define BN_ENUM(type, name) typedef type name; enum __BN_ENUM_ATTRIBUTES name : type
 #else
 	#define BN_ENUM(type, name) typedef type name; enum __BN_ENUM_ATTRIBUTES
 #endif
@@ -109,8 +111,10 @@
 // BN_OPTIONS macro for defining flag enums with explicit size in a C-compatible way
 // In C++, use an explicitly sized enum directly.
 // In C, add a typedef to the underlying type and use an unnamed enum to define the values.
-#if defined(__cplusplus) || __has_extension(c_fixed_enum)
+#if defined(__cplusplus)
 	#define BN_OPTIONS(type, name) enum __BN_OPTIONS_ATTRIBUTES name : type
+#elif __has_extension(c_fixed_enum)
+  #define BN_OPTIONS(type, name) typedef type name; enum __BN_OPTIONS_ATTRIBUTES name : type
 #else
 	#define BN_OPTIONS(type, name) typedef type name; enum __BN_OPTIONS_ATTRIBUTES
 #endif


### PR DESCRIPTION
This pull request makes binaryninjacore.h parseable with default MacOS clang compiler.

binaryninjacore.h does not parse with default arguments under clang packaged from Xcode with the following versions:

Xcode 26.4.1, Build version 17E202
Apple clang version 21.0.0 (clang-2100.0.123.102).

```
bloombit@Mac binaryninja-api % clang -fsyntax-only binaryninjacore.h
binaryninjacore.h:827:3: error: must use 'enum' tag to refer to type 'BNFunctionGraphType'
  827 |                 BNFunctionGraphType type;
      |                 ^
      |                 enum
binaryninjacore.h:1188:3: error: must use 'enum' tag to refer to type 'BNInlineDuringAnalysis'
 1188 |                 BNInlineDuringAnalysis value;
      |                 ^
      |                 enum
...
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
```