### PR TITLE
[Doc] Replace get_function_containing with get_functions_containing in cookbook

### DIFF
--- a/docs/dev/cookbook.md
+++ b/docs/dev/cookbook.md
@@ -86,7 +86,7 @@ for func in bv.functions:
 func = bv.get_functions_by_name(here)[0]  # Multiple functions can share the same name!
 func = bv.get_function_at(here)      # Shortcut for the next one
 func = bv.get_functions_at(here)[0]  # Binary Ninja support functions that overlap!
-func = bv.get_function_containing(here)  # Functions that contain the given address
+func = bv.get_functions_containing(here)[0]  # Functions that contain the given address
 # Just a note that using address to work with functions is fine
 # But when working with ILs, addresses are approximate and can change for any given instruction
 ```


### PR DESCRIPTION
Replace ```bv.get_function_containing(here)``` with ```bv.get_functions_containing(here)[0]``` in cookbook.md.

```get_function_containing``` does not exist in BinaryView in latest stable or dev.