### PR TITLE
Fix Python and Rust memory leaks

### DIFF
--- a/python/debuginfo.py
+++ b/python/debuginfo.py
@@ -74,9 +74,7 @@ class _DebugInfoParserMetaClass(type):
 		parser = core.BNGetDebugInfoParserByName(str(value))
 		if parser is None:
 			raise KeyError(f"'{str(value)}' is not a valid debug-info parser")
-		parser_ref = core.BNNewDebugInfoParserReference(parser)
-		assert parser_ref is not None, "core.BNNewDebugInfoParserReference returned None"
-		return DebugInfoParser(parser_ref)
+		return DebugInfoParser(parser)
 
 	def __contains__(cls: '_DebugInfoParserMetaClass', name: object) -> bool:
 		if not isinstance(name, str):
@@ -162,9 +160,7 @@ class _DebugInfoParserMetaClass(type):
 		_debug_info_parsers[len(_debug_info_parsers)] = (is_valid_cb, parse_info_cb)
 		parser = core.BNRegisterDebugInfoParser(name, is_valid_cb, parse_info_cb, None)
 		assert parser is not None, "core.BNRegisterDebugInfoParser is not None"
-		parser_ref = core.BNNewDebugInfoParserReference(parser)
-		assert parser_ref is not None, "core.BNNewDebugInfoParserReference returned None"
-		return DebugInfoParser(parser_ref)
+		return DebugInfoParser(parser)
 
 
 class DebugInfoParser(object, metaclass=_DebugInfoParserMetaClass):

--- a/python/typecontainer.py
+++ b/python/typecontainer.py
@@ -362,10 +362,9 @@ class TypeContainer:
 				_types.QualifiedName._from_core_struct(result_cpp.name),
 				_types.Type.create(handle=core.BNNewTypeReference(result_cpp.type))
 			)
-			core.BNFreeQualifiedNameAndType(result_cpp)
 		else:
 			result = None
-		core.BNFreeTypeParserResult(result_cpp)
+		core.BNFreeQualifiedNameAndType(result_cpp)
 
 		errors = []
 		for i in range(error_count.value):
@@ -426,5 +425,4 @@ class TypeContainer:
 		core.BNFreeTypeParserErrors(errors_cpp, error_count.value)
 
 		return result, errors
-
 

--- a/python/typeparser.py
+++ b/python/typeparser.py
@@ -649,9 +649,9 @@ class CoreTypeParser(TypeParser):
 				types.QualifiedName._from_core_struct(result_cpp.name),
 				types.Type.create(handle=core.BNNewTypeReference(result_cpp.type))
 			)
-			core.BNFreeQualifiedNameAndType(result_cpp)
 		else:
 			result = None
+		core.BNFreeQualifiedNameAndType(result_cpp)
 
 		errors = []
 		for i in range(error_count.value):

--- a/python/workflow.py
+++ b/python/workflow.py
@@ -722,7 +722,7 @@ class Workflow(metaclass=_WorkflowMetaclass):
 		handle = core.BNWorkflowRegisterActivity(self.handle, activity.handle, input_list, len(subactivities))
 		if handle is None:
 			return None
-		return activity
+		return Activity(handle=handle)
 
 	def contains(self, activity: ActivityType) -> bool:
 		"""

--- a/rust/src/types/container.rs
+++ b/rust/src/types/container.rs
@@ -310,6 +310,7 @@ impl TypeContainer {
         if success {
             Ok(QualifiedNameAndType::from_owned_raw(result))
         } else {
+            unsafe { BNFreeQualifiedNameAndType(&mut result) };
             assert!(!errors.is_null());
             Err(unsafe { Array::new(errors, error_count, ()) })
         }

--- a/rust/src/types/parser.rs
+++ b/rust/src/types/parser.rs
@@ -201,6 +201,7 @@ impl TypeParser for CoreTypeParser {
         if result {
             Ok(QualifiedNameAndType::from_owned_raw(output))
         } else {
+            unsafe { BNFreeQualifiedNameAndType(&mut output) };
             let errors: Array<TypeParserError> = unsafe { Array::new(errors, error_count, ()) };
             Err(errors.to_vec())
         }

--- a/typeparser.cpp
+++ b/typeparser.cpp
@@ -585,6 +585,7 @@ bool CoreTypeParser::ParseTypeString(const std::string& source, Ref<Platform> pl
 
 	if (!success)
 	{
+		BNFreeQualifiedNameAndType(&apiResult);
 		return false;
 	}
 


### PR DESCRIPTION
Fixes the Python and Rust ownership issues reported in Vector35/binaryninja#1506. Ensures owned references and parse results are freed correctly on both success and failure paths.
Verified with Python compilation and Rust formatting/build checks.