### PR TITLE
Turn shallow cloning on for vendored binexport and bindiff submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,6 +22,8 @@
 [submodule "vendor/bindiff"]
 	path = vendor/bindiff
 	url = https://github.com/Vector35/google_bindiff.git
+	shallow = true
 [submodule "vendor/binexport"]
 	path = vendor/binexport
 	url = https://github.com/Vector35/binexport.git
+	shallow = true


### PR DESCRIPTION
Reduces the size of cloning by ~200mb for binexport