### PR TITLE
[codex] Guard disposed BinaryView handles

### DIFF
--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -3197,7 +3197,7 @@ class BinaryView:
 			_handle = core.BNCreateCustomBinaryView(self.__class__.name, file_metadata.handle, _parent_view, self._cb)
 
 		assert _handle is not None
-		self.handle = _handle
+		self._handle = _handle
 		self._notifications = {}
 		self._parse_only = False
 		self._preload_limit = 5
@@ -3210,9 +3210,9 @@ class BinaryView:
 		for i in self._notifications.values():
 			i._unregister()
 		self._notifications.clear()
-		if self.handle is not None:
-			core.BNFreeBinaryView(self.handle)
-			self.handle = None
+		if self._handle is not None:
+			core.BNFreeBinaryView(self._handle)
+			self._handle = None
 
 	def __enter__(self) -> 'BinaryView':
 		return self
@@ -3225,6 +3225,8 @@ class BinaryView:
 		self._cleanup()
 
 	def __repr__(self):
+		if self._handle is None:
+			return "<BinaryView: disposed>"
 		start = self.start
 		length = self.length
 		if start != 0:
@@ -3239,6 +3241,12 @@ class BinaryView:
 	@property
 	def length(self):
 		return int(core.BNGetViewLength(self.handle))
+
+	@property
+	def handle(self):
+		if self._handle is None:
+			raise ReferenceError("BinaryView has been disposed")
+		return self._handle
 
 	def __bool__(self):
 		return True


### PR DESCRIPTION
## Summary

Fixes Vector35/binaryninja-api#8161 by keeping the raw BinaryView handle private and routing public access through a guard that raises `ReferenceError` after disposal. `repr()` now reports disposed views explicitly instead of attempting to query freed state.

## Behavior

```python
>>> with load("/bin/ls") as b:
...  print(b)
... 
... 
<BinaryView: '/bin/ls', start 0x100000000, len 0xe310>
>>> b
<BinaryView: disposed>
>>> b.start
Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/Users/peterl/src/binaryninja/cmake-build-relwithdebinfo/out/binaryninja.app/Contents/MacOS/plugins/../../Resources/python/binaryninja/binaryview.py", line 3730, in start
    return core.BNGetStartOffset(self.handle)
  File "/Users/peterl/src/binaryninja/cmake-build-relwithdebinfo/out/binaryninja.app/Contents/MacOS/plugins/../../Resources/python/binaryninja/binaryview.py", line 3248, in handle
    raise ReferenceError("BinaryView has been disposed")
ReferenceError: BinaryView has been disposed
```

## Validation

- `git diff --check -- python/binaryview.py`