### PR TITLE
Fix a use-after-free in the GNU3 demangler when expanding a template parameter pack

### DIFF
--- a/demangler/gnu3/demangle_gnu3.cpp
+++ b/demangler/gnu3/demangle_gnu3.cpp
@@ -2194,7 +2194,8 @@ bool DemangleGNU3::TryDemangleTemplateParamExpressionPackExpansion(string& expr,
 }
 
 
-bool DemangleGNU3::AppendTemplateParamPackExpansion(ParamList& params, const NodeRef& expansion, bool functionParameter)
+// `expansion` is by value because some callers pass m_lastTypeRef, which the loop below overwrites.
+bool DemangleGNU3::AppendTemplateParamPackExpansion(ParamList& params, NodeRef expansion, bool functionParameter)
 {
 	if (!expansion.IsTemplateParamPackExpansion())
 		return false;

--- a/demangler/gnu3/demangle_gnu3.h
+++ b/demangler/gnu3/demangle_gnu3.h
@@ -157,7 +157,7 @@ private:
 	NodeRef PushType(DemangledTypeNode&& type);
 	NodeRef GetTypeRef(size_t ref);
 	const DemangledTypeNode& GetType(size_t ref);
-	bool AppendTemplateParamPackExpansion(ParamList& params, const NodeRef& expansion, bool functionParameter);
+	bool AppendTemplateParamPackExpansion(ParamList& params, NodeRef expansion, bool functionParameter);
 
 #ifdef GNUDEMANGLE_DEBUG
 	const DemangledTypeNode& GetTemplateType(size_t ref);


### PR DESCRIPTION
The code was passing a member variable to a function as a const reference. The function reassigned the same member variable within its body, causing its parameter to point to freed memory.