### PR TITLE
Guard sidebar widget container index

### DIFF
--- a/ui/sidebarcontainer.h
+++ b/ui/sidebarcontainer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <QtCore/QPointer>
 #include <QtWidgets/QWidget>
 #include <QtWidgets/QStackedWidget>
 #include <QtWidgets/QWidget>
@@ -85,7 +86,7 @@ class BINARYNINJAUIAPI SidebarWidgetContainer : public QWidget
 	std::set<SidebarWidgetType*> m_active, m_docked;
 	std::map<SidebarWidgetType*, SidebarStackedWidget> m_stackedWidgets;
 	std::map<SplitPaneWidget*,
-		std::map<ViewFrame*, std::map<QString, std::map<SidebarWidgetType*, SidebarWidgetAndHeader*>>>>
+		std::map<ViewFrame*, std::map<QString, std::map<SidebarWidgetType*, QPointer<SidebarWidgetAndHeader>>>>>
 		m_widgets;
 	std::map<SplitPaneWidget*,
 		std::map<ViewFrame*, std::map<QString, std::map<SidebarWidgetType*, SidebarContentClassifier*>>>>
@@ -97,9 +98,11 @@ class BINARYNINJAUIAPI SidebarWidgetContainer : public QWidget
 	SidebarWidgetType* m_focusedType = nullptr;
 
 	SidebarStackedWidget& stackedWidgetForType(SidebarWidgetType* type);
-	std::vector<SidebarWidgetAndHeader*> widgetsForContext() const;
+	std::vector<QPointer<SidebarWidgetAndHeader>> widgetsForContext() const;
 	std::vector<SidebarContentClassifier*> contentClassifiersForContext() const;
 	void insertWidgetIntoContainer(SidebarWidgetType* type, QStackedWidget* widget);
+	void trackWidget(SidebarWidgetAndHeader* widget);
+	void pruneDeadWidgets();
 	void updateContentsVisibility();
 
 private Q_SLOTS:

--- a/ui/sidebarwidget.h
+++ b/ui/sidebarwidget.h
@@ -98,6 +98,7 @@ class BINARYNINJAUIAPI SidebarWidgetAndHeader : public QWidget
 	std::map<QWidget*, SidebarHeader*> m_headerWidgets;
 	std::set<SidebarWidget*> m_activeWidgets;
 	QLabel* m_noWidgetLabel = nullptr;
+	void finishRemovingWidget(SidebarWidget* widget, bool deactivateOnEmpty);
 
 private Q_SLOTS:
 	void tabChanged(QWidget* widget);


### PR DESCRIPTION
## Summary

Changes `SidebarWidgetContainer::m_widgets` leaf values from raw `SidebarWidgetAndHeader*` to `QPointer<SidebarWidgetAndHeader>` so the sidebar context index observes Qt-owned widgets safely.

## Why

The E9 crash path points at stale sidebar widget/header pointers during view-change fan-out. The container index is not the owner; Qt parentage and the stacked widget hierarchy own these widgets. Using `QPointer` makes stale observer entries become null when Qt destroys the object.

## Validation

- `git -C api diff --check`
- Parent demo UI build: `cmake --build /private/tmp/bn-e9-build-demo --target binaryninjaui -j 8`

Companion parent repo PR will update the submodule pointer and implementation.