### PR TITLE
[BNTL] Add compiler flags processing to BNTL utils

### DIFF
--- a/plugins/bntl_utils/cli/src/create.rs
+++ b/plugins/bntl_utils/cli/src/create.rs
@@ -19,6 +19,9 @@ pub struct CreateArgs {
     pub include_directories: Vec<PathBuf>,
     #[clap(long)]
     pub dry_run: bool,
+
+    #[arg(last = true, allow_hyphen_values = true, num_args = 0..)]
+    compiler_flags: Vec<String>,
 }
 
 impl CreateArgs {
@@ -41,7 +44,8 @@ impl CreateArgs {
         std::fs::create_dir_all(&output_path).expect("Failed to create output directory");
 
         let processor = TypeLibProcessor::new(&self.name, &self.platform)
-            .with_include_directories(self.include_directories.clone());
+            .with_include_directories(self.include_directories.clone())
+            .with_options(self.compiler_flags.clone());
         // TODO: Need progress indicator here, when downloading files.
         let resolved_input = self.input.resolve().expect("Failed to resolve input");
 

--- a/plugins/bntl_utils/cli/src/create.rs
+++ b/plugins/bntl_utils/cli/src/create.rs
@@ -21,7 +21,7 @@ pub struct CreateArgs {
     pub dry_run: bool,
     /// A list of additional compiler options to pass to the compiler when parsing C header files.
     #[arg(last = true, allow_hyphen_values = true, num_args = 0..)]
-    compiler_options: Vec<String>,
+    pub compiler_options: Vec<String>,
 }
 
 impl CreateArgs {

--- a/plugins/bntl_utils/cli/src/create.rs
+++ b/plugins/bntl_utils/cli/src/create.rs
@@ -19,9 +19,9 @@ pub struct CreateArgs {
     pub include_directories: Vec<PathBuf>,
     #[clap(long)]
     pub dry_run: bool,
-
+    /// A list of additional compiler options to pass to the compiler when parsing C header files.
     #[arg(last = true, allow_hyphen_values = true, num_args = 0..)]
-    compiler_flags: Vec<String>,
+    compiler_options: Vec<String>,
 }
 
 impl CreateArgs {
@@ -45,7 +45,7 @@ impl CreateArgs {
 
         let processor = TypeLibProcessor::new(&self.name, &self.platform)
             .with_include_directories(self.include_directories.clone())
-            .with_options(self.compiler_flags.clone());
+            .with_compiler_options(self.compiler_options.clone());
         // TODO: Need progress indicator here, when downloading files.
         let resolved_input = self.input.resolve().expect("Failed to resolve input");
 

--- a/plugins/bntl_utils/src/command/create.rs
+++ b/plugins/bntl_utils/src/command/create.rs
@@ -124,6 +124,23 @@ impl PlatformField {
     }
 }
 
+pub struct FlagsField;
+
+impl FlagsField {
+    pub fn field() -> FormInputField {
+        FormInputField::MultilineText { 
+            prompt: "Compiler flags".to_string(), 
+            default: None, 
+            value: None, 
+        }
+    }
+
+    pub fn from_form(form: &Form) -> Option<String> {
+        let field = form.get_field_with_name("Compiler flags")?;
+        field.try_value_string()
+    }
+}
+
 pub struct CreateFromDirectory;
 
 impl CreateFromDirectory {
@@ -134,6 +151,8 @@ impl CreateFromDirectory {
         form.add_field(PlatformField::field());
         form.add_field(NameField::field());
         form.add_field(OutputDirectoryField::field());
+        form.add_field(FlagsField::field());
+        
         if !form.prompt() {
             return;
         }
@@ -141,13 +160,15 @@ impl CreateFromDirectory {
         let platform_name = PlatformField::from_form(&form).unwrap();
         let default_name = NameField::from_form(&form).unwrap();
         let output_dir = OutputDirectoryField::from_form(&form).unwrap();
+        let flags = FlagsField::from_form(&form).unwrap();
 
         let Some(default_platform) = Platform::by_name(&platform_name) else {
             tracing::error!("Invalid platform name: {}", platform_name);
             return;
         };
 
-        let processor = TypeLibProcessor::new(&default_name, &default_platform.name());
+        let processor = TypeLibProcessor::new(&default_name, &default_platform.name())
+            .with_options(split_args(flags.as_str()));
 
         let background_task = BackgroundTask::new("Processing started...", true);
         new_processing_state_background_thread(background_task.clone(), processor.state());
@@ -273,4 +294,23 @@ impl ProjectCommand for CreateFromProject {
     fn valid(&self, _project: &Project) -> bool {
         true
     }
+}
+
+fn split_args(input: &str) -> Vec<String> {
+    let mut args = Vec::new();
+    let mut cur = String::new();
+    let mut in_quote = false;
+    let mut has_token = false;
+
+    for c in input.chars() {
+        match c {
+            '"' => { in_quote = !in_quote; has_token = true; }
+            c if c.is_whitespace() && !in_quote => {
+                if has_token { args.push(std::mem::take(&mut cur)); has_token = false; }
+            }
+            c => { cur.push(c); has_token = true; }
+        }
+    }
+    if has_token { args.push(cur); }
+    args
 }

--- a/plugins/bntl_utils/src/command/create.rs
+++ b/plugins/bntl_utils/src/command/create.rs
@@ -124,19 +124,19 @@ impl PlatformField {
     }
 }
 
-pub struct FlagsField;
+pub struct CompilerOptionsField;
 
-impl FlagsField {
+impl CompilerOptionsField {
     pub fn field() -> FormInputField {
         FormInputField::MultilineText { 
-            prompt: "Compiler flags".to_string(), 
+            prompt: "Compiler options".to_string(), 
             default: None, 
             value: None, 
         }
     }
 
     pub fn from_form(form: &Form) -> Option<String> {
-        let field = form.get_field_with_name("Compiler flags")?;
+        let field = form.get_field_with_name("Compiler options")?;
         field.try_value_string()
     }
 }
@@ -151,7 +151,7 @@ impl CreateFromDirectory {
         form.add_field(PlatformField::field());
         form.add_field(NameField::field());
         form.add_field(OutputDirectoryField::field());
-        form.add_field(FlagsField::field());
+        form.add_field(CompilerOptionsField::field());
         
         if !form.prompt() {
             return;
@@ -160,7 +160,7 @@ impl CreateFromDirectory {
         let platform_name = PlatformField::from_form(&form).unwrap();
         let default_name = NameField::from_form(&form).unwrap();
         let output_dir = OutputDirectoryField::from_form(&form).unwrap();
-        let flags = FlagsField::from_form(&form).unwrap();
+        let flags = CompilerOptionsField::from_form(&form).unwrap();
 
         let Some(default_platform) = Platform::by_name(&platform_name) else {
             tracing::error!("Invalid platform name: {}", platform_name);
@@ -168,7 +168,7 @@ impl CreateFromDirectory {
         };
 
         let processor = TypeLibProcessor::new(&default_name, &default_platform.name())
-            .with_options(split_args(flags.as_str()));
+            .with_compiler_options(split_args(flags.as_str()));
 
         let background_task = BackgroundTask::new("Processing started...", true);
         new_processing_state_background_thread(background_task.clone(), processor.state());

--- a/plugins/bntl_utils/src/command/create.rs
+++ b/plugins/bntl_utils/src/command/create.rs
@@ -128,10 +128,10 @@ pub struct CompilerOptionsField;
 
 impl CompilerOptionsField {
     pub fn field() -> FormInputField {
-        FormInputField::MultilineText { 
-            prompt: "Compiler options".to_string(), 
-            default: None, 
-            value: None, 
+        FormInputField::MultilineText {
+            prompt: "Compiler options".to_string(),
+            default: None,
+            value: None,
         }
     }
 
@@ -152,7 +152,7 @@ impl CreateFromDirectory {
         form.add_field(NameField::field());
         form.add_field(OutputDirectoryField::field());
         form.add_field(CompilerOptionsField::field());
-        
+
         if !form.prompt() {
             return;
         }
@@ -304,13 +304,24 @@ fn split_args(input: &str) -> Vec<String> {
 
     for c in input.chars() {
         match c {
-            '"' => { in_quote = !in_quote; has_token = true; }
-            c if c.is_whitespace() && !in_quote => {
-                if has_token { args.push(std::mem::take(&mut cur)); has_token = false; }
+            '"' => {
+                in_quote = !in_quote;
+                has_token = true;
             }
-            c => { cur.push(c); has_token = true; }
+            c if c.is_whitespace() && !in_quote => {
+                if has_token {
+                    args.push(std::mem::take(&mut cur));
+                    has_token = false;
+                }
+            }
+            c => {
+                cur.push(c);
+                has_token = true;
+            }
         }
     }
-    if has_token { args.push(cur); }
+    if has_token {
+        args.push(cur);
+    }
     args
 }

--- a/plugins/bntl_utils/src/process.rs
+++ b/plugins/bntl_utils/src/process.rs
@@ -435,7 +435,7 @@ pub struct TypeLibProcessor {
     /// Whether to process existing type libraries when processing a binary file.
     process_existing_type_libraries: bool,
     /// The compiler flags to use when processing header files.
-    options: Vec<String>,
+    compiler_options: Vec<String>,
 }
 
 impl TypeLibProcessor {
@@ -450,7 +450,7 @@ impl TypeLibProcessor {
             default_platform_name: default_platform_name.to_owned(),
             include_directories: Vec::new(),
             process_existing_type_libraries: false,
-            options: Vec::new(),
+            compiler_options: Vec::new(),
         }
     }
 
@@ -464,8 +464,8 @@ impl TypeLibProcessor {
         self
     }
 
-    pub fn with_options(mut self, options: Vec<String>) -> Self {
-        self.options = options;
+    pub fn with_compiler_options(mut self, options: Vec<String>) -> Self {
+        self.compiler_options = options;
         self
     }
 
@@ -996,7 +996,7 @@ impl TypeLibProcessor {
                 &file_name,
                 &platform,
                 &platform_type_container,
-                &self.options,
+                &self.compiler_options,
                 &include_dirs,
                 "",
             )

--- a/plugins/bntl_utils/src/process.rs
+++ b/plugins/bntl_utils/src/process.rs
@@ -434,6 +434,8 @@ pub struct TypeLibProcessor {
     include_directories: Vec<PathBuf>,
     /// Whether to process existing type libraries when processing a binary file.
     process_existing_type_libraries: bool,
+    /// The compiler flags to use when processing header files.
+    options: Vec<String>,
 }
 
 impl TypeLibProcessor {
@@ -448,6 +450,7 @@ impl TypeLibProcessor {
             default_platform_name: default_platform_name.to_owned(),
             include_directories: Vec::new(),
             process_existing_type_libraries: false,
+            options: Vec::new(),
         }
     }
 
@@ -458,6 +461,11 @@ impl TypeLibProcessor {
 
     pub fn with_include_directories(mut self, include_directories: Vec<PathBuf>) -> Self {
         self.include_directories = include_directories;
+        self
+    }
+
+    pub fn with_options(mut self, options: Vec<String>) -> Self {
+        self.options = options;
         self
     }
 
@@ -988,7 +996,7 @@ impl TypeLibProcessor {
                 &file_name,
                 &platform,
                 &platform_type_container,
-                &[],
+                &self.options,
                 &include_dirs,
                 "",
             )


### PR DESCRIPTION
Small change to allow adding of clang compiler flags when creating BNTLs.
The CLI is untested as I have no headless license, but I'm happy to make changes where needed for ergonomics.