### PR TITLE
Fix use-after-free of enum type id in Function::set_int_display_type

### DIFF
--- a/rust/src/function.rs
+++ b/rust/src/function.rs
@@ -1945,7 +1945,11 @@ impl Function {
     ) {
         let arch = arch.unwrap_or_else(|| self.arch());
         let enum_display_typeid = enum_display_typeid.map(IntoCStr::to_cstr);
+        // Borrow the owned C string rather than moving it into `map`, otherwise it is dropped
+        // before the FFI call below and `BNSetIntegerConstantDisplayType` reads freed memory,
+        // storing a garbage type id for the enumeration.
         let enum_display_typeid_ptr = enum_display_typeid
+            .as_ref()
             .map(|x| x.as_ptr())
             .unwrap_or(std::ptr::null());
         unsafe {


### PR DESCRIPTION
## Summary

`Function::set_int_display_type` converts the optional enumeration type id to an owned `CString`, then moves it into a `map` closure to take its pointer:

```rust
let enum_display_typeid = enum_display_typeid.map(IntoCStr::to_cstr);
let enum_display_typeid_ptr = enum_display_typeid
    .map(|x| x.as_ptr())            // moves the CString in, takes a pointer, then drops it
    .unwrap_or(std::ptr::null());
unsafe { BNSetIntegerConstantDisplayType(..., enum_display_typeid_ptr) }
```

The owned `CString` is dropped at the end of that closure, **before** the FFI call uses its pointer, so `BNSetIntegerConstantDisplayType` reads freed memory and stores a garbage type id.

## Impact

Setting an integer operand to `EnumerationDisplayType` with a type id never resolves to the intended enumeration — the operand renders as a raw constant instead of the enumeration member. Confirmed by reading back the stored type id (garbage bytes) and by the operand failing to render the enum until this fix, after which it renders correctly.

## Fix

Borrow the owned `CString` with `.as_ref()` so it lives until after the FFI call.