### PR TITLE
Remove SysV from the Windows kernel platform

### DIFF
--- a/platform/windows-kernel/platform_windows_kernel.cpp
+++ b/platform/windows-kernel/platform_windows_kernel.cpp
@@ -72,10 +72,6 @@ public:
 			RegisterFastcallCallingConvention(cc);
 			RegisterStdcallCallingConvention(cc);
 		}
-
-		// Linux-style calling convention is sometimes used internally by WindowsKernel applications
-		cc = arch->GetCallingConventionByName("sysv");
-		RegisterCallingConvention(cc);
 	}
 
 	virtual bool GetFallbackEnabled() override


### PR DESCRIPTION
Remove the explicit SysV calling-convention registration from windows-kernel-x86_64. SysV remains available at the x86-64 architecture level but is no longer advertised as supported by the Windows-kernel platform.