### PR TITLE
Fix potential object lifetime issue in DSCView

### DIFF
--- a/view/sharedcache/ui/dsctriage.cpp
+++ b/view/sharedcache/ui/dsctriage.cpp
@@ -155,7 +155,7 @@ void DSCTriageView::loadImagesWithAddr(const std::vector<uint64_t>& addresses, b
 			watcher->deleteLater();
 		}
 	});
-	QFuture<ImageList> future = QtConcurrent::run([this, controller, images, imageLoadTask]() {
+	QFuture<ImageList> future = QtConcurrent::run([data = m_data, controller, images, imageLoadTask]() {
 		ImageList loadedImages = {};
 		for (const auto& image : images)
 		{
@@ -163,7 +163,7 @@ void DSCTriageView::loadImagesWithAddr(const std::vector<uint64_t>& addresses, b
 				break;
 			std::string newLoad = fmt::format("Loading images... ({}/{})", loadedImages.size(), images.size());
 			imageLoadTask->SetProgressText(newLoad);
-			if (controller->ApplyImage(*this->m_data, image))
+			if (controller->ApplyImage(*data, image))
 				loadedImages.emplace_back(image);
 		}
 		imageLoadTask->Finish();
@@ -630,8 +630,8 @@ void DSCTriageView::loadStringRegion(const CacheString& string, std::optional<ui
 			navigateToAddress(*navigateTo);
 		watcher->deleteLater();
 	});
-	QFuture<bool> future = QtConcurrent::run([this, controller, region]() {
-		return controller->ApplyRegion(*this->m_data, *region);
+	QFuture<bool> future = QtConcurrent::run([data = m_data, controller, region]() {
+		return controller->ApplyRegion(*data, *region);
 	});
 	watcher->setFuture(future);
 	connect(this, &QObject::destroyed, this, [watcher]() {


### PR DESCRIPTION
While I was reviewing #8277, I got suspicious of some places where we were capturing `this`. It's late and I might be wrong, but I _think_ there's a potential lifetime issue here.

I believe the following sequence is theoretically possible:

1. `DSCTriageView::loadImagesWithAddr()` starts a background task
2. The lambda in the worker captures `this`
3. The worker starts running on a background thread
4. The user closes the view
5. `DSCTriageView` is destructed (or at least starts to be)
6. The worker tries to access `this->m_data`

If 5 gets far enough before 6 happens, I think that could be a use-after-free? I also just think it's weird to have a background worker thread have a raw pointer to a UI object.

My change here is to just take a reference to the BV outside of the worker, rather than relying on the UI object. I think this should be the right move, but someone can let me know.