### PR TITLE
[Rust] Allow configuring API path for cargo builds

### DIFF
--- a/rust/binaryninjacore-sys/build.rs
+++ b/rust/binaryninjacore-sys/build.rs
@@ -41,16 +41,22 @@ fn link_path() -> PathBuf {
         })
 }
 
+fn api_base_path() -> PathBuf {
+    env::var_os("BINARYNINJA_API_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let manifest_dir =
+                std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+            std::path::PathBuf::from(manifest_dir)
+                .join("../../")
+                .canonicalize()
+                .unwrap()
+        })
+}
+
 // Generate and compile stub shared library and return the path to the folder containing the built stub library
 fn generate_stubs() -> PathBuf {
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
-
-    let api_base_path = std::path::PathBuf::from(manifest_dir)
-        .join("../../")
-        .canonicalize()
-        .unwrap();
-
-    let stubs_path = api_base_path.join("stubs");
+    let stubs_path = api_base_path().join("stubs");
 
     // TODO: does visual studio add the config name as a subdirectory?
     cmake::Config::new(stubs_path)
@@ -61,7 +67,13 @@ fn generate_stubs() -> PathBuf {
 
 fn main() {
     println!("cargo:rerun-if-env-changed=BINARYNINJADIR");
-    println!("cargo:rerun-if-changed=../../binaryninjacore.h");
+    println!("cargo:rerun-if-env-changed=BINARYNINJA_API_DIR");
+
+    let api_base_path = api_base_path();
+    println!(
+        "cargo:rerun-if-changed={}",
+        api_base_path.join("binaryninjacore.h").display()
+    );
 
     //Cargo's output directory
     let out_dir = env::var("OUT_DIR").unwrap();
@@ -97,7 +109,7 @@ fn main() {
     let minimum_line = "#define BN_MINIMUM_UI_ABI_VERSION ";
     let mut current_version = "0".to_string();
     let mut minimum_version = "0".to_string();
-    let file = File::open("../../ui/uitypes.h").expect("Couldn't open uitypes.h");
+    let file = File::open(api_base_path.join("ui/uitypes.h")).expect("Couldn't open uitypes.h");
     for line in BufReader::new(file).lines() {
         let line = line.unwrap();
         if let Some(version) = line.strip_prefix(current_line) {
@@ -108,7 +120,12 @@ fn main() {
     }
 
     bindgen::builder()
-        .header("../../binaryninjacore.h")
+        .header(
+            api_base_path
+                .join("binaryninjacore.h")
+                .to_string_lossy()
+                .into_owned(),
+        )
         .clang_arg("-std=c++20")
         .clang_arg("-x")
         .clang_arg("c++")


### PR DESCRIPTION
Allow configuring the Binary Ninja API directory via `BINARYNINJA_API_DIR`. Preserves existing behavior if it's unset.