### PR TITLE
can't uninstall deprecated plugin fix 

### DIFF
--- a/binaryninjaapi.h
+++ b/binaryninjaapi.h
@@ -20915,6 +20915,11 @@ namespace BinaryNinja {
 		bool Uninstall();
 		bool CancelUninstall();
 		bool Install(std::string versionID);
+		// Like Install, but also permits installing a version of a plugin that has since been marked
+		// deprecated. Intended only for migrating a plugin the user already had installed under a previous
+		// extension manager: deprecation should block fresh installs, but must never strand a
+		// previously-installed plugin where it can't be registered as installed (and so can't be uninstalled).
+		bool InstallForMigration(std::string versionID);
 		bool InstallDependencies();
 		bool InstallDependencies(const std::string& versionID);
 		bool InstallDependencies(const std::vector<std::string>& excludedPackageNames);

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -37,7 +37,7 @@
 // Current ABI version for linking to the core. This is incremented any time
 // there are changes to the API that affect linking, including new functions,
 // new types, or modifications to existing functions or types.
-#define BN_CURRENT_CORE_ABI_VERSION 188
+#define BN_CURRENT_CORE_ABI_VERSION 189
 
 // Minimum ABI version that is supported for loading of plugins. Plugins that
 // are linked to an ABI version less than this will not be able to load and

--- a/binaryninjacore.h
+++ b/binaryninjacore.h
@@ -8910,6 +8910,7 @@ extern "C"
 	BINARYNINJACOREAPI bool BNPluginEnable(BNPlugin* p, bool force);
 	BINARYNINJACOREAPI bool BNPluginDisable(BNPlugin* p);
 	BINARYNINJACOREAPI bool BNPluginInstall(BNPlugin* p, const char* versionID);
+	BINARYNINJACOREAPI bool BNPluginInstallForMigration(BNPlugin* p, const char* versionID);
 	BINARYNINJACOREAPI bool BNPluginInstallDependencies(BNPlugin* p);
 	BINARYNINJACOREAPI bool BNPluginInstallDependenciesForVersion(BNPlugin* p, const char* versionID);
 	BINARYNINJACOREAPI bool BNPluginInstallDependenciesWithExclusions(BNPlugin* p,

--- a/pluginmanager.cpp
+++ b/pluginmanager.cpp
@@ -375,6 +375,15 @@ bool Extension::Install(std::string versionID)
 }
 
 
+bool Extension::InstallForMigration(std::string versionID)
+{
+	char* versionIDStr = BNAllocString(versionID.c_str());
+	auto success = BNPluginInstallForMigration(m_object, versionIDStr);
+	BNFreeString(versionIDStr);
+	return success;
+}
+
+
 bool Extension::InstallDependencies()
 {
 	return InstallDependencies("");


### PR DESCRIPTION
API fix for deprecated plugins being impossible to uninstall from UI. Fixes https://github.com/Vector35/binaryninja-api/issues/8545