### PR TITLE
[ARMv7] Fix full-width bitfield instruction lifting

### DIFF
--- a/arch/armv7/il.cpp
+++ b/arch/armv7/il.cpp
@@ -2208,12 +2208,12 @@ bool GetLowLevelILForArmInstruction(Architecture* arch, uint64_t addr, LowLevelI
 		case ARMV7_BFC:
 			ConditionExecute(il, instr.cond, SetRegisterOrBranch(il, op1.reg,
 				il.And(get_register_size(op1.reg), ReadRegisterOrPointer(il, op1, addr),
-					il.Const(get_register_size(op1.reg), ~(((1<<op3.imm) - 1) << op2.imm)))));
+					il.Const(get_register_size(op1.reg), ~(((1ULL << op3.imm) - 1) << op2.imm)))));
 			break;
 		case ARMV7_BFI:
 		{
 			uint32_t lsb = op3.imm;
-			uint32_t width_mask = (1<<op4.imm) - 1;
+			uint32_t width_mask = (1ULL << op4.imm) - 1;
 			uint32_t mask = width_mask << lsb;
 
 			//bit field insert: op1 = (op1 & (~(<width_mask> << lsb))) | ((op2 & <width_mask>) << lsb)

--- a/arch/armv7/test_lift.py
+++ b/arch/armv7/test_lift.py
@@ -97,6 +97,14 @@ test_cases = \
     ('T', b'\x28\x40', 'LLIL_SET_REG.d(r0,LLIL_AND.d{*}(LLIL_REG.d(r0),LLIL_REG.d(r5)))'),
     # bics r3, r3
     ('T', b'\x9b\x43', 'LLIL_SET_REG.d(r3,LLIL_AND.d{*}(LLIL_REG.d(r3),LLIL_NOT.d(LLIL_REG.d(r3))))'),
+    # bfi r2, r1, #0, #32 -- a full-width insert copies the source register
+    ('A', b'\x11\x20\xdf\xe7', 'LLIL_SET_REG.d(r2,LLIL_OR.d(LLIL_AND.d(LLIL_REG.d(r2),LLIL_CONST.d(0x0)),LLIL_LSL.d(LLIL_AND.d(LLIL_REG.d(r1),LLIL_CONST.d(0xFFFFFFFF)),LLIL_CONST.d(0x0))))'),
+    ('T', b'\x61\xf3\x1f\x02', 'LLIL_SET_REG.d(r2,LLIL_OR.d(LLIL_AND.d(LLIL_REG.d(r2),LLIL_CONST.d(0x0)),LLIL_LSL.d(LLIL_AND.d(LLIL_REG.d(r1),LLIL_CONST.d(0xFFFFFFFF)),LLIL_CONST.d(0x0))))'),
+    # bfc r2, #0, #32 -- a full-width clear zeros the destination register
+    ('A', b'\x1f\x20\xdf\xe7', 'LLIL_SET_REG.d(r2,LLIL_AND.d(LLIL_REG.d(r2),LLIL_CONST.d(0x0)))'),
+    ('T', b'\x6f\xf3\x1f\x02', 'LLIL_SET_REG.d(r2,LLIL_AND.d(LLIL_REG.d(r2),LLIL_CONST.d(0x0)))'),
+    # ubfx r2, r1, #0, #32 -- a full-width extract copies the source register
+    ('T', b'\xc1\xf3\x1f\x02', 'LLIL_SET_REG.d(r2,LLIL_AND.d(LLIL_LSR.d(LLIL_REG.d(r1),LLIL_CONST.d(0x0)),LLIL_CONST.d(0xFFFFFFFF)))'),
     # mvns r3, r6
     ('T', b'\xf3\x43', 'LLIL_SET_REG.d(r3,LLIL_NOT.d{*}(LLIL_REG.d(r6)))'),
     # eors r2, r0

--- a/arch/armv7/thumb2_disasm/il_thumb2.cpp
+++ b/arch/armv7/thumb2_disasm/il_thumb2.cpp
@@ -2405,7 +2405,7 @@ bool GetLowLevelILForThumbInstruction(Architecture* arch, LowLevelILFunction& il
 	{
 		uint32_t lsb = instr->fields[instr->format->operands[1].field0];
 		uint32_t clear_width = instr->fields[instr->format->operands[2].field0];
-		uint32_t mask = ((1 << clear_width) - 1) << lsb;
+		uint32_t mask = ((1ULL << clear_width) - 1) << lsb;
 		il.AddInstruction(WriteILOperand(il, instr, 0,
 					il.And(4,
 						ReadILOperand(il, instr, 0),
@@ -2421,7 +2421,7 @@ bool GetLowLevelILForThumbInstruction(Architecture* arch, LowLevelILFunction& il
 
 		width = instr->fields[instr->format->operands[3].field0];
 		lsb = instr->fields[instr->format->operands[2].field0];
-		width_mask = (1 << width) - 1;
+		width_mask = (1ULL << width) - 1;
 		mask = width_mask << lsb;
 		//bit field insert: op1 = (op1 & (~(<width_mask> << lsb))) | ((op2 & <width_mask>) << lsb)
 		il.AddInstruction(WriteILOperand(il, instr, 0,
@@ -3653,10 +3653,13 @@ bool GetLowLevelILForThumbInstruction(Architecture* arch, LowLevelILFunction& il
 			{ ReadILOperand(il, instr, 1), ReadILOperand(il, instr, 2) });
 		break;
 	case armv7::ARMV7_UBFX:
+	{
+		uint32_t width = instr->fields[instr->format->operands[3].field0];
+		uint32_t width_mask = (1ULL << width) - 1;
 		il.AddInstruction(WriteILOperand(il, instr, 0, il.And(4, il.LogicalShiftRight(4, ReadILOperand(il, instr, 1),
-												 ReadILOperand(il, instr, 2)),
-									 il.Const(4, (1 << instr->fields[instr->format->operands[3].field0]) - 1))));
+			 ReadILOperand(il, instr, 2)), il.Const(4, width_mask))));
 		break;
+	}
 	case armv7::ARMV7_UDF:
 		il.AddInstruction(il.Trap(instr->fields[instr->format->operands[0].field0]));
 		break;


### PR DESCRIPTION
Currently, we construct masks using a 32-bit expression (`1 << width) - 1`). This is valid when `lsb` is zero, but shifting a 32-bit integer by 32 is undefined. This produces a zero mask and causes incorrect LLIL for full-width operations such as `bfi Rd, Rn, #0, #32`, `bfc Rd, #0, #32` and `ubfx Rd, Rn, #0, #32`. 

This change constructs bitfield masks using a 64-bit intermediate before narrowing to 32 bits: `(uint64_t{1} << width) - 1)`.

Before:
<img width="1442" height="947" alt="Screenshot 2026-08-14 at 12 16 56 PM" src="https://github.com/user-attachments/assets/63f46f3c-a878-42ef-9cfe-9c6bffbcc1dd" />

After:
<img width="1442" height="947" alt="Screenshot 2026-08-14 at 12 17 43 PM" src="https://github.com/user-attachments/assets/f169ea75-5ac9-4004-ae04-332441631e48" />

I've attached a binary if anyone cares to test.
[thumb2_bitfield_width32.elf.zip](https://github.com/user-attachments/files/31078274/thumb2_bitfield_width32.elf.zip)
