### PR TITLE
[ELF] Improve performance of loading binaries with many sections not mapped into the address space

### DIFF
--- a/arch/msp430/src/lib.rs
+++ b/arch/msp430/src/lib.rs
@@ -30,14 +30,14 @@ pub extern "C" fn CorePluginInit() -> bool {
     // standardized one that is compatible with TI's compiler
     let default = calling_convention::ConventionBuilder::new(arch)
         .is_eligible_for_heuristics(true)
-        .int_arg_registers(&["r15", "r14", "r13", "r12"])
-        .return_int_reg("r15")
-        .return_hi_int_reg("r14")
+        .int_arg_registers(&["r12", "r13", "r14", "r15"])
+        .return_int_reg("r12")
+        .return_hi_int_reg("r13")
         .register("default");
     calling_convention::ConventionBuilder::new(arch)
         .is_eligible_for_heuristics(true)
-        .return_int_reg("r15")
-        .return_hi_int_reg("r14")
+        .return_int_reg("r12")
+        .return_hi_int_reg("r13")
         .register("stack");
 
     arch.set_default_calling_convention(&default);

--- a/view/elf/elfview.cpp
+++ b/view/elf/elfview.cpp
@@ -615,6 +615,7 @@ bool ElfView::Init()
 	Elf64SectionHeader symbolTableSection;
 
 	BeginBulkAddSegments();
+	GetParentView()->BeginBulkAddSegments();
 	uint64_t segmentStart = 0;
 	for (size_t i = 1; i < m_elfSections.size(); i++)
 	{
@@ -736,6 +737,7 @@ bool ElfView::Init()
 		}
 	}
 
+	GetParentView()->EndBulkAddSegments();
 	EndBulkAddSegments();
 	// Apply architecture and platform
 	if (!m_arch)


### PR DESCRIPTION
These sections are added to the parent view. Do the work within a bulk segment modification to significantly reduce the overhead of adding sections.