### PR TITLE
[API] Add FFI wrapper modifier to strong typedefs

### DIFF
--- a/base/strong_typedef.h
+++ b/base/strong_typedef.h
@@ -22,6 +22,7 @@
 
 #include <compare>  // IWYU pragma: keep
 #include <stddef.h>
+#include <concepts>
 #include <functional>
 #include <type_traits>
 #include <utility>
@@ -89,6 +90,8 @@
 //     Hashable        usable as a key in std and absl hash containers
 //     Formattable     formattable with fmt, forwarding format specs such as {:#x} to the
 //                     underlying type's formatter
+//     FfiWrapper      implicit conversion to and from a C-style wrapper structure through
+//                     the specified member, without making the underlying type implicit
 //     NonExtractable  removes the explicit operator T() and the Value() accessor, so the
 //                     underlying value can be constructed but never read back out. Every
 //                     other modifier continues to function as normal.
@@ -114,6 +117,25 @@ namespace detail {
 // True when Modifier appears in the Mods pack.
 template <typename Modifier, typename... Mods>
 inline constexpr bool HasModifier = (std::is_same_v<Modifier, Mods> || ...);
+
+template <typename Mod, typename Ffi, typename T>
+concept FfiWrapperFor = requires(const Ffi& value) {
+	typename Mod::FfiType;
+	requires std::same_as<typename Mod::FfiType, Ffi>;
+	{ Mod::template FromFfi<T>(value) } -> std::same_as<T>;
+};
+
+template <typename Ffi, typename T, typename... Mods>
+inline constexpr bool HasFfiWrapper = (FfiWrapperFor<Mods, Ffi, T> || ...);
+
+template <typename T, typename Ffi, typename First, typename... Rest>
+constexpr T FromFfi(const Ffi& value)
+{
+	if constexpr (FfiWrapperFor<First, Ffi, T>)
+		return First::template FromFfi<T>(value);
+	else
+		return FromFfi<T, Ffi, Rest...>(value);
+}
 
 // Internal access to a StrongTypedef's underlying value so that modifiers have
 // access to it even when NonExtractable is in use.
@@ -409,6 +431,33 @@ struct Formattable
 	};
 };
 
+// Enables implicit conversion to and from a C-style wrapper structure whose selected
+// member stores the StrongTypedef's underlying value. Conversion to the underlying type
+// itself remains explicit.
+template <typename Ffi, auto ValueMember>
+struct FfiWrapper
+{
+	using FfiType = Ffi;
+
+	template <typename T>
+	static constexpr T FromFfi(const Ffi& value)
+	{
+		return T(value.*ValueMember);
+	}
+
+	template <typename Self, typename T>
+		requires requires(Ffi ffi, const T& value) { ffi.*ValueMember = value; }
+	struct Apply
+	{
+		constexpr operator Ffi() const
+		{
+			Ffi result {};
+			result.*ValueMember = detail::Access::Get(static_cast<const Self&>(*this));
+			return result;
+		}
+	};
+};
+
 // Disable both the explicit operator T() and the Value() accessor.
 // All other modifiers continue to function as normal.
 struct NonExtractable
@@ -434,6 +483,13 @@ public:
 
 	explicit constexpr StrongTypedef(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
 		: m_value(std::move(value))
+	{
+	}
+
+	template <typename Ffi>
+		requires detail::HasFfiWrapper<std::remove_cvref_t<Ffi>, T, Mods...>
+	constexpr StrongTypedef(Ffi&& value)
+		: m_value(detail::FromFfi<T, std::remove_cvref_t<Ffi>, Mods...>(value))
 	{
 	}
 

--- a/base/strong_typedef.h
+++ b/base/strong_typedef.h
@@ -22,6 +22,7 @@
 
 #include <compare>  // IWYU pragma: keep
 #include <stddef.h>
+#include <concepts>
 #include <functional>
 #include <type_traits>
 #include <utility>
@@ -89,6 +90,8 @@
 //     Hashable        usable as a key in std and absl hash containers
 //     Formattable     formattable with fmt, forwarding format specs such as {:#x} to the
 //                     underlying type's formatter
+//     APIStruct       implicit conversion to and from a single-member C API structure,
+//                     without making the underlying type implicit
 //     NonExtractable  removes the explicit operator T() and the Value() accessor, so the
 //                     underlying value can be constructed but never read back out. Every
 //                     other modifier continues to function as normal.
@@ -151,6 +154,15 @@ struct AffineOps
 	friend constexpr Self& operator+=(Self& a, const Diff& d) { detail::Access::Get(a) += detail::Access::Get(d); return a; }
 	friend constexpr Self& operator-=(Self& a, const Diff& d) { detail::Access::Get(a) -= detail::Access::Get(d); return a; }
 };
+
+template <typename Mod, typename API>
+concept APIObjectFor = requires {
+	typename Mod::TAPI;
+	requires std::same_as<typename Mod::TAPI, API>;
+};
+
+template <typename API, typename... Mods>
+inline constexpr bool HasAPIObject = (APIObjectFor<Mods, API> || ...);
 
 } // namespace detail
 
@@ -409,6 +421,35 @@ struct Formattable
 	};
 };
 
+// Enables implicit conversion to and from a single-member C API structure. Also provides
+// the GetAPIObject, FromAPIObject, and FreeAPIObject interface expected by APIAble.
+// Conversion to the underlying type itself remains explicit.
+template <typename API>
+struct APIStruct
+{
+	using TAPI = API;
+
+	template <typename Self, typename T>
+		requires requires(const T& value) { TAPI {value}; }
+	struct Apply
+	{
+		[[nodiscard]] constexpr TAPI GetAPIObject() const
+		{
+			return TAPI {detail::Access::Get(static_cast<const Self&>(*this))};
+		}
+
+		static constexpr Self FromAPIObject(const TAPI* object)
+		{
+			const auto& [value] = *object;
+			return Self(value);
+		}
+
+		static constexpr void FreeAPIObject(TAPI*) {}
+
+		constexpr operator TAPI() const { return GetAPIObject(); }
+	};
+};
+
 // Disable both the explicit operator T() and the Value() accessor.
 // All other modifiers continue to function as normal.
 struct NonExtractable
@@ -434,6 +475,13 @@ public:
 
 	explicit constexpr StrongTypedef(T&& value) noexcept(std::is_nothrow_move_constructible_v<T>)
 		: m_value(std::move(value))
+	{
+	}
+
+	template <typename API>
+		requires detail::HasAPIObject<std::remove_cvref_t<API>, Mods...>
+	constexpr StrongTypedef(API&& object)
+		: StrongTypedef(StrongTypedef::FromAPIObject(&object))
 	{
 	}
 


### PR DESCRIPTION
> Apart of https://github.com/Vector35/binaryninja/pull/1735 (Binary Similarity)
> For a test_* build with this change see the above branch ^

This modifier is used for wrapping and unwrapping FFI structures representing the raw value type.

In particular we are using it in the binary similarity like:

```cpp
namespace BinaryNinjaCore {
	namespace st = ::bn::base::strong_typedef;
	using SimilarityEntityId = ::bn::base::StrongTypedef<uint32_t, struct SimilarityEntityIdTag,
		st::FfiWrapper<BNSimilarityEntityId, &BNSimilarityEntityId::value>, st::Ordered, st::Hashable,
		st::Incrementable>;
}  // namespace BinaryNinjaCore
```

Where we want to use the strong_typedef modifiers to derive functionality for use in containers (hashable, ordered) and still preserve the relationship between the C++ and C (via FfiWrapper).

Also see https://github.com/Vector35/binaryninja/pull/1737 for unit tests.