### PR TITLE
Fix setter decorator for project property

### DIFF
--- a/python/plugin.py
+++ b/python/plugin.py
@@ -105,7 +105,7 @@ class PluginCommandContext:
 	def project(self):
 		return self._project
 
-	@function.setter
+	@project.setter
 	def project(self, value):
 		self._project = value
 


### PR DESCRIPTION
`PluginCommandContext.project`'s setter is decorated with `@function.setter` instead of `@project.setter`. Because `@x.setter` returns a new property built from `x`, this attaches the new setter to the *function* property while keeping its original getter, and binds the whole thing to the name `project`. The result: `context.project` reads back `self._function` instead of `self._project`.