### PR TITLE
Fix cache UI actions without UI context

### DIFF
--- a/view/kernelcache/ui/KernelCacheUINotifications.cpp
+++ b/view/kernelcache/ui/KernelCacheUINotifications.cpp
@@ -108,17 +108,25 @@ void UINotifications::OnViewChange(UIContext* context, ViewFrame* frame, const Q
 		uint64_t addr = 0;
 		if (GetAddressInput(addr, "Address", "Address"))
 		{
-			BackgroundThread::create(ctx.context->mainWindow())
-				->thenBackground([ctx, addr]() {
-					loadImageAtAddr(*ctx.binaryView, addr);
+			auto view = ctx.binaryView;
+			if (!view)
+				return;
+			auto owner = ctx.context ? ctx.context->mainWindow() : nullptr;
+			BackgroundThread::create(owner)
+				->thenBackground([view, addr]() {
+					loadImageAtAddr(*view, addr);
 				})->start();
 		}
 	};
 
 	auto loadImageTokenAction = [](const UIActionContext& ctx) {
+		auto view = ctx.binaryView;
+		if (!view)
+			return;
 		uint64_t addr = TokenAddress(ctx);
-		BackgroundThread::create(ctx.context->mainWindow())
-			->thenBackground([ctx, addr](){ loadImageAtAddr(*ctx.binaryView, addr); })
+		auto owner = ctx.context ? ctx.context->mainWindow() : nullptr;
+		BackgroundThread::create(owner)
+			->thenBackground([view, addr](){ loadImageAtAddr(*view, addr); })
 			->start();
 	};
 

--- a/view/sharedcache/ui/SharedCacheUINotifications.cpp
+++ b/view/sharedcache/ui/SharedCacheUINotifications.cpp
@@ -129,9 +129,13 @@ void UINotifications::OnViewChange(UIContext* context, ViewFrame* frame, const Q
 		uint64_t addr = 0;
 		if (GetAddressInput(addr, "Address", "Address"))
 		{
-			BackgroundThread::create(ctx.context->mainWindow())
-				->thenBackground([ctx, addr]() {
-					loadImageAtAddr(*ctx.binaryView, addr);
+			auto view = ctx.binaryView;
+			if (!view)
+				return;
+			auto owner = ctx.context ? ctx.context->mainWindow() : nullptr;
+			BackgroundThread::create(owner)
+				->thenBackground([view, addr]() {
+					loadImageAtAddr(*view, addr);
 				})->start();
 		}
 	};
@@ -140,23 +144,35 @@ void UINotifications::OnViewChange(UIContext* context, ViewFrame* frame, const Q
 		uint64_t addr = 0;
 		if (GetAddressInput(addr, "Address", "Address"))
 		{
-			BackgroundThread::create(ctx.context->mainWindow())
-				->thenBackground([ctx, addr](){ loadRegionAtAddr(*ctx.binaryView, addr); })
+			auto view = ctx.binaryView;
+			if (!view)
+				return;
+			auto owner = ctx.context ? ctx.context->mainWindow() : nullptr;
+			BackgroundThread::create(owner)
+				->thenBackground([view, addr](){ loadRegionAtAddr(*view, addr); })
 				->start();
 		}
 	};
 
 	auto loadRegionTokenAction = [](const UIActionContext& ctx) {
+		auto view = ctx.binaryView;
+		if (!view)
+			return;
 		uint64_t addr = TokenAddress(ctx);
-		BackgroundThread::create(ctx.context->mainWindow())
-			->thenBackground([ctx, addr](){ loadRegionAtAddr(*ctx.binaryView, addr); })
+		auto owner = ctx.context ? ctx.context->mainWindow() : nullptr;
+		BackgroundThread::create(owner)
+			->thenBackground([view, addr](){ loadRegionAtAddr(*view, addr); })
 			->start();
 	};
 
 	auto loadImageTokenAction = [](const UIActionContext& ctx) {
+		auto view = ctx.binaryView;
+		if (!view)
+			return;
 		uint64_t addr = TokenAddress(ctx);
-		BackgroundThread::create(ctx.context->mainWindow())
-			->thenBackground([ctx, addr](){ loadImageAtAddr(*ctx.binaryView, addr); })
+		auto owner = ctx.context ? ctx.context->mainWindow() : nullptr;
+		BackgroundThread::create(owner)
+			->thenBackground([view, addr](){ loadImageAtAddr(*view, addr); })
 			->start();
 	};
 


### PR DESCRIPTION

Fix cache image-loading actions invoked without an active UI context, preventing null dereferences during background execution. Also applies the same protection to dyld shared-cache actions.

Repro:

First select the unloaded green address then run:

```
from binaryninja import execute_on_main_thread_and_wait
from binaryninjaui import UIContext

def repro_bnkc4():
    ui = UIContext.activeContext()
    view = ui.getCurrentViewFrame().getCurrentViewInterface()
    handler = view.actionHandler()
    ctx = view.actionContext()

    assert handler.isValidAction("KC Load IMGHERE", ctx), \
        "Select an unloaded off-image address first"

    ctx.context = None
    handler.executeAction("KC Load IMGHERE", ctx)

execute_on_main_thread_and_wait(repro_bnkc4)
```

This should fix issue: https://github.com/Vector35/binaryninja/issues/1898  