### PR TITLE
Ensure out-of-tree API builds succeed across all platforms

### DIFF
--- a/scripts/test_build_external.py
+++ b/scripts/test_build_external.py
@@ -22,6 +22,8 @@ parser.add_argument('--qmake', default=os.environ.get('QMAKE'), help='Path to qm
 parser.add_argument('--cmake', default=os.environ.get('CMAKE'), help='Path to cmake. Defaults to CMAKE or PATH lookup.')
 parser.add_argument('--cc', default=os.environ.get('CC'), help='C compiler to use. Defaults to CC or CMake platform default.')
 parser.add_argument('--cxx', default=os.environ.get('CXX'), help='C++ compiler to use. Defaults to CXX or CMake platform default.')
+parser.add_argument('--config', default=os.environ.get('CMAKE_BUILD_CONFIG', 'Release'),
+                    help='CMake build configuration to use. Defaults to CMAKE_BUILD_CONFIG or Release.')
 parser.add_argument('--extra-project', action='append', default=[],
                     help='Additional out-of-tree CMake project directory to build. May be specified multiple times.')
 args = parser.parse_args()
@@ -170,9 +172,10 @@ print_tool('cmake', cmake, ['--version'], env=configure_env)
 
 print(f'C compiler: {configure_env.get("CC", "CMake platform default")}')
 print(f'C++ compiler: {configure_env.get("CXX", "CMake platform default")}')
+print(f'CMake build config: {args.config}')
 
-configure_args = []
-build_args = []
+configure_args = [f'-DCMAKE_BUILD_TYPE={args.config}']
+build_args = ['--config', args.config]
 
 if platform.system() == "Windows":
 	configure_env['CXXFLAGS'] = f'/MP{args.parallel}'

--- a/scripts/test_build_internal.py
+++ b/scripts/test_build_internal.py
@@ -20,6 +20,8 @@ parser.add_argument('--qmake', default=os.environ.get('QMAKE'), help='Path to qm
 parser.add_argument('--cmake', default=os.environ.get('CMAKE'), help='Path to cmake. Defaults to CMAKE or PATH lookup.')
 parser.add_argument('--cc', default=os.environ.get('CC'), help='C compiler to use. Defaults to CC or CMake platform default.')
 parser.add_argument('--cxx', default=os.environ.get('CXX'), help='C++ compiler to use. Defaults to CXX or CMake platform default.')
+parser.add_argument('--config', default=os.environ.get('CMAKE_BUILD_CONFIG', 'Release'),
+                    help='CMake build configuration to use. Defaults to CMAKE_BUILD_CONFIG or Release.')
 args = parser.parse_args()
 
 api_base = Path(__file__).parent.parent.absolute()
@@ -113,9 +115,10 @@ print_tool('cmake', cmake, ['--version'], env=env)
 
 print(f'C compiler: {env.get("CC", "CMake platform default")}')
 print(f'C++ compiler: {env.get("CXX", "CMake platform default")}')
+print(f'CMake build config: {args.config}')
 
-configure_args = ['-DBN_API_BUILD_EXAMPLES=1']
-build_args = []
+configure_args = ['-DBN_API_BUILD_EXAMPLES=1', f'-DCMAKE_BUILD_TYPE={args.config}']
+build_args = ['--config', args.config]
 
 if platform.system() == 'Windows':
 	env['CXXFLAGS'] = f'/MP{args.parallel}'


### PR DESCRIPTION
A user last week complained that we had broken the ability to build the API and some examples with a change we made. It wasn't broken for _us_, since we build in-tree, but customers don't have the rest of our source code.

As it turns out, @CouleeApps wrote a nice little script that lets us test this out-of-tree build process in February 2022 so we wouldn't have this problem. Unfortunately, it appears to have been taken out of our build process pretty quickly because it added a lot of overall time to builds.

I've gone ahead and set up a new nightly process for ensuring we are made aware when we break builds for customers. To do this, I've split the original script @CouleeApps wrote into two–one for us to test in-tree builds with, and one to test out-of-tree builds with. (They were previously both in the same script, so the former would fail with my setup that approximates a customer's environment.)

In the process of doing this, I discovered that the Triage example would no longer build on Windows and the API itself would not build with clang 14 on Ubuntu 22.04. This PR fixes those issues in the quickest and most straight-forward way I could figure out how.

I have separately run a full build with these API changes through CI as well, which has succeeded. Just want someone else to look these over and ensure they look reasonable before I merge them.