### PR TITLE
[ARMv7] Add VRHADD/VRECPE lifts and fix SBC immediates

### DIFF
--- a/arch/armv7/arch_armv7.cpp
+++ b/arch/armv7/arch_armv7.cpp
@@ -1597,6 +1597,10 @@ public:
 			return "__vqadd";
 		case ARMV7_INTRIN_VHADD:
 			return "__vhadd";
+		case ARMV7_INTRIN_VRHADD:
+			return "__vrhadd";
+		case ARMV7_INTRIN_VRECPE:
+			return "__vrecpe";
 		case ARMV7_INTRIN_VQSHL:
 			return "__vqshl";
 		case ARMV7_INTRIN_VQRSHL:
@@ -1860,6 +1864,8 @@ public:
 			ARMV7_INTRIN_VBSL,
 			ARMV7_INTRIN_VQADD,
 			ARMV7_INTRIN_VHADD,
+			ARMV7_INTRIN_VRHADD,
+			ARMV7_INTRIN_VRECPE,
 			ARMV7_INTRIN_VQSHL,
 			ARMV7_INTRIN_VQRSHL,
 			ARMV7_INTRIN_VQSHRN,
@@ -2175,6 +2181,7 @@ public:
 		case ARMV7_INTRIN_VPMIN:
 		case ARMV7_INTRIN_VCGT:
 		case ARMV7_INTRIN_VHADD:
+		case ARMV7_INTRIN_VRHADD:
 			return {
 				NameAndType("size", Type::IntegerType(1, false)),
 				NameAndType("is_unsigned", Type::BoolType()),
@@ -2187,6 +2194,12 @@ public:
 				NameAndType("is_float", Type::BoolType()),
 				NameAndType("source1", Type::IntegerType(8, false)),
 				NameAndType("source2", Type::IntegerType(8, false)),
+			};
+		case ARMV7_INTRIN_VRECPE:
+			return {
+				NameAndType("size", Type::IntegerType(1, false)),
+				NameAndType("is_float", Type::BoolType()),
+				NameAndType("source", Type::IntegerType(8, false)),
 			};
 		case ARMV7_INTRIN_VREV16:
 		case ARMV7_INTRIN_VREV32:
@@ -2535,6 +2548,8 @@ public:
 		case ARMV7_INTRIN_VSUB:
 		case ARMV7_INTRIN_VQADD:
 		case ARMV7_INTRIN_VHADD:
+		case ARMV7_INTRIN_VRHADD:
+		case ARMV7_INTRIN_VRECPE:
 		case ARMV7_INTRIN_VQSHL:
 		case ARMV7_INTRIN_VQRSHL:
 		case ARMV7_INTRIN_VQSHRN:

--- a/arch/armv7/il.cpp
+++ b/arch/armv7/il.cpp
@@ -480,7 +480,7 @@ static ExprId VectorTableLookup(LowLevelILFunction& il, Instruction& instr)
 		inputs);
 }
 
-static void HalvingVectorAdd(LowLevelILFunction& il, Instruction& instr)
+static void HalvingVectorAdd(LowLevelILFunction& il, Instruction& instr, uint32_t intrinsic)
 {
 	InstructionOperand& dst = instr.operands[0];
 	InstructionOperand& src1 = instr.operands[1];
@@ -493,16 +493,48 @@ static void HalvingVectorAdd(LowLevelILFunction& il, Instruction& instr)
 		il.AddInstruction(il.Unimplemented());
 		return;
 	}
+	if (intrinsic == ARMV7_INTRIN_VRHADD && elementSize != 1 && elementSize != 2 && elementSize != 4)
+	{
+		il.AddInstruction(il.Unimplemented());
+		return;
+	}
 
 	il.AddInstruction(il.Intrinsic(
 		{ RegisterOrFlag::Register(dst.reg) },
-		ARMV7_INTRIN_VHADD,
+		intrinsic,
 		{
 			il.Const(1, elementSize * 8),
 			il.Const(1, IsSignedDataType(instr.dataType) ? 0 : 1),
 			il.Register(get_register_size(src1.reg), src1.reg),
 			il.Register(get_register_size(src2.reg), src2.reg),
 		}));
+}
+
+static ExprId VectorReciprocalEstimate(LowLevelILFunction& il, Instruction& instr)
+{
+	InstructionOperand& dst = instr.operands[0];
+	InstructionOperand& src = instr.operands[1];
+
+	if (dst.cls != REG || src.cls != REG)
+		return il.Unimplemented();
+
+	if (instr.dataType != DT_U32 && instr.dataType != DT_F32)
+		return il.Unimplemented();
+
+	size_t elementSize = GetDataTypeSize(instr.dataType);
+	size_t destSize = get_register_size(dst.reg);
+	size_t sourceSize = get_register_size(src.reg);
+	if (elementSize == 0 || destSize == 0 || sourceSize == 0)
+		return il.Unimplemented();
+
+	return il.Intrinsic(
+		{ RegisterOrFlag::Register(dst.reg) },
+		ARMV7_INTRIN_VRECPE,
+		{
+			il.Const(1, elementSize * 8),
+			il.Const(1, instr.dataType == DT_F32 ? 1 : 0),
+			il.Register(sourceSize, src.reg),
+		});
 }
 
 static ExprId SaturatingVectorShiftRightNarrow(LowLevelILFunction& il, Instruction& instr)
@@ -3359,7 +3391,7 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 					SetRegisterOrBranch(il, op1.reg,
 						il.SubBorrow(get_register_size(op2.reg),
 							ReadILOperand(il, op2, addr),
-							ReadRegisterOrPointer(il, op3, addr),
+							ReadILOperand(il, op3, addr),
 							il.Not(1,il.Flag(IL_FLAG_C))),
 							flagOperation[instr.setsFlags]));
 			break;
@@ -4723,7 +4755,15 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 				[&](size_t addrSize, Instruction& instr, LowLevelILFunction& il)
 				{
 					(void) addrSize;
-					HalvingVectorAdd(il, instr);
+					HalvingVectorAdd(il, instr, ARMV7_INTRIN_VHADD);
+				});
+			break;
+		case ARMV7_VRHADD:
+			ConditionExecute(addrSize, instr.cond, instr, il,
+				[&](size_t addrSize, Instruction& instr, LowLevelILFunction& il)
+				{
+					(void) addrSize;
+					HalvingVectorAdd(il, instr, ARMV7_INTRIN_VRHADD);
 				});
 			break;
 		case ARMV7_VSQRT:
@@ -4839,6 +4879,9 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 			break;
 		case ARMV7_VRADDHN:
 			ConditionExecute(il, instr.cond, VectorRoundingAddNarrow(il, instr));
+			break;
+		case ARMV7_VRECPE:
+			ConditionExecute(il, instr.cond, VectorReciprocalEstimate(il, instr));
 			break;
 		case ARMV7_VQSHL:
 			ConditionExecute(il, instr.cond, SaturatingVectorShiftLeft(il, instr, ARMV7_INTRIN_VQSHL));

--- a/arch/armv7/il.h
+++ b/arch/armv7/il.h
@@ -199,6 +199,8 @@ enum Armv7Intrinsic : uint32_t
 	ARMV7_INTRIN_SMLATT,
 	ARMV7_INTRIN_VADD,
 	ARMV7_INTRIN_VSUB,
+	ARMV7_INTRIN_VRHADD,
+	ARMV7_INTRIN_VRECPE,
 };
 
 enum ArmFakeRegister: uint32_t

--- a/arch/armv7/test_lift.py
+++ b/arch/armv7/test_lift.py
@@ -15,6 +15,10 @@ def scalar_q_intrinsic_expected(dst, intrinsic, *sources):
 def vector_intrinsic_expected(dst, intrinsic, size, modifier, src1, src2):
     return f'LLIL_INTRINSIC([{dst}],__{intrinsic},[LLIL_CONST.b(0x{size:X}),LLIL_CONST.b(0x{modifier:X}),LLIL_REG.q({src1}),LLIL_REG.q({src2})])'
 
+def vector_unary_intrinsic_expected(dst, intrinsic, size, modifier, src):
+    src_size = 'o' if src.startswith('q') else 'q'
+    return f'LLIL_INTRINSIC([{dst}],__{intrinsic},[LLIL_CONST.b(0x{size:X}),LLIL_CONST.b(0x{modifier:X}),LLIL_REG.{src_size}({src})])'
+
 def saturating_scalar_expected(dst, src1, src2, intrinsic):
     return scalar_q_intrinsic_expected(dst, intrinsic, src1, src2)
 
@@ -184,6 +188,8 @@ test_cases = \
     ('T', b'\x50\xea\x4c\x00', 'LLIL_SET_REG.d(r0,LLIL_OR.d{*}(LLIL_REG.d(r0),LLIL_LSL.d(LLIL_REG.d(r12),LLIL_CONST.d(0x1))))'),
     # asrs r5, r5, #0x1e
     ('T', b'\xad\x17', 'LLIL_SET_REG.d(r5,LLIL_ASR.d{cnz}(LLIL_REG.d(r5),LLIL_CONST.d(0x1E)))'),
+    # sbcs r3, r7, #0
+    ('A', b'\x00\x30\xd7\xe2', 'LLIL_SET_REG.d{*}(r3,LLIL_SBB.d(LLIL_REG.d(r7),LLIL_CONST.d(0x0),LLIL_NOT.b(LLIL_FLAG(c))))'),
     # adcs r2, r7
     ('T', b'\x7a\x41', 'LLIL_SET_REG.d(r2,LLIL_ADC.d{*}(LLIL_REG.d(r2),LLIL_REG.d(r7),LLIL_FLAG(c)))'),
     # strht r3, [r3, #0x7f]
@@ -630,6 +636,22 @@ test_cases = \
     ('T', b'\x0d\xff\x08\x08', 'LLIL_INTRINSIC([d0],__vsub,[LLIL_CONST.b(0x8),LLIL_CONST.b(0x1),LLIL_REG.q(d13),LLIL_REG.q(d8)])'),
     # vhadd.u8 d0, d0, d0
     ('T', b'\x00\xff\x00\x00', vector_intrinsic_expected('d0', 'vhadd', 8, 1, 'd0', 'd0')),
+    # vrhadd.u16 d14, d14, d31
+    ('A', b'\x2f\xe1\x1e\xf3', vector_intrinsic_expected('d14', 'vrhadd', 16, 1, 'd14', 'd31')),
+    # vrhadd.u16 d14, d14, d31
+    ('T', b'\x1e\xff\x2f\xe1', vector_intrinsic_expected('d14', 'vrhadd', 16, 1, 'd14', 'd31')),
+    # vrecpe.f32 q13, q2
+    ('A', b'\x44\xa5\xfb\xf3', vector_unary_intrinsic_expected('q13', 'vrecpe', 32, 1, 'q2')),
+    # vrecpe.f32 d26, d23
+    ('A', b'\x27\xa5\xfb\xf3', vector_unary_intrinsic_expected('d26', 'vrecpe', 32, 1, 'd23')),
+    # vrecpe.f32 q13, q2
+    ('T', b'\xfb\xff\x44\xa5', vector_unary_intrinsic_expected('q13', 'vrecpe', 32, 1, 'q2')),
+    # vrecpe.f32 d26, d23
+    ('T', b'\xfb\xff\x27\xa5', vector_unary_intrinsic_expected('d26', 'vrecpe', 32, 1, 'd23')),
+    # vrecpe.u32 q13, q2
+    ('A', b'\x44\xa4\xfb\xf3', vector_unary_intrinsic_expected('q13', 'vrecpe', 32, 0, 'q2')),
+    # vrecpe.u32 q13, q2
+    ('T', b'\xfb\xff\x44\xa4', vector_unary_intrinsic_expected('q13', 'vrecpe', 32, 0, 'q2')),
     # vceq.s16 d16, d0, d13
     ('T', b'\x50\xff\x1d\x08', vector_intrinsic_expected('d16', 'vceq', 16, 0, 'd0', 'd13')),
     # vcgt.s32 d0, d19, #0

--- a/arch/armv7/thumb2_disasm/arch_thumb2.cpp
+++ b/arch/armv7/thumb2_disasm/arch_thumb2.cpp
@@ -1807,6 +1807,10 @@ public:
 			return "__vqadd";
 		case ARMV7_INTRIN_VHADD:
 			return "__vhadd";
+		case ARMV7_INTRIN_VRHADD:
+			return "__vrhadd";
+		case ARMV7_INTRIN_VRECPE:
+			return "__vrecpe";
 		case ARMV7_INTRIN_VQSHL:
 			return "__vqshl";
 		case ARMV7_INTRIN_VQRSHL:
@@ -2115,6 +2119,8 @@ public:
 			ARMV7_INTRIN_VBSL,
 			ARMV7_INTRIN_VQADD,
 			ARMV7_INTRIN_VHADD,
+			ARMV7_INTRIN_VRHADD,
+			ARMV7_INTRIN_VRECPE,
 			ARMV7_INTRIN_VQSHL,
 			ARMV7_INTRIN_VQRSHL,
 			ARMV7_INTRIN_VQSHRN,
@@ -2406,6 +2412,7 @@ public:
 		case ARMV7_INTRIN_VPMIN:
 		case ARMV7_INTRIN_VCGT:
 		case ARMV7_INTRIN_VHADD:
+		case ARMV7_INTRIN_VRHADD:
 			return {
 				NameAndType("size", Type::IntegerType(1, false)),
 				NameAndType("is_unsigned", Type::BoolType()),
@@ -2418,6 +2425,12 @@ public:
 				NameAndType("is_float", Type::BoolType()),
 				NameAndType("source1", Type::IntegerType(8, false)),
 				NameAndType("source2", Type::IntegerType(8, false)),
+			};
+		case ARMV7_INTRIN_VRECPE:
+			return {
+				NameAndType("size", Type::IntegerType(1, false)),
+				NameAndType("is_float", Type::BoolType()),
+				NameAndType("source", Type::IntegerType(8, false)),
 			};
 		case ARMV7_INTRIN_VREV16:
 		case ARMV7_INTRIN_VREV32:
@@ -2826,6 +2839,8 @@ public:
 		case ARMV7_INTRIN_VSUB:
 		case ARMV7_INTRIN_VQADD:
 		case ARMV7_INTRIN_VHADD:
+		case ARMV7_INTRIN_VRHADD:
+		case ARMV7_INTRIN_VRECPE:
 		case ARMV7_INTRIN_VQSHL:
 		case ARMV7_INTRIN_VQRSHL:
 		case ARMV7_INTRIN_VQSHRN:

--- a/arch/armv7/thumb2_disasm/il_thumb2.cpp
+++ b/arch/armv7/thumb2_disasm/il_thumb2.cpp
@@ -1551,7 +1551,7 @@ static void SaturatingVectorMoveNarrow(LowLevelILFunction& il, decomp_result* in
 		}));
 }
 
-static void HalvingVectorAdd(LowLevelILFunction& il, decomp_result* instr)
+static void HalvingVectorAdd(LowLevelILFunction& il, decomp_result* instr, uint32_t intrinsic)
 {
 	if (instr->format->operandCount < 3 || !IS_FIELD_PRESENT(instr, FIELD_esize))
 	{
@@ -1562,6 +1562,11 @@ static void HalvingVectorAdd(LowLevelILFunction& il, decomp_result* instr)
 	size_t regSize = GetRegisterSize(instr, 0);
 	size_t elementSize = instr->fields[FIELD_esize] / 8;
 	if (regSize == 0 || elementSize == 0)
+	{
+		il.AddInstruction(il.Unimplemented());
+		return;
+	}
+	if (intrinsic == ARMV7_INTRIN_VRHADD && elementSize != 1 && elementSize != 2 && elementSize != 4)
 	{
 		il.AddInstruction(il.Unimplemented());
 		return;
@@ -1577,12 +1582,45 @@ static void HalvingVectorAdd(LowLevelILFunction& il, decomp_result* instr)
 
 	il.AddInstruction(il.Intrinsic(
 		{ RegisterOrFlag::Register(GetRegisterOperand(instr, 0)) },
-		ARMV7_INTRIN_VHADD,
+		intrinsic,
 		{
 			il.Const(1, instr->fields[FIELD_esize]),
 			il.Const(1, IsSignedVectorElement(instr) ? 0 : 1),
 			il.Register(GetRegisterSize(instr, 1), source1),
 			il.Register(GetRegisterSize(instr, 2), source2),
+		}));
+}
+
+static void VectorReciprocalEstimate(LowLevelILFunction& il, decomp_result* instr)
+{
+	if (instr->format->operandCount < 2 || !IS_FIELD_PRESENT(instr, FIELD_esize))
+	{
+		il.AddInstruction(il.Unimplemented());
+		return;
+	}
+
+	uint32_t dest = GetRegisterOperand(instr, 0);
+	if (dest == armv7::REG_INVALID)
+	{
+		il.AddInstruction(il.Unimplemented());
+		return;
+	}
+
+	size_t sourceSize = GetRegisterSize(instr, 1);
+	if (GetRegisterSize(instr, 0) == 0 || sourceSize == 0)
+	{
+		il.AddInstruction(il.Unimplemented());
+		return;
+	}
+
+	bool isFloat = (instr->format->operationFlags & INSTR_FORMAT_FLAG_F32) != 0;
+	il.AddInstruction(il.Intrinsic(
+		{ RegisterOrFlag::Register(dest) },
+		ARMV7_INTRIN_VRECPE,
+		{
+			il.Const(1, instr->fields[FIELD_esize]),
+			il.Const(1, isFloat ? 1 : 0),
+			ReadILOperand(il, instr, 1, sourceSize),
 		}));
 }
 
@@ -3976,6 +4014,9 @@ bool GetLowLevelILForNEONInstruction(Architecture* arch, LowLevelILFunction& il,
 	case armv7::ARMV7_VRADDHN:
 		VectorRoundingAddNarrow(il, instr);
 		break;
+	case armv7::ARMV7_VRECPE:
+		VectorReciprocalEstimate(il, instr);
+		break;
 	case armv7::ARMV7_VQSHL:
 		SaturatingVectorShiftLeft(il, instr, ARMV7_INTRIN_VQSHL);
 		break;
@@ -4062,7 +4103,10 @@ bool GetLowLevelILForNEONInstruction(Architecture* arch, LowLevelILFunction& il,
 			}
 			break;
 	case armv7::ARMV7_VHADD:
-		HalvingVectorAdd(il, instr);
+		HalvingVectorAdd(il, instr, ARMV7_INTRIN_VHADD);
+		break;
+	case armv7::ARMV7_VRHADD:
+		HalvingVectorAdd(il, instr, ARMV7_INTRIN_VRHADD);
 		break;
 	case armv7::ARMV7_VFNMS:
 	case armv7::ARMV7_VNMLS:


### PR DESCRIPTION
Add ARM and Thumb lifting for VRHADD and VRECPE using new intrinsics.

Also fix ARM SBC/SBCS lifting to read the third operand through the generic operand path, so immediates like #0 lift as constants instead of being interpreted as r0.

Closes #6075
Closes #3988