### PR TITLE
[Python] Fix exceptions from __del__ during interpreter shutdown

### DIFF
--- a/python/architecture.py
+++ b/python/architecture.py
@@ -2734,7 +2734,7 @@ _architecture_cache = {}
 
 class CoreArchitecture(Architecture):
 	def __init__(self, handle: core.BNArchitecture):
-		super(CoreArchitecture, self).__init__()
+		super().__init__()
 
 		self.handle = core.handle_of_type(handle, core.BNArchitecture)
 		self.name = core.BNGetArchitectureName(self.handle)
@@ -3408,7 +3408,7 @@ _registered_architecture_hooks: List['ArchitectureHook'] = []
 class ArchitectureHook(CoreArchitecture):
 	def __init__(self, base_arch: 'Architecture'):
 		self._base_arch = base_arch
-		super(ArchitectureHook, self).__init__(base_arch.handle)
+		super().__init__(base_arch.handle)
 
 		# To improve performance of simpler hooks, use null callback for functions that are not being overridden
 		if self.get_associated_arch_by_address.__code__ == CoreArchitecture.get_associated_arch_by_address.__code__:

--- a/python/binaryview.py
+++ b/python/binaryview.py
@@ -280,7 +280,7 @@ class BinaryDataNotification:
 
 	>>> class NotifyTest(binaryninja.BinaryDataNotification):
 	... 	def __init__(self):
-	... 		super(NotifyTest, self).__init__(binaryninja.NotificationType.NotificationBarrier | binaryninja.NotificationType.FunctionLifetime | binaryninja.NotificationType.FunctionUpdated)
+	... 		super().__init__(binaryninja.NotificationType.NotificationBarrier | binaryninja.NotificationType.FunctionLifetime | binaryninja.NotificationType.FunctionUpdated)
 	... 		self.received_event = False
 	... 	def notification_barrier(self, view: 'BinaryView') -> int:
 	... 		has_events = self.received_event
@@ -12228,7 +12228,7 @@ class CoreDataVariable:
 
 class DataVariable(CoreDataVariable):
 	def __init__(self, view: BinaryView, address: int, type: '_types.Type', auto_discovered: bool):
-		super(DataVariable, self).__init__(address, type, auto_discovered)
+		super().__init__(address, type, auto_discovered)
 		self.view = view
 		self._accessor = TypedDataAccessor(self.type, self.address, self.view, self.view.endianness)
 
@@ -12324,7 +12324,7 @@ class DataVariable(CoreDataVariable):
 
 class DataVariableAndName(CoreDataVariable):
 	def __init__(self, addr: int, var_type: '_types.Type', var_name: str, auto_discovered: bool) -> None:
-		super(DataVariableAndName, self).__init__(addr, var_type, auto_discovered)
+		super().__init__(addr, var_type, auto_discovered)
 		self.name = var_name
 
 	def __repr__(self) -> str:

--- a/python/constantrenderer.py
+++ b/python/constantrenderer.py
@@ -205,7 +205,7 @@ _renderer_cache = {}
 
 class CoreConstantRenderer(ConstantRenderer):
 	def __init__(self, handle: core.BNConstantRenderer):
-		super(CoreConstantRenderer, self).__init__(handle=handle)
+		super().__init__(handle=handle)
 		if type(self) is CoreConstantRenderer:
 			global _renderer_cache
 			_renderer_cache[ctypes.addressof(handle.contents)] = self

--- a/python/deprecation.py
+++ b/python/deprecation.py
@@ -67,7 +67,7 @@ class DeprecatedWarning(DeprecationWarning):
         self.deprecated_in = deprecated_in
         self.removed_in = removed_in
         self.details = details
-        super(DeprecatedWarning, self).__init__(function, deprecated_in,
+        super().__init__(function, deprecated_in,
                                                 removed_in, details)
 
     def __str__(self):

--- a/python/downloadprovider.py
+++ b/python/downloadprovider.py
@@ -370,7 +370,7 @@ try:
 
 	class PythonDownloadInstance(DownloadInstance):
 		def __init__(self, provider):
-			super(PythonDownloadInstance, self).__init__(provider)
+			super().__init__(provider)
 
 		def perform_destroy_instance(self):
 			pass
@@ -466,7 +466,7 @@ if not _loaded and (sys.platform != "win32"):
 
 		class PythonDownloadInstance(DownloadInstance):
 			def __init__(self, provider):
-				super(PythonDownloadInstance, self).__init__(provider)
+				super().__init__(provider)
 
 			def perform_destroy_instance(self):
 				pass

--- a/python/flowgraph.py
+++ b/python/flowgraph.py
@@ -921,7 +921,7 @@ class FlowGraph:
 
 class CoreFlowGraph(FlowGraph):
 	def __init__(self, handle):
-		super(CoreFlowGraph, self).__init__(handle)
+		super().__init__(handle)
 
 	def update(self):
 		graph = core.BNUpdateFlowGraph(self.handle)

--- a/python/highlevelil.py
+++ b/python/highlevelil.py
@@ -5186,7 +5186,7 @@ class HighLevelILBasicBlock(basicblock.BasicBlock):
 	def __init__(
 	    self, handle: core.BNBasicBlockHandle, owner: HighLevelILFunction, view: Optional['binaryview.BinaryView']
 	):
-		super(HighLevelILBasicBlock, self).__init__(handle, view)
+		super().__init__(handle, view)
 		self._il_function = owner
 
 	def __iter__(self) -> Generator[HighLevelILInstruction, None, None]:

--- a/python/languagerepresentation.py
+++ b/python/languagerepresentation.py
@@ -872,7 +872,7 @@ _language_cache = {}
 
 class CoreLanguageRepresentationFunctionType(LanguageRepresentationFunctionType):
 	def __init__(self, handle: core.BNLanguageRepresentationFunctionTypeHandle):
-		super(CoreLanguageRepresentationFunctionType, self).__init__(handle=handle)
+		super().__init__(handle=handle)
 		if type(self) is CoreLanguageRepresentationFunctionType:
 			global _language_cache
 			_language_cache[ctypes.addressof(handle.contents)] = self

--- a/python/lineformatter.py
+++ b/python/lineformatter.py
@@ -247,7 +247,7 @@ _formatter_cache = {}
 
 class CoreLineFormatter(LineFormatter):
     def __init__(self, handle: core.BNLineFormatter):
-        super(CoreLineFormatter, self).__init__(handle=handle)
+        super().__init__(handle=handle)
         if type(self) is CoreLineFormatter:
             global _formatter_cache
             _formatter_cache[ctypes.addressof(handle.contents)] = self

--- a/python/lowlevelil.py
+++ b/python/lowlevelil.py
@@ -6678,7 +6678,7 @@ class LowLevelILBasicBlock(basicblock.BasicBlock):
 	def __init__(
 	    self, handle: core.BNBasicBlockHandle, owner: LowLevelILFunction, view: Optional['binaryview.BinaryView']
 	):
-		super(LowLevelILBasicBlock, self).__init__(handle, view)
+		super().__init__(handle, view)
 		self._il_function = owner
 
 	def __hash__(self):

--- a/python/mediumlevelil.py
+++ b/python/mediumlevelil.py
@@ -7035,7 +7035,7 @@ class MediumLevelILBasicBlock(basicblock.BasicBlock):
 	    self, handle: core.BNBasicBlockHandle, owner: MediumLevelILFunction,
 	    view: Optional['binaryview.BinaryView'] = None
 	):
-		super(MediumLevelILBasicBlock, self).__init__(handle, view)
+		super().__init__(handle, view)
 		self._il_function = owner
 
 	def __iter__(self):

--- a/python/platform.py
+++ b/python/platform.py
@@ -796,7 +796,7 @@ _platform_cache = {}
 
 class CorePlatform(Platform):
 	def __init__(self, handle: core.BNPlatform):
-		super(CorePlatform, self).__init__(handle=handle)
+		super().__init__(handle=handle)
 		if type(self) is CorePlatform:
 			global _platform_cache
 			_platform_cache[ctypes.addressof(handle.contents)] = self

--- a/python/scriptingprovider.py
+++ b/python/scriptingprovider.py
@@ -638,7 +638,7 @@ class _PythonScriptingInstanceInput:
 
 class BlacklistedDict(dict):
 	def __init__(self, blacklist, *args):
-		super(BlacklistedDict, self).__init__(*args)
+		super().__init__(*args)
 		self.__blacklist = set(blacklist)
 		self._blacklist_enabled = True
 
@@ -648,7 +648,7 @@ class BlacklistedDict(dict):
 			    'Setting variable "{}" will have no affect as it is automatically controlled by the ScriptingProvider.\n'.
 			    format(k)
 			)
-		super(BlacklistedDict, self).__setitem__(k, v)
+		super().__setitem__(k, v)
 
 	def enable_blacklist(self, enabled):
 		self.__enable_blacklist = enabled
@@ -947,7 +947,7 @@ from binaryninja import *
 				return self.active_view.insert(self.active_selection_begin, data)
 
 	def __init__(self, provider):
-		super(PythonScriptingInstance, self).__init__(provider)
+		super().__init__(provider)
 		self.interpreter = PythonScriptingInstance.InterpreterThread(self)
 		self.interpreter.start()
 		self.queued_input = ""

--- a/python/stringrecognizer.py
+++ b/python/stringrecognizer.py
@@ -421,7 +421,7 @@ _recognizer_cache = {}
 
 class CoreStringRecognizer(StringRecognizer):
 	def __init__(self, handle: core.BNStringRecognizer):
-		super(CoreStringRecognizer, self).__init__(handle=handle)
+		super().__init__(handle=handle)
 		if type(self) is CoreStringRecognizer:
 			global _recognizer_cache
 			_recognizer_cache[ctypes.addressof(handle.contents)] = self

--- a/python/types.py
+++ b/python/types.py
@@ -436,7 +436,7 @@ class Symbol(CoreSymbol):
 		_namespace = NameSpace.get_core_struct(namespace)
 		_handle = core.BNCreateSymbol(sym_type, short_name, full_name, raw_name, addr, binding, _namespace, ordinal)
 		assert _handle is not None, "core.BNCreateSymbol return None"
-		super(Symbol, self).__init__(_handle)
+		super().__init__(_handle)
 
 
 @dataclass
@@ -805,7 +805,7 @@ class MutableTypeBuilder(Generic[TB]):
 
 class TypeBuilderAttributes(dict):
 	def __init__(self, builder: 'TypeBuilder', *args):
-		super(TypeBuilderAttributes, self).__init__(*args)
+		super().__init__(*args)
 		self._builder = builder
 
 	def __setitem__(self, key: str, value: str):
@@ -814,13 +814,13 @@ class TypeBuilderAttributes(dict):
 		if not isinstance(value, str):
 			raise TypeError("Type attribute value must be a string")
 		core.BNSetTypeBuilderAttribute(self._builder._handle, key, value)
-		super(TypeBuilderAttributes, self).__setitem__(key, value)
+		super().__setitem__(key, value)
 
 	def __delitem__(self, key: str):
 		if not isinstance(key, str):
 			raise TypeError("Type attribute key must be a string")
 		core.BNRemoveTypeBuilderAttribute(self._builder._handle, key)
-		super(TypeBuilderAttributes, self).__delitem__(key)
+		super().__delitem__(key)
 
 
 class TypeBuilder:
@@ -1780,7 +1780,7 @@ class StructureBuilder(TypeBuilder):
 	    self, handle: core.BNTypeBuilderHandle, builder_handle: core.BNStructureBuilderHandle,
 	    platform: Optional['_platform.Platform'] = None, confidence: int = core.max_confidence
 	):
-		super(StructureBuilder, self).__init__(handle, platform, confidence)
+		super().__init__(handle, platform, confidence)
 		assert builder_handle is not None, "Can't instantiate Structure with builder_handle set to None"
 		self.builder_handle = builder_handle
 
@@ -2028,7 +2028,7 @@ class EnumerationBuilder(TypeBuilder):
 	    self, handle: core.BNTypeBuilderHandle, enum_builder_handle: core.BNEnumerationBuilderHandle,
 	    platform: Optional['_platform.Platform'] = None, confidence: int = core.max_confidence
 	):
-		super(EnumerationBuilder, self).__init__(handle, platform, confidence)
+		super().__init__(handle, platform, confidence)
 		assert isinstance(enum_builder_handle, core.BNEnumerationBuilderHandle)
 		self.enum_builder_handle = enum_builder_handle
 
@@ -2155,7 +2155,7 @@ class NamedTypeReferenceBuilder(TypeBuilder):
 		assert isinstance(
 		    ntr_builder_handle, core.BNNamedTypeReferenceBuilderHandle
 		), "Failed to construct NameTypeReference"
-		super(NamedTypeReferenceBuilder, self).__init__(handle, platform, confidence)
+		super().__init__(handle, platform, confidence)
 		self.ntr_builder_handle = ntr_builder_handle
 
 	@classmethod
@@ -2911,7 +2911,7 @@ class BoolType(Type):
 
 class IntegerType(Type):
 	def __init__(self, handle, platform: Optional['_platform.Platform'] = None, confidence: int = core.max_confidence):
-		super(IntegerType, self).__init__(handle, platform, confidence)
+		super().__init__(handle, platform, confidence)
 
 	@classmethod
 	def create(
@@ -2957,7 +2957,7 @@ class FloatType(Type):
 class StructureType(Type):
 	def __init__(self, handle, platform: Optional['_platform.Platform'] = None, confidence: int = core.max_confidence):
 		assert handle is not None, "Attempted to create EnumerationType with handle which is None"
-		super(StructureType, self).__init__(handle, platform, confidence)
+		super().__init__(handle, platform, confidence)
 		struct_handle = core.BNGetTypeStructure(handle)
 		assert struct_handle is not None, "core.BNGetTypeStructure returned None"
 		self.struct_handle = struct_handle
@@ -2994,7 +2994,7 @@ class StructureType(Type):
 	def __del__(self):
 		if core is not None:
 			core.BNFreeStructure(self.struct_handle)
-		super(StructureType, self).__del__()
+		super().__del__()
 
 	def __hash__(self):
 		return hash(ctypes.addressof(self.struct_handle.contents))
@@ -3234,7 +3234,7 @@ class StructureType(Type):
 class EnumerationType(IntegerType):
 	def __init__(self, handle, platform: Optional['_platform.Platform'] = None, confidence: int = core.max_confidence):
 		assert handle is not None, "Attempted to create EnumerationType without handle"
-		super(EnumerationType, self).__init__(handle, platform, confidence)
+		super().__init__(handle, platform, confidence)
 		enum_handle = core.BNGetTypeEnumeration(handle)
 		assert enum_handle is not None, "core.BNGetTypeEnumeration returned None"
 		self.enum_handle = enum_handle
@@ -3242,7 +3242,7 @@ class EnumerationType(IntegerType):
 	def __del__(self):
 		if core is not None:
 			core.BNFreeEnumeration(self.enum_handle)
-		super(EnumerationType, self).__del__()
+		super().__del__()
 
 	def __hash__(self):
 		return hash(ctypes.addressof(self.enum_handle.contents))
@@ -3622,7 +3622,7 @@ class NamedTypeReferenceType(Type):
 	    self, handle, platform: Optional['_platform.Platform'] = None, confidence: int = core.max_confidence, ntr_handle=None
 	):
 		assert handle is not None, "Attempting to create NamedTypeReferenceType handle which is None"
-		super(NamedTypeReferenceType, self).__init__(handle, platform, confidence)
+		super().__init__(handle, platform, confidence)
 		if ntr_handle is None:
 			ntr_handle = core.BNGetTypeNamedTypeReference(handle)
 		assert ntr_handle is not None, "core.BNGetTypeNamedTypeReference returned None"
@@ -3700,7 +3700,7 @@ class NamedTypeReferenceType(Type):
 	def __del__(self):
 		if core is not None:
 			core.BNFreeNamedTypeReference(self.ntr_handle)
-		super(NamedTypeReferenceType, self).__del__()
+		super().__del__()
 
 	def __repr__(self):
 		if self.named_type_class == NamedTypeReferenceClass.TypedefNamedTypeClass:

--- a/python/variable.py
+++ b/python/variable.py
@@ -969,7 +969,7 @@ class ArchitectureVariable(CoreVariable):
 		self, arch: 'binaryninja.architecture.Architecture', source_type: VariableSourceType, index: int,
 		storage: int
 	):
-		super(ArchitectureVariable, self).__init__(int(source_type), index, storage)
+		super().__init__(int(source_type), index, storage)
 		self._arch = arch
 
 	@property
@@ -1067,7 +1067,7 @@ class Variable(CoreVariable):
 	in medium level IL, so variables objects are only valid for MLIL and above.
 	"""
 	def __init__(self, func: FunctionOrILFunction, source_type: VariableSourceType, index: int, storage: int):
-		super(Variable, self).__init__(int(source_type), index, storage)
+		super().__init__(int(source_type), index, storage)
 		if isinstance(func, binaryninja.function.Function):
 			self._function = func
 			self._il_function = None


### PR DESCRIPTION
`StructureType`, `EnumerationType`, and `NamedTypeReferenceType` called `super(Class, self)` in `__del__`. The interpreter nulls that module-global class name during teardown, so finalizers running at shutdown raised a `TypeError`. Switch to zero-arg `super()` here and across the rest of the Python API.