### PR TITLE
[KernelCache] Improve compatibility with iOS 27 kernel caches

### DIFF
--- a/view/kernelcache/CMakeLists.txt
+++ b/view/kernelcache/CMakeLists.txt
@@ -32,7 +32,7 @@ set(METADATA_VERSION 3 CACHE STRING "Version of the metadata")
 
 add_subdirectory(core)
 add_subdirectory(api)
-# add_subdirectory(workflow)
+add_subdirectory(workflow)
 
 add_library(kernelcache SHARED
     HeadlessPlugin.cpp)
@@ -60,7 +60,7 @@ set_target_properties(kernelcache PROPERTIES
 
 target_include_directories(kernelcache PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/core ${CMAKE_CURRENT_SOURCE_DIR}/api ${CMAKE_CURRENT_SOURCE_DIR}/workflow)
 
-target_link_libraries(kernelcache PUBLIC kernelcacheapi binaryninjaapi kernelcachecore) # kernelcacheworkflow)
+target_link_libraries(kernelcache PUBLIC kernelcacheapi binaryninjaapi kernelcachecore kernelcacheworkflow)
 
 
 

--- a/view/kernelcache/HeadlessPlugin.cpp
+++ b/view/kernelcache/HeadlessPlugin.cpp
@@ -1,6 +1,7 @@
 #include <binaryninjaapi.h>
 #include "KernelCacheView.h"
 #include "transformers/KernelCacheTransforms.h"
+#include "workflow/KernelCacheWorkflow.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -17,6 +18,7 @@ extern "C"
 	{
 		KernelCacheViewType::Register();
 		RegisterTransformers();
+		RegisterKernelCacheWorkflow();
 		return true;
 	}
 }

--- a/view/kernelcache/core/MachOProcessor.cpp
+++ b/view/kernelcache/core/MachOProcessor.cpp
@@ -193,11 +193,16 @@ uint64_t KernelCacheMachOProcessor::ApplyHeaderSections(KernelCacheMachOHeader& 
 			semantics = ReadOnlyDataSectionSemantics;
 		if (strncmp(section.sectname, "__data", sizeof(section.sectname)) == 0)
 			semantics = ReadWriteDataSectionSemantics;
-		if (strncmp(section.sectname, "__auth_got", sizeof(section.sectname)) == 0)
-			semantics = ReadOnlyDataSectionSemantics;
 
 		if (auto overriddenSemantics = SectionSemanticsForSection(section))
 			semantics = static_cast<BNSectionSemantics>(overriddenSemantics);
+
+		// GOT entries are resolved to concrete targets by chained-fixup processing. Mark them
+		// read-only for analysis so indirect calls through __auth_stubs are resolved to their
+		// targets, even though they sit in a segment that is mapped writable during early boot.
+		if (strncmp(section.sectname, "__got", sizeof(section.sectname)) == 0
+			|| strncmp(section.sectname, "__auth_got", sizeof(section.sectname)) == 0)
+			semantics = ReadOnlyDataSectionSemantics;
 
 		// Typically a view would add auto sections but those won't persist when loading the BNDB.
 		// if we want to use an auto section here we would need to allow the core to apply auto sections from the database.

--- a/view/kernelcache/ui/KernelCacheUINotifications.cpp
+++ b/view/kernelcache/ui/KernelCacheUINotifications.cpp
@@ -4,6 +4,7 @@
 
 #include "KernelCacheUINotifications.h"
 #include <kernelcacheapi.h>
+#include "mediumlevelilinstruction.h"
 #include "ui/sidebar.h"
 #include "ui/linearview.h"
 #include "ui/viewframe.h"
@@ -13,6 +14,57 @@ using namespace BinaryNinja;
 using namespace KernelCacheAPI;
 
 UINotifications* UINotifications::m_instance = nullptr;
+
+// Resolve a stub function at `addr` to the constant target of its jump or tail call. Stub functions
+// are identified by the `j_` symbol prefix that the kernel cache workflow applies when renaming them.
+static std::optional<uint64_t> ResolveStubTarget(BinaryView& view, uint64_t addr)
+{
+	auto symbol = view.GetSymbolByAddress(addr);
+	if (!symbol || symbol->GetShortName().rfind("j_", 0) != 0)
+		return std::nullopt;
+
+	auto func = view.GetAnalysisFunction(view.GetDefaultPlatform(), addr);
+	if (!func)
+		return std::nullopt;
+
+	// Skip any function that is very clearly not a stub (not a single basic block with only a few instructions).
+	const auto blocks = func->GetBasicBlocks();
+	constexpr uint64_t maxStubLength = 0x20;
+	if (blocks.size() != 1 || blocks[0]->GetLength() > maxStubLength)
+		return std::nullopt;
+
+	auto mlil = func->GetMediumLevelIL();
+	if (!mlil)
+		return std::nullopt;
+
+	const auto mlilBlocks = mlil->GetBasicBlocks();
+	if (mlilBlocks.size() != 1 || mlilBlocks[0]->GetEnd() == mlilBlocks[0]->GetStart())
+		return std::nullopt;
+
+	// The jump or tail call terminates the stub's single basic block, so it can only be the last instruction.
+	const auto instr = mlil->GetInstruction(mlilBlocks[0]->GetEnd() - 1);
+	if (instr.operation != MLIL_JUMP && instr.operation != MLIL_TAILCALL)
+		return std::nullopt;
+
+	const auto dest = instr.GetDestExpr();
+	if (dest.operation != MLIL_CONST_PTR && dest.operation != MLIL_CONST)
+		return std::nullopt;
+
+	return dest.GetConstant();
+}
+
+// The address a token-based load action should operate on. A stub function's address is in an
+// already-loaded image, so resolve it to its target and offer to load what the stub jumps to.
+static uint64_t TokenAddress(const UIActionContext& ctx)
+{
+	uint64_t addr = ctx.token.token.value;
+	if (!ctx.binaryView->GetSectionsAt(addr).empty())
+	{
+		if (auto target = ResolveStubTarget(*ctx.binaryView, addr))
+			return *target;
+	}
+	return addr;
+}
 
 void UINotifications::init()
 {
@@ -35,7 +87,7 @@ void UINotifications::OnViewChange(UIContext* context, ViewFrame* frame, const Q
 
 	auto ah = viewInt->actionHandler();
 	// Check to see if we have already bound these actions.
-	if (ah->isBoundAction("Load Image by Name"))
+	if (ah->isBoundAction("KC Load IMGHERE"))
 		return;
 
 	static auto loadImageAtAddr = [](BinaryView& view, uint64_t addr) {
@@ -64,13 +116,14 @@ void UINotifications::OnViewChange(UIContext* context, ViewFrame* frame, const Q
 	};
 
 	auto loadImageTokenAction = [](const UIActionContext& ctx) {
+		uint64_t addr = TokenAddress(ctx);
 		BackgroundThread::create(ctx.context->mainWindow())
-			->thenBackground([ctx](){ loadImageAtAddr(*ctx.binaryView, ctx.token.token.value); })
+			->thenBackground([ctx, addr](){ loadImageAtAddr(*ctx.binaryView, addr); })
 			->start();
 	};
 
 	auto isValidUnloadedImageAction = [](const UIActionContext& ctx) {
-		uint64_t addr = ctx.token.token.value;
+		uint64_t addr = TokenAddress(ctx);
 		// Check if the image is already loaded in the view.
 		if (!ctx.binaryView->GetSectionsAt(addr).empty())
 			return false;
@@ -80,15 +133,16 @@ void UINotifications::OnViewChange(UIContext* context, ViewFrame* frame, const Q
 		return controller->GetImageContaining(addr).has_value();
 	};
 
-	ah->bindAction("Load Image by Address", UIAction(loadImageAddrAction));
+	ah->bindAction("KC Load Image by Address", UIAction(loadImageAddrAction));
+	ah->setActionDisplayName("KC Load Image by Address", "Load Image by Address");
 
-	ah->bindAction("Load IMGHERE", UIAction(loadImageTokenAction, isValidUnloadedImageAction));
+	ah->bindAction("KC Load IMGHERE", UIAction(loadImageTokenAction, isValidUnloadedImageAction));
 
-	ah->setActionDisplayName("Load IMGHERE", [](const UIActionContext& ctx) {
+	ah->setActionDisplayName("KC Load IMGHERE", [](const UIActionContext& ctx) {
 		auto controller = KernelCacheController::GetController(*ctx.binaryView);
 		if (!controller)
 			return QString("NO CONTROLLER");
-		uint64_t addr = ctx.token.token.value;
+		uint64_t addr = TokenAddress(ctx);
 		auto image = controller->GetImageContaining(addr);
 		if (!image)
 			return QString("NO IMAGE");
@@ -100,8 +154,8 @@ void UINotifications::OnViewChange(UIContext* context, ViewFrame* frame, const Q
 	{
 		constexpr auto groupOneName = KC_VIEW_NAME;
 		constexpr auto groupTwoName = KC_VIEW_NAME "2";
-		linearView->contextMenu().addAction("Load IMGHERE", groupOneName);
-		linearView->contextMenu().addAction("Load Image by Address", groupTwoName);
+		linearView->contextMenu().addAction("KC Load IMGHERE", groupOneName);
+		linearView->contextMenu().addAction("KC Load Image by Address", groupTwoName);
 		linearView->contextMenu().setGroupOrdering(groupOneName, 0);
 		linearView->contextMenu().setGroupOrdering(groupTwoName, 1);
 	}

--- a/view/kernelcache/ui/Plugin.cpp
+++ b/view/kernelcache/ui/Plugin.cpp
@@ -14,6 +14,7 @@ extern "C"
 	{
 		UINotifications::init();
 		UIAction::registerAction("KC Load IMGHERE");
+		UIAction::registerAction("KC Load Image by Address");
 
 		KCTriageViewType::Register();
 

--- a/view/kernelcache/workflow/CMakeLists.txt
+++ b/view/kernelcache/workflow/CMakeLists.txt
@@ -1,0 +1,62 @@
+cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
+
+project(kernelcacheworkflow)
+file(GLOB SOURCES CONFIGURE_DEPENDS *.cpp *.h)
+add_library(kernelcacheworkflow OBJECT ${SOURCES})
+
+set(COMPILE_DEFS "")
+
+if (HARD_FAIL_MODE)
+    set(COMPILE_DEFS "${COMPILE_DEFS} ABORT_FAILURES")
+endif()
+
+if (BN_REF_COUNT_DEBUG)
+    set(COMPILE_DEFS "${COMPILE_DEFS} BN_REF_COUNT_DEBUG;")
+endif()
+
+if (KC_VIEW_NAME)
+    set(COMPILE_DEFS "${COMPILE_DEFS} KC_VIEW_NAME=\"${KC_VIEW_NAME}\";")
+endif()
+
+target_compile_definitions(kernelcacheworkflow PRIVATE ${COMPILE_DEFS})
+
+
+function(get_recursive_include_dirs target result)
+    # Initialize an empty list to store include directories
+    set(include_dirs "")
+
+    # Get the include directories of the current target
+    get_target_property(current_target_includes ${target} INTERFACE_INCLUDE_DIRECTORIES)
+    if(current_target_includes)
+        list(APPEND include_dirs ${current_target_includes})
+    endif()
+
+    # Get the libraries that this target links to
+    get_target_property(linked_libraries ${target} INTERFACE_LINK_LIBRARIES)
+    if(linked_libraries)
+        foreach(linked_library IN LISTS linked_libraries)
+            # Skip plain library names (non-target libraries)
+            if(TARGET ${linked_library})
+                # Recursively get include directories from linked libraries
+                get_recursive_include_dirs(${linked_library} linked_library_includes)
+                list(APPEND include_dirs ${linked_library_includes})
+            endif()
+        endforeach()
+    endif()
+
+    # Set the result to the collected include directories
+    set(${result} ${include_dirs} PARENT_SCOPE)
+endfunction()
+
+get_recursive_include_dirs(binaryninjaapi INCLUDES)
+
+target_include_directories(kernelcacheworkflow
+        PUBLIC ${PROJECT_SOURCE_DIR} ${PROJECT_SOURCE_DIR}/../core ${INCLUDES})
+
+set_target_properties(kernelcacheworkflow PROPERTIES
+        CXX_STANDARD 20
+        CXX_VISIBILITY_PRESET hidden
+        CXX_STANDARD_REQUIRED ON
+        VISIBILITY_INLINES_HIDDEN ON
+        POSITION_INDEPENDENT_CODE ON
+        ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/out)

--- a/view/kernelcache/workflow/KernelCacheWorkflow.cpp
+++ b/view/kernelcache/workflow/KernelCacheWorkflow.cpp
@@ -1,0 +1,130 @@
+#include "binaryninjaapi.h"
+#include "lowlevelilinstruction.h"
+#include "mediumlevelilinstruction.h"
+#include "KernelCacheController.h"
+#include "KernelCacheWorkflow.h"
+
+using namespace BinaryNinja;
+using namespace BinaryNinja::KC;
+
+namespace {
+
+// Name a resolved stub with the j_ thunk convention. The target's symbol name is used when one
+// exists. When it does not, the destination address is encoded (with the owning image when it can
+// be resolved) so the j_ prefix still signals a cross-image thunk to an unnamed or unloaded target.
+void IdentifyStub(BinaryView& view, KernelCacheController& controller, uint64_t stubAddr, uint64_t targetAddr)
+{
+	auto& cache = controller.GetCache();
+
+	std::string name;
+	if (auto symbol = cache.GetSymbolAt(targetAddr))
+		name = "j_" + symbol->name;
+	else if (auto image = cache.GetImageContaining(targetAddr))
+		name = fmt::format("j_{}_{:x}", image->GetName(), targetAddr);
+	else
+		name = fmt::format("j_{:x}", targetAddr);
+
+	view.DefineAutoSymbol(new Symbol(FunctionSymbol, name, stubAddr));
+}
+
+// Read the resolved branch target out of a stub's IL. Returns the destination address once data
+// flow has folded the __auth_got load into a constant.
+std::optional<uint64_t> ResolveStubTarget(MediumLevelILFunction& mlil, const MediumLevelILInstruction& dest)
+{
+	if (dest.operation == MLIL_CONST_PTR)
+		return dest.GetConstant<MLIL_CONST_PTR>();
+	if (dest.operation == MLIL_VAR_SSA)
+	{
+		auto value = mlil.GetSSAVarValue(dest.GetSourceSSAVariable());
+		if (value.state == ConstantValue || value.state == ConstantPointerValue)
+			return value.value;
+	}
+	return std::nullopt;
+}
+
+void AnalyzeStubFunction(Function& func, MediumLevelILFunction& mlil, KernelCacheController& controller)
+{
+	auto view = func.GetView();
+	for (const auto& block : mlil.GetBasicBlocks())
+	{
+		for (size_t i = block->GetStart(), end = block->GetEnd(); i < end; ++i)
+		{
+			auto instr = mlil.GetInstruction(i);
+
+			std::optional<uint64_t> target;
+			if (instr.operation == MLIL_JUMP)
+				target = ResolveStubTarget(mlil, instr.GetDestExpr<MLIL_JUMP>());
+			else if (instr.operation == MLIL_TAILCALL_SSA)
+				target = ResolveStubTarget(mlil, instr.GetDestExpr<MLIL_TAILCALL_SSA>());
+			else
+				continue;
+
+			if (!target)
+				continue;
+
+			// Inline the thunk at its call sites when the target is mapped, matching how the
+			// shared cache presents resolved stubs.
+			if (view->IsValidOffset(*target))
+				func.SetAutoInlinedDuringAnalysis(InlineUsingCallAddress);
+
+			IdentifyStub(*view, controller, func.GetStart(), *target);
+			return;
+		}
+	}
+}
+
+void AnalyzeFunction(Ref<AnalysisContext> ctx)
+{
+	auto func = ctx->GetFunction();
+	auto view = func->GetView();
+	auto mlil = ctx->GetMediumLevelILFunction();
+	if (!mlil)
+		return;
+	auto mlilSsa = mlil->GetSSAForm();
+	if (!mlilSsa)
+		return;
+
+	auto controller = KernelCacheController::FromView(*view);
+	if (!controller)
+		return;
+
+	auto sections = view->GetSectionsAt(func->GetStart());
+	if (sections.empty())
+		return;
+	auto sectionName = sections.front()->GetName();
+	if (sectionName.find("__auth_stubs") == std::string::npos
+		&& sectionName.find("__stubs") == std::string::npos)
+		return;
+
+	AnalyzeStubFunction(*func, *mlilSsa, *controller);
+}
+
+}  // namespace
+
+void KernelCacheWorkflowRegister()
+{
+	auto workflow = Workflow::Get("core.function.metaAnalysis")->Clone("core.function.metaAnalysis");
+	workflow->RegisterActivity(new Activity(R"({
+	  "name": "core.analysis.kernelCache.analysis",
+	  "eligibility": {
+	    "predicates": [
+	      {
+	        "type": "viewType",
+	        "operator": "in",
+	        "value": [ "KCView" ]
+	      }
+	    ]
+	  }
+	})", &AnalyzeFunction));
+	std::vector<std::string> inserted = { "core.analysis.kernelCache.analysis" };
+	workflow->Insert("core.function.analyzeTailCalls", inserted);
+	Workflow::RegisterWorkflow(workflow);
+}
+
+extern "C"
+{
+	void RegisterKernelCacheWorkflow()
+	{
+		KernelCacheWorkflowRegister();
+	}
+}

--- a/view/kernelcache/workflow/KernelCacheWorkflow.h
+++ b/view/kernelcache/workflow/KernelCacheWorkflow.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+	void RegisterKernelCacheWorkflow();
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
iOS 27 / macOS 27 route cross-image calls through `__auth_stubs`, loading their target from `__auth_got`. `__auth_got` is now marked as read-only to allow the target of the cross-image call to be resolved.

Additionally, a workflow activity was added to name these stub functions, and the context menu actions for loading additional images were updated to resolve the target image through the stub functions. Most of this logic is a simplified version of the equivalent code from the dyld shared cache plug-in.