### PR TITLE
Add new API call to remove alternate names from a loaded type library.

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -21231,6 +21231,12 @@ namespace BinaryNinja {
 		*/
 		void AddAlternateName(const std::string& alternate);
 
+		/*! Removes an extra name from this type library used during library lookups and dependency resolution
+
+			\param alternate
+		*/
+		void RemoveAlternateName(const std::string& alternate);
+
 		/*! Sets the dependency name of a type library instance that has not been finalized
 
 			\param depName

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -7225,6 +7225,7 @@ extern "C"
 	BINARYNINJACOREAPI char* BNGetTypeLibraryName(BNTypeLibrary* lib);
 
 	BINARYNINJACOREAPI void BNAddTypeLibraryAlternateName(BNTypeLibrary* lib, const char* name);
+	BINARYNINJACOREAPI void BNRemoveTypeLibraryAlternateName(BNTypeLibrary* lib, const char* name);
 	BINARYNINJACOREAPI char** BNGetTypeLibraryAlternateNames(BNTypeLibrary* lib, size_t* count);  // BNFreeStringList
 
 	BINARYNINJACOREAPI void BNSetTypeLibraryDependencyName(BNTypeLibrary* lib, const char* name);

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -37,7 +37,7 @@
 // Current ABI version for linking to the core. This is incremented any time
 // there are changes to the API that affect linking, including new functions,
 // new types, or modifications to existing functions or types.
-#define BN_CURRENT_CORE_ABI_VERSION 182
+#define BN_CURRENT_CORE_ABI_VERSION 183
 
 // Minimum ABI version that is supported for loading of plugins. Plugins that
 // are linked to an ABI version less than this will not be able to load and

--- a/python/typelibrary.py
+++ b/python/typelibrary.py
@@ -195,6 +195,12 @@ class TypeLibrary:
 			raise ValueError(f"Expected name to be str, got {type(name)}")
 		core.BNAddTypeLibraryAlternateName(self.handle, name)
 
+	def remove_alternate_name(self, name: str) -> None:
+		"""Removes an extra name from this type library instance that has not been finalized"""
+		if not isinstance(name, str):
+			raise ValueError(f"Expected name to be str, got {type(name)}")
+		core.BNRemoveTypeLibraryAlternateName(self.handle, name)
+
 	@property
 	def platform_names(self) -> List[str]:
 		"""

--- a/rust/src/types/library.rs
+++ b/rust/src/types/library.rs
@@ -183,6 +183,12 @@ impl TypeLibrary {
         unsafe { BNAddTypeLibraryAlternateName(self.as_raw(), value.as_ptr()) }
     }
 
+    /// Removes an extra name from this type library used during library lookups and dependency resolution
+    pub fn remove_alternate_name(&self, value: &str) {
+        let value = value.to_cstr();
+        unsafe { BNRemoveTypeLibraryAlternateName(self.as_raw(), value.as_ptr()) }
+    }
+
     /// Returns a list of all platform names that this type library will register with during platform
     /// type registration.
     ///

--- a/rust/tests/type_library.rs
+++ b/rust/tests/type_library.rs
@@ -69,6 +69,8 @@ fn test_create_type_library() {
     // Create the new type library.
     let my_library = TypeLibrary::new(arch, "test_type_lib");
     my_library.add_alternate_name("alternate_test");
+    my_library.add_alternate_name("alternate_to_be_removed");
+    my_library.remove_alternate_name("alternate_to_be_removed");
     my_library.add_platform(&platform);
     my_library.add_named_type("test_type".into(), &Type::int(7, true));
 

--- a/typelibrary.cpp
+++ b/typelibrary.cpp
@@ -195,6 +195,12 @@ void TypeLibrary::AddAlternateName(const std::string& alternate)
 }
 
 
+void TypeLibrary::RemoveAlternateName(const std::string& alternate)
+{
+	BNRemoveTypeLibraryAlternateName(m_object, alternate.c_str());
+}
+
+
 void TypeLibrary::SetDependencyName(const std::string& depName)
 {
 	BNSetTypeLibraryDependencyName(m_object, depName.c_str());


### PR DESCRIPTION
Added an API call that allows the removal of alternate names from a loaded type library. This is needed if we need to manually patch the type libraries we have to prevent another issue like #7880 . 