### PR TITLE
Fix MIPS HI16 relocation overflow

### DIFF
--- a/arch/mips/arch_mips.cpp
+++ b/arch/mips/arch_mips.cpp
@@ -3747,10 +3747,8 @@ public:
 				uint32_t ahl = ((inst & 0xffff) << 16) + immediate;
 
 				// ((AHL + S) – (short)(AHL + S)) >> 16
-				dest32[0] = swap((uint32_t)(
-					(inst & ~0xffff) |
-					(((ahl + target) - (short)(ahl + target)) >> 16)
-				));
+				uint32_t hi = ((ahl + target) - (short)(ahl + target)) >> 16;
+				dest32[0] = swap((inst & ~0xffff) | (hi & 0xffff));
 			}
 			else
 			{


### PR DESCRIPTION
## Summary
- mask the computed `R_MIPS_HI16` value to the instruction’s 16-bit immediate field
- prevent a carry above bit 15 from corrupting LUI’s destination register

## Reproduction
Loading a MIPS32 relocatable ELF at `0x1_0000_0000` produced a 17-bit high-half value (`0x10000`). The unmasked value changed `lui $v0, 0` (`0x3c020000`) into `lui $v1, 0` (`0x3c030000`).

## Testing
- built the standalone `arch_mips` plugin successfully
- loaded the reproducer with the rebuilt plugin at `0x1_0000_0000`
- verified the relocated instruction remains `lui $v0, 0`