### PR TITLE
Delay-load dbghelp.dll in bindiff_similarity (Fix #1860)

### DIFF
--- a/plugins/bindiff_similarity/CMakeLists.txt
+++ b/plugins/bindiff_similarity/CMakeLists.txt
@@ -57,6 +57,13 @@ target_link_libraries(${PROJECT_NAME}
         bindiff_shared
 )
 
+if (WIN32 AND NOT DEMO)
+    # Abseil's symbolizer imports dbghelp.dll. A static import maps System32's copy at plugin init,
+    # which then wins name-based resolution and breaks the debugger's WinDbg dbgeng.
+    target_link_libraries(${PROJECT_NAME} PRIVATE delayimp.lib)  # Helper for /DELAYLOAD
+    target_link_options(${PROJECT_NAME} PRIVATE /DELAYLOAD:dbghelp.dll)
+endif ()
+
 if (APPLE)
     target_link_options(${PROJECT_NAME} PRIVATE
             "LINKER:-exported_symbol,_CorePluginABIVersion"


### PR DESCRIPTION
`bindiff_similarity` links bindiff/binexport, which pull in Abseil's Win32 symbolizer and its **static** import of `dbghelp.dll`. Plugin init therefore maps System32's dbghelp before the debugger can load the WinDbg copy by full path. PE imports resolve by base name, so `dbgeng.dll` binds against the wrong one and fails with `ERROR_PROC_NOT_FOUND` (WinDbg 29547 needs `SymGetSymbolsNegativeAuthCache`, absent from System32 dbghelp 26100).

`/DELAYLOAD:dbghelp.dll` defers the bind until the symbolizer is actually used. Same treatment `binaryninjacore`, `crashreporter`, `debuggercore` and the upstream bindiff/binexport plugin targets already have.

Vector35/binaryninja#1860